### PR TITLE
[cargo-nextest] add a BufWriter around reporter writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-nextest"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "camino",
  "cfg-if",

--- a/cargo-nextest/Cargo.toml
+++ b/cargo-nextest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-nextest"
 description = "A next-generation test runner for Rust."
-version = "0.9.2"
+version = "0.9.3"
 readme = "README.md"
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/nextest-rs/nextest"

--- a/site/src/CHANGELOG.md
+++ b/site/src/CHANGELOG.md
@@ -3,6 +3,13 @@
 This page documents new features and bugfixes for cargo-nextest. Please see the [stability
 policy](book/stability.md) for how versioning works with cargo-nextest.
 
+## [0.9.3] - 2022-02-14
+
+### Fixed
+
+- Add a `BufWriter` around stderr for the reporter, reducing the number of syscalls and fixing
+  issues around output overlap on Windows ([#35](https://github.com/nextest-rs/nextest/issues/35)). Thanks [@fdncred](https://github.com/fdncred) for reporting this!
+
 ## [0.9.2] - 2022-02-14
 
 ### Fixed


### PR DESCRIPTION
Stops lots of little syscalls from happening.

Fixes #35.