### PR TITLE
Update clap from 3.0.14 to 3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.14"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
+checksum = "e5f1fea81f183005ced9e59cdb01737ef2423956dac5a6d731b06b2ecfaa3467"
 dependencies = [
  "atty",
  "bitflags",
@@ -205,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.14"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1132dc3944b31c20dd8b906b3a9f0a5d0243e092d59171414969657ac6aa85"
+checksum = "5fd1122e63869df2cb309f449da1ad54a7c6dfeb7c7e6ccd8e0825d9eb93bb72"
 dependencies = [
  "heck",
  "proc-macro-error",

--- a/cargo-nextest/Cargo.toml
+++ b/cargo-nextest/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.54"
 [dependencies]
 camino = "1.0.7"
 cfg-if = "1.0.0"
-clap = { version = "3.0.14", features = ["derive"] }
+clap = { version = "3.1.0", features = ["derive"] }
 # we don't use the tracing support
 color-eyre = { version = "0.6.0", default-features = false }
 duct = "0.13.5"

--- a/cargo-nextest/src/cargo_cli.rs
+++ b/cargo-nextest/src/cargo_cli.rs
@@ -10,7 +10,7 @@ use std::{convert::TryInto, path::PathBuf};
 
 /// Options passed down to cargo.
 #[derive(Debug, Args)]
-#[clap(help_heading = "CARGO OPTIONS", setting = AppSettings::DeriveDisplayOrder)]
+#[clap(next_help_heading = "CARGO OPTIONS", setting = AppSettings::DeriveDisplayOrder)]
 pub(crate) struct CargoOptions {
     /// Test only this package's library unit tests
     #[clap(long)]

--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -158,7 +158,7 @@ impl Default for MessageFormatOpts {
 }
 
 #[derive(Debug, Args)]
-#[clap(help_heading = "FILTER OPTIONS")]
+#[clap(next_help_heading = "FILTER OPTIONS")]
 struct TestBuildFilter {
     #[clap(flatten)]
     cargo_options: CargoOptions,
@@ -215,7 +215,7 @@ impl TestBuildFilter {
 
 /// Test runner options.
 #[derive(Debug, Default, Args)]
-#[clap(help_heading = "RUNNER OPTIONS")]
+#[clap(next_help_heading = "RUNNER OPTIONS")]
 pub struct TestRunnerOpts {
     /// Number of tests to run simultaneously [default: logical CPU count]
     #[clap(
@@ -261,7 +261,7 @@ impl TestRunnerOpts {
 }
 
 #[derive(Debug, Default, Args)]
-#[clap(help_heading = "REPORTER OPTIONS")]
+#[clap(next_help_heading = "REPORTER OPTIONS")]
 struct TestReporterOpts {
     /// Output stdout and stderr on failure
     #[clap(


### PR DESCRIPTION
This commit updates cargo-nextest to 3.1.0, and replaces the deprecated `help_heading` in the clap attributes with its replacement: `next_help_heading`.

#54 and #55 individually also update clap and clap_derive (lock only) from 3.0.14 to 3.1.0. Since `RUSTFLAGS=-D warnings` is used however, their GitHub actions pipelines fail, because `-D warnings` implies use of deprecated functions are not allowed.

While already stated in the Apache license, I will explicitly agree that my contributions will be dual-licensed under the terms of the [`LICENSE-MIT`](https://github.com/nextest-rs/nextest/blob/e4d2431c10f05fe9f6e9397aaeecee9d6503dd91/LICENSE-MIT) and [`LICENSE-APACHE`](https://github.com/nextest-rs/nextest/blob/e4d2431c10f05fe9f6e9397aaeecee9d6503dd91/LICENSE-APACHE) files in the root directory of the nextest source tree.

NB: The [contributing](https://github.com/nextest-rs/nextest/blob/e4d2431c10f05fe9f6e9397aaeecee9d6503dd91/CONTRIBUTING.md) guidelines state: 
> If you haven't already, complete the Contributor License Agreement ("CLA")

I wasn't able to find the CLA for this repository. (I however did complete this step for https://github.com/facebookincubator/cargo-guppy, in case it's the same CLA)