### PR TITLE
Add support for target runners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,6 +470,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,6 +642,7 @@ dependencies = [
  "aho-corasick",
  "camino",
  "cargo_metadata",
+ "cfg-expr",
  "chrono",
  "color-eyre",
  "config",
@@ -641,6 +651,7 @@ dependencies = [
  "debug-ignore",
  "duct",
  "guppy",
+ "home",
  "humantime-serde",
  "indent_write",
  "indoc",
@@ -657,6 +668,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strip-ansi-escapes",
+ "toml",
  "twox-hash",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,7 +642,6 @@ dependencies = [
  "aho-corasick",
  "camino",
  "cargo_metadata",
- "cfg-expr",
  "chrono",
  "color-eyre",
  "config",
@@ -668,6 +667,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strip-ansi-escapes",
+ "target-spec",
  "toml",
  "twox-hash",
 ]

--- a/cargo-nextest/src/cargo_cli.rs
+++ b/cargo-nextest/src/cargo_cli.rs
@@ -89,7 +89,7 @@ pub(crate) struct CargoOptions {
 
     /// Build for the target triple
     #[clap(long, value_name = "TRIPLE")]
-    target: Option<String>,
+    pub(crate) target: Option<String>,
 
     /// Directory for all generated artifacts
     #[clap(long, value_name = "DIR")]

--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -371,12 +371,10 @@ impl AppImpl {
                 }
 
                 let handler = SignalHandler::new().wrap_err("failed to set up Ctrl-C handler")?;
-                let runner = runner_opts.to_builder(no_capture).build(
-                    &test_list,
-                    &profile,
-                    handler,
-                    target_runner.as_ref(),
-                );
+                let mut runner_builder = runner_opts.to_builder(no_capture);
+                runner_builder.set_target_runner(target_runner);
+
+                let runner = runner_builder.build(&test_list, &profile, handler);
                 let stderr = std::io::stderr();
                 let mut writer = BufWriter::new(stderr);
                 let run_stats = runner.try_execute(|event| {

--- a/fixtures/nextest-tests/.cargo/config
+++ b/fixtures/nextest-tests/.cargo/config
@@ -1,0 +1,8 @@
+[target.x86_64-pc-windows-gnu]
+runner = "wine"
+
+[target.'cfg(target_os = "android")']
+runner = "android-runner -x"
+
+[target.'cfg(all(target_arch = "x86_64", target_os = "linux", target_env = "musl"))']
+runner = "passthrough --ensure-this-arg-is-sent"

--- a/fixtures/passthrough
+++ b/fixtures/passthrough
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+if [[ "$1" != "--ensure-this-arg-is-sent" ]] ; then
+    exit 1
+fi
+
+bin="$2"
+shift 2
+
+$bin "$@"

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -14,8 +14,6 @@ aho-corasick = "0.7.18"
 camino = { version = "1.0.7", features = ["serde1"] }
 config = { version = "0.11.0", default-features = false, features = ["toml"] }
 cargo_metadata = "0.14.1"
-# For cfg expression evaluation for [target.'cfg()'] expressions
-cfg-expr = { version = "0.10.1", features = ["targets"] }
 chrono = "0.4.19"
 crossbeam-channel = "0.5.2"
 ctrlc = { version = "3.2.1", features = ["termination"] }
@@ -34,6 +32,8 @@ rayon = "1.5.1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 strip-ansi-escapes = "0.1.1"
+# For cfg expression evaluation for [target.'cfg()'] expressions
+target-spec = "1.0"
 # For parsing of .cargo/config.toml files
 toml = "0.5.8"
 twox-hash = { version = "1.6.2", default-features = false }

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -14,12 +14,17 @@ aho-corasick = "0.7.18"
 camino = { version = "1.0.7", features = ["serde1"] }
 config = { version = "0.11.0", default-features = false, features = ["toml"] }
 cargo_metadata = "0.14.1"
+# For cfg expression evaluation for [target.'cfg()'] expressions
+cfg-expr = { version = "0.10.1", features = ["targets"] }
 chrono = "0.4.19"
 crossbeam-channel = "0.5.2"
 ctrlc = { version = "3.2.1", features = ["termination"] }
 debug-ignore = "1.0.1"
 duct = "0.13.5"
 guppy = "0.13.0"
+# Used to find the cargo root directory, which is needed in case the user has
+# added a config.toml there
+home = "0.5.3"
 humantime-serde = "1.0.1"
 indent_write = "2.2.0"
 once_cell = "1.9.0"
@@ -29,6 +34,8 @@ rayon = "1.5.1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 strip-ansi-escapes = "0.1.1"
+# For parsing of .cargo/config.toml files
+toml = "0.5.8"
 twox-hash = { version = "1.6.2", default-features = false }
 
 nextest-metadata = { version = "0.1.0", path = "../nextest-metadata" }

--- a/nextest-runner/src/lib.rs
+++ b/nextest-runner/src/lib.rs
@@ -48,5 +48,6 @@ pub mod reporter;
 pub mod runner;
 pub mod signal;
 mod stopwatch;
+pub mod target_runner;
 pub mod test_filter;
 pub mod test_list;

--- a/nextest-runner/src/target_runner.rs
+++ b/nextest-runner/src/target_runner.rs
@@ -5,6 +5,7 @@ use camino::Utf8PathBuf;
 
 /// A [target runner](https://doc.rust-lang.org/cargo/reference/config.html#targettriplerunner)
 /// used to execute a test binary rather than the default of executing natively
+#[derive(Debug)]
 pub struct TargetRunner {
     /// This is required
     runner_binary: Utf8PathBuf,
@@ -215,7 +216,7 @@ impl TargetRunner {
     /// binary found in `PATH`
     #[inline]
     pub fn binary(&self) -> &str {
-        &self.runner_binary.as_str()
+        self.runner_binary.as_str()
     }
 
     /// Gets the (optional) runner binary arguments

--- a/nextest-runner/src/target_runner.rs
+++ b/nextest-runner/src/target_runner.rs
@@ -1,0 +1,218 @@
+//! Adds support for [target runners](https://doc.rust-lang.org/cargo/reference/config.html#targettriplerunner)
+
+use crate::errors::TargetRunnerError;
+use camino::Utf8PathBuf;
+
+/// A [target runner](https://doc.rust-lang.org/cargo/reference/config.html#targettriplerunner)
+/// used to execute a test binary rather than the default of executing natively
+pub struct TargetRunner {
+    /// This is required
+    runner_binary: Utf8PathBuf,
+    /// These are optional
+    args: Vec<String>,
+}
+
+impl TargetRunner {
+    /// Acquires the [target runner](https://doc.rust-lang.org/cargo/reference/config.html#targettriplerunner)
+    /// which can be set in a [.cargo/config.toml](https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure)
+    /// or via a `CARGO_TARGET_{TRIPLE}_RUNNER` environment variable
+    pub fn for_target(target_triple: Option<&str>) -> Result<Option<Self>, TargetRunnerError> {
+        use std::borrow::Cow;
+
+        let target_triple: Cow<'_, str> = match target_triple {
+            Some(target) => Cow::Borrowed(target),
+            None => Cow::Owned(cfg_expr::target_lexicon::HOST.to_string()),
+        };
+
+        // First check if have a CARGO_TARGET_{TRIPLE}_RUNNER environment variable
+        // set, and if so use that, as it takes precedence over the static config.toml
+        {
+            let env_key = format!(
+                "CARGO_TARGET_{}_RUNNER",
+                target_triple.to_ascii_uppercase().replace('-', "_")
+            );
+
+            if let Some(runner_var) = std::env::var_os(&env_key) {
+                let runner = runner_var
+                    .into_string()
+                    .map_err(|_osstr| TargetRunnerError::InvalidEnvironmentVar(env_key.clone()))?;
+                return Self::parse_runner(&env_key, runner).map(Some);
+            }
+        }
+
+        Self::find_config(&target_triple)
+    }
+
+    fn find_config(target_triple: &str) -> Result<Option<Self>, TargetRunnerError> {
+        // This is a bit non-intuitive, but the .cargo/config.toml hierarchy is actually
+        // based on the current working directory, _not_ the manifest path, this bug
+        // has existed for a while https://github.com/rust-lang/cargo/issues/2930
+        let root = std::env::current_dir()
+            .map_err(TargetRunnerError::UnableToReadDir)
+            .and_then(|cwd| {
+                Utf8PathBuf::from_path_buf(cwd).map_err(TargetRunnerError::NonUtf8Path)
+            })?;
+
+        // Attempt lookup the $CARGO_HOME directory from the cwd, as that can
+        // contain a default config.toml
+        let mut cargo_home_path = home::cargo_home_with_cwd(root.as_std_path())
+            .map_err(TargetRunnerError::UnableToReadDir)
+            .and_then(|home| {
+                Utf8PathBuf::from_path_buf(home).map_err(TargetRunnerError::NonUtf8Path)
+            })?;
+
+        // Note versions of cargo older than 1.39 only support .cargo/config without
+        // the toml extension, but since this repo states its MSRV as 1.54 it should
+        // be ok to lose that particular piece of backwards compatibility
+        let mut configs = Vec::new();
+
+        fn read_config_dir(dir: &mut Utf8PathBuf) -> Option<Utf8PathBuf> {
+            dir.push("config.toml");
+
+            if !dir.exists() {
+                dir.set_extension("toml");
+            }
+
+            if dir.exists() {
+                let ret = dir.clone();
+                dir.pop();
+                Some(ret)
+            } else {
+                dir.pop();
+                None
+            }
+        }
+
+        let mut dir = root
+            .canonicalize()
+            .map_err(|io| TargetRunnerError::FailedPathCanonicalization(root, io))
+            .and_then(|canon| {
+                Utf8PathBuf::from_path_buf(canon).map_err(TargetRunnerError::NonUtf8Path)
+            })?;
+
+        for _ in 0..dir.ancestors().count() {
+            dir.push(".cargo");
+
+            if !dir.exists() {
+                dir.pop();
+                dir.pop();
+                continue;
+            }
+
+            if let Some(config) = read_config_dir(&mut dir) {
+                configs.push(config);
+            }
+
+            dir.pop();
+            dir.pop();
+        }
+
+        if let Some(home_config) = read_config_dir(&mut cargo_home_path) {
+            // Ensure we don't add a duplicate if the current directory is underneath
+            // the same root as $CARGO_HOME
+            if !configs.iter().any(|path| path == &home_config) {
+                configs.push(home_config);
+            }
+        }
+
+        #[derive(serde::Deserialize, Debug)]
+        struct CargoConfigRunner {
+            runner: Option<String>,
+        }
+
+        #[derive(serde::Deserialize, Debug)]
+        struct CargoConfig {
+            target: Option<std::collections::BTreeMap<String, CargoConfigRunner>>,
+        }
+
+        let mut target_runner = None;
+
+        let triple_runner_key = format!("target.{}.runner", target_triple);
+        // Attempt to get the target info from a triple, this can fail if the
+        // target is actually a .json target spec, or is otherwise of a form
+        // that target_lexicon is unable to parse, which can happen with newer
+        // niche targets
+        let target_info: Option<cfg_expr::target_lexicon::Triple> = target_triple.parse().ok();
+
+        // Now that we've found all of the config files that could declare
+        // a runner that matches our target triple, we need to actually find
+        // all the matches, but in reverse order as the closer the config is
+        // to our current working directory, the higher precedence it has
+        'config: for config_path in configs.into_iter().rev() {
+            let config_contents = std::fs::read_to_string(&config_path)
+                .map_err(|io| TargetRunnerError::FailedToReadConfig(config_path.clone(), io))?;
+            let config: CargoConfig = toml::from_str(&config_contents)
+                .map_err(|io| TargetRunnerError::FailedToParseConfig(config_path.clone(), io))?;
+
+            if let Some(mut targets) = config.target {
+                // First lookup by the exact triple, as that one always takes precedence
+                if let Some(target) = targets.remove(target_triple) {
+                    if let Some(runner) = target.runner {
+                        target_runner = Some(Self::parse_runner(&triple_runner_key, runner)?);
+                        continue;
+                    }
+                }
+
+                if let Some(target_info) = &target_info {
+                    // Next check if there are target.'cfg(..)' expressions that match
+                    // the target. cargo states that it is not allowed for more than
+                    // 1 cfg runner to match the target, but we let cargo handle that
+                    // error itself, we just use the first one that matches
+                    for (cfg, runner) in targets.into_iter().filter_map(|(k, v)| match v.runner {
+                        Some(runner) if k.starts_with("cfg(") => Some((k, runner)),
+                        _ => None,
+                    }) {
+                        // Treat these as non-fatal, but would be good to log maybe
+                        let expr = match cfg_expr::Expression::parse(&cfg) {
+                            Ok(expr) => expr,
+                            Err(_err) => continue,
+                        };
+
+                        if expr.eval(|pred| match pred {
+                            cfg_expr::Predicate::Target(tp) => tp.matches(target_info),
+                            _ => false,
+                        }) {
+                            target_runner = Some(Self::parse_runner(&triple_runner_key, runner)?);
+                            continue 'config;
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(target_runner)
+    }
+
+    fn parse_runner(key: &str, value: String) -> Result<Self, TargetRunnerError> {
+        // We only split on whitespace, which doesn't take quoting into account,
+        // but I believe that cargo doesn't do that either
+        let mut runner_iter = value.split_whitespace();
+
+        let runner_binary = runner_iter
+            .next()
+            .ok_or_else(|| TargetRunnerError::BinaryNotSpecified(key.to_owned(), value.clone()))?;
+        let args = runner_iter.map(String::from).collect();
+
+        Ok(Self {
+            runner_binary: runner_binary.into(),
+            args,
+        })
+    }
+
+    /// Gets the runner binary path.
+    ///
+    /// Note that this is returned as a `str` specifically to avoid duct's
+    /// behavior of prepending `.` to paths it thinks are relative, the path
+    /// specified for a runner can be a full path, but it is most commonly a
+    /// binary found in `PATH`
+    #[inline]
+    pub fn binary(&self) -> &str {
+        &self.runner_binary.as_str()
+    }
+
+    /// Gets the (optional) runner binary arguments
+    #[inline]
+    pub fn args(&self) -> impl Iterator<Item = &str> {
+        self.args.iter().map(AsRef::as_ref)
+    }
+}

--- a/nextest-runner/src/target_runner.rs
+++ b/nextest-runner/src/target_runner.rs
@@ -61,26 +61,24 @@ impl TargetRunner {
                 Utf8PathBuf::from_path_buf(home).map_err(TargetRunnerError::NonUtf8Path)
             })?;
 
-        // Note versions of cargo older than 1.39 only support .cargo/config without
-        // the toml extension, but since this repo states its MSRV as 1.54 it should
-        // be ok to lose that particular piece of backwards compatibility
         let mut configs = Vec::new();
 
         fn read_config_dir(dir: &mut Utf8PathBuf) -> Option<Utf8PathBuf> {
-            dir.push("config.toml");
+            // Check for config before config.toml, same as cargo does
+            dir.push("config");
 
             if !dir.exists() {
                 dir.set_extension("toml");
             }
 
-            if dir.exists() {
-                let ret = dir.clone();
-                dir.pop();
-                Some(ret)
+            let ret = if dir.exists() {
+                Some(dir.clone())
             } else {
-                dir.pop();
                 None
-            }
+            };
+
+            dir.pop();
+            ret
         }
 
         let mut dir = root

--- a/nextest-runner/src/test_list.rs
+++ b/nextest-runner/src/test_list.rs
@@ -446,8 +446,8 @@ impl<'g> RustTestArtifact<'g> {
         let mut argv = Vec::new();
 
         let program: std::ffi::OsString = if let Some(runner) = runner {
-            argv.push(self.binary_path.as_str());
             argv.extend(runner.args());
+            argv.push(self.binary_path.as_str());
             runner.binary().into()
         } else {
             use duct::IntoExecutablePath;
@@ -514,8 +514,8 @@ impl<'a> TestInstance<'a> {
 
         let program: std::ffi::OsString = match target_runner {
             Some(tr) => {
-                args.push(self.binary.as_str());
                 args.extend(tr.args());
+                args.push(self.binary.as_str());
                 tr.binary().into()
             }
             None => {

--- a/nextest-runner/tests/basic.rs
+++ b/nextest-runner/tests/basic.rs
@@ -217,8 +217,7 @@ fn test_run() -> Result<()> {
         .profile(NextestConfig::DEFAULT_PROFILE)
         .expect("default config is valid");
 
-    let runner =
-        TestRunnerBuilder::default().build(&test_list, &profile, SignalHandler::noop(), None);
+    let runner = TestRunnerBuilder::default().build(&test_list, &profile, SignalHandler::noop());
 
     let (instance_statuses, run_stats) = execute_collect(&runner);
 
@@ -267,8 +266,7 @@ fn test_run_ignored() -> Result<()> {
         .profile(NextestConfig::DEFAULT_PROFILE)
         .expect("default config is valid");
 
-    let runner =
-        TestRunnerBuilder::default().build(&test_list, &profile, SignalHandler::noop(), None);
+    let runner = TestRunnerBuilder::default().build(&test_list, &profile, SignalHandler::noop());
 
     let (instance_statuses, run_stats) = execute_collect(&runner);
 
@@ -320,8 +318,7 @@ fn test_retries() -> Result<()> {
     let retries = profile.retries();
     assert_eq!(retries, 2, "retries set in with-retries profile");
 
-    let runner =
-        TestRunnerBuilder::default().build(&test_list, &profile, SignalHandler::noop(), None);
+    let runner = TestRunnerBuilder::default().build(&test_list, &profile, SignalHandler::noop());
 
     let (instance_statuses, run_stats) = execute_collect(&runner);
 

--- a/nextest-runner/tests/basic.rs
+++ b/nextest-runner/tests/basic.rs
@@ -441,9 +441,12 @@ fn execute_collect<'a>(
     (instance_statuses, run_stats)
 }
 
+#[cfg(all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"))]
 mod target_runner;
+#[cfg(all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"))]
 use target_runner::with_env;
 
+#[cfg(all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"))]
 fn passthrough_path() -> &'static Utf8Path {
     static PP: once_cell::sync::OnceCell<Utf8PathBuf> = once_cell::sync::OnceCell::new();
     PP.get_or_init(|| {

--- a/nextest-runner/tests/basic.rs
+++ b/nextest-runner/tests/basic.rs
@@ -150,7 +150,7 @@ fn init_fixture_targets() -> BTreeMap<String, RustTestArtifact<'static>> {
 fn test_list_tests() -> Result<()> {
     let test_filter = TestFilterBuilder::any(RunIgnored::Default);
     let test_bins: Vec<_> = FIXTURE_TARGETS.values().cloned().collect();
-    let test_list = TestList::new(test_bins, &test_filter)?;
+    let test_list = TestList::new(test_bins, &test_filter, None)?;
 
     for (name, expected) in &*EXPECTED_TESTS {
         let test_binary = FIXTURE_TARGETS
@@ -210,14 +210,15 @@ impl fmt::Debug for InstanceStatus {
 fn test_run() -> Result<()> {
     let test_filter = TestFilterBuilder::any(RunIgnored::Default);
     let test_bins: Vec<_> = FIXTURE_TARGETS.values().cloned().collect();
-    let test_list = TestList::new(test_bins, &test_filter)?;
+    let test_list = TestList::new(test_bins, &test_filter, None)?;
     let config =
         NextestConfig::from_sources(&workspace_root(), None).expect("loaded fixture config");
     let profile = config
         .profile(NextestConfig::DEFAULT_PROFILE)
         .expect("default config is valid");
 
-    let runner = TestRunnerBuilder::default().build(&test_list, &profile, SignalHandler::noop());
+    let runner =
+        TestRunnerBuilder::default().build(&test_list, &profile, SignalHandler::noop(), None);
 
     let (instance_statuses, run_stats) = execute_collect(&runner);
 
@@ -259,14 +260,15 @@ fn test_run() -> Result<()> {
 fn test_run_ignored() -> Result<()> {
     let test_filter = TestFilterBuilder::any(RunIgnored::IgnoredOnly);
     let test_bins: Vec<_> = FIXTURE_TARGETS.values().cloned().collect();
-    let test_list = TestList::new(test_bins, &test_filter)?;
+    let test_list = TestList::new(test_bins, &test_filter, None)?;
     let config =
         NextestConfig::from_sources(&workspace_root(), None).expect("loaded fixture config");
     let profile = config
         .profile(NextestConfig::DEFAULT_PROFILE)
         .expect("default config is valid");
 
-    let runner = TestRunnerBuilder::default().build(&test_list, &profile, SignalHandler::noop());
+    let runner =
+        TestRunnerBuilder::default().build(&test_list, &profile, SignalHandler::noop(), None);
 
     let (instance_statuses, run_stats) = execute_collect(&runner);
 
@@ -308,7 +310,7 @@ fn test_run_ignored() -> Result<()> {
 fn test_retries() -> Result<()> {
     let test_filter = TestFilterBuilder::any(RunIgnored::Default);
     let test_bins: Vec<_> = FIXTURE_TARGETS.values().cloned().collect();
-    let test_list = TestList::new(test_bins, &test_filter)?;
+    let test_list = TestList::new(test_bins, &test_filter, None)?;
     let config =
         NextestConfig::from_sources(&workspace_root(), None).expect("loaded fixture config");
     let profile = config
@@ -318,7 +320,8 @@ fn test_retries() -> Result<()> {
     let retries = profile.retries();
     assert_eq!(retries, 2, "retries set in with-retries profile");
 
-    let runner = TestRunnerBuilder::default().build(&test_list, &profile, SignalHandler::noop());
+    let runner =
+        TestRunnerBuilder::default().build(&test_list, &profile, SignalHandler::noop(), None);
 
     let (instance_statuses, run_stats) = execute_collect(&runner);
 

--- a/nextest-runner/tests/target_runner.rs
+++ b/nextest-runner/tests/target_runner.rs
@@ -1,0 +1,196 @@
+use camino::Utf8PathBuf;
+use nextest_runner::{errors::TargetRunnerError, target_runner::TargetRunner};
+use once_cell::sync::OnceCell;
+use std::{env, sync::Mutex};
+
+fn env_mutex() -> &'static Mutex<()> {
+    static MUTEX: OnceCell<Mutex<()>> = OnceCell::new();
+    MUTEX.get_or_init(|| Mutex::new(()))
+}
+
+pub fn with_env(
+    vars: impl IntoIterator<Item = (impl Into<String>, impl AsRef<str>)>,
+    func: impl FnOnce() -> Result<Option<TargetRunner>, TargetRunnerError>,
+) -> Result<Option<TargetRunner>, TargetRunnerError> {
+    let lock = env_mutex().lock().unwrap();
+
+    let keys: Vec<_> = vars
+        .into_iter()
+        .map(|(key, val)| {
+            let key = key.into();
+            env::set_var(&key, val.as_ref());
+            key
+        })
+        .collect();
+
+    let res = func();
+
+    for key in keys {
+        env::remove_var(key);
+    }
+    drop(lock);
+
+    res
+}
+
+fn default() -> &'static target_spec::Platform {
+    static DEF: OnceCell<target_spec::Platform> = OnceCell::new();
+    DEF.get_or_init(|| target_spec::Platform::current().unwrap())
+}
+
+#[test]
+fn parses_nextest_env() {
+    let def_runner = with_env(
+        [(
+            format!(
+                "NEXTEST_{}_RUNNER",
+                default()
+                    .triple_str()
+                    .to_ascii_uppercase()
+                    .replace('-', "_")
+            ),
+            "nextest_with_default",
+        )],
+        || TargetRunner::for_target(None),
+    )
+    .unwrap()
+    .unwrap();
+
+    assert_eq!("nextest_with_default", def_runner.binary());
+    assert_eq!(0, def_runner.args().count());
+
+    let specific_runner = with_env(
+        [(
+            "NEXTEST_X86_64_PC_WINDOWS_MSVC_RUNNER",
+            "nextest_with_specific --arg1 -b",
+        )],
+        || TargetRunner::for_target(Some("x86_64-pc-windows-msvc")),
+    )
+    .unwrap()
+    .unwrap();
+
+    assert_eq!("nextest_with_specific", specific_runner.binary());
+    assert_eq!(
+        vec!["--arg1", "-b"],
+        specific_runner.args().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn parses_cargo_env() {
+    let def_runner = with_env(
+        [(
+            format!(
+                "CARGO_TARGET_{}_RUNNER",
+                default()
+                    .triple_str()
+                    .to_ascii_uppercase()
+                    .replace('-', "_")
+            ),
+            "cargo_with_default --arg --arg2",
+        )],
+        || TargetRunner::for_target(None),
+    )
+    .unwrap()
+    .unwrap();
+
+    assert_eq!("cargo_with_default", def_runner.binary());
+    assert_eq!(
+        vec!["--arg", "--arg2"],
+        def_runner.args().collect::<Vec<_>>()
+    );
+
+    let specific_runner = with_env(
+        [(
+            "CARGO_TARGET_AARCH64_LINUX_ANDROID_RUNNER",
+            "cargo_with_specific",
+        )],
+        || TargetRunner::for_target(Some("aarch64-linux-android")),
+    )
+    .unwrap()
+    .unwrap();
+
+    assert_eq!("cargo_with_specific", specific_runner.binary());
+    assert_eq!(0, specific_runner.args().count());
+}
+
+/// Use fixtures/nextest-test as the root dir
+fn root_dir() -> Utf8PathBuf {
+    Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("fixtures/nextest-tests")
+}
+
+fn parse_triple(triple: &'static str) -> target_spec::Platform {
+    target_spec::Platform::new(triple, target_spec::TargetFeatures::Unknown).unwrap()
+}
+
+#[test]
+fn parses_cargo_config_exact() {
+    let windows = parse_triple("x86_64-pc-windows-gnu");
+
+    let runner = TargetRunner::find_config(windows, false, root_dir())
+        .unwrap()
+        .unwrap();
+
+    assert_eq!("wine", runner.binary());
+    assert_eq!(0, runner.args().count());
+}
+
+#[test]
+fn disregards_non_matching() {
+    let windows = parse_triple("x86_64-unknown-linux-gnu");
+    assert!(TargetRunner::find_config(windows, false, root_dir())
+        .unwrap()
+        .is_none());
+}
+
+#[test]
+fn parses_cargo_config_cfg() {
+    let android = parse_triple("aarch64-linux-android");
+    let runner = TargetRunner::find_config(android, false, root_dir())
+        .unwrap()
+        .unwrap();
+
+    assert_eq!("android-runner", runner.binary());
+    assert_eq!(vec!["-x"], runner.args().collect::<Vec<_>>());
+
+    let linux = parse_triple("x86_64-unknown-linux-musl");
+    let runner = TargetRunner::find_config(linux, false, root_dir())
+        .unwrap()
+        .unwrap();
+
+    assert_eq!("passthrough", runner.binary());
+    assert_eq!(
+        vec!["--ensure-this-arg-is-sent"],
+        runner.args().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn fallsback_to_cargo_config() {
+    let linux = parse_triple("x86_64-unknown-linux-musl");
+
+    let runner = with_env(
+        [
+            (
+                "NEXTEST_X86_64_UNKNOWN_LINUX_GNU_RUNNER",
+                "nextest-runner-linux",
+            ),
+            (
+                "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_RUNNER",
+                "cargo-runner-windows",
+            ),
+        ],
+        || TargetRunner::with_root(Some(linux.triple_str()), false, root_dir()),
+    )
+    .unwrap()
+    .unwrap();
+
+    assert_eq!("passthrough", runner.binary());
+    assert_eq!(
+        vec!["--ensure-this-arg-is-sent"],
+        runner.args().collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
This adds support for [target runners](https://doc.rust-lang.org/cargo/reference/config.html#targettriplerunner) which allows nextest to run tests for binaries that can't execute natively on the host such in cross-compilation situations targeting `x86_64-pc-windows-msvc` from a Linux host, or `wasm32-unknown-unknown`, etc.

This PR supports both the `CARGO_TARGET_{TRIPLE}_RUNNER` environment variable, as well as reading configured runners from `.cargo/config.toml`. This currently respects the same (IMO broken) [behavior](https://github.com/rust-lang/cargo/issues/2930) in cargo for looking up the hierarchy of configs.

Example output running windows binaries via wine from linux

![image](https://user-images.githubusercontent.com/2316028/154704670-524df341-06e3-4717-a220-19b5e5ff51cb.png)


Resolves: #57