### PR TITLE
Adds support for separated build and run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,10 +124,13 @@ dependencies = [
  "log",
  "nextest-metadata",
  "nextest-runner",
+ "once_cell",
  "owo-colors",
+ "regex",
  "serde_json",
  "shellwords",
  "supports-color",
+ "tempdir",
 ]
 
 [[package]]
@@ -390,6 +393,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "getrandom"
@@ -870,7 +879,7 @@ dependencies = [
  "lazy_static",
  "num-traits",
  "quick-error 2.0.1",
- "rand",
+ "rand 0.8.5",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -941,13 +950,26 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -957,8 +979,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -975,7 +1012,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -1001,6 +1038,15 @@ dependencies = [
  "crossbeam-utils",
  "lazy_static",
  "num_cpus",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1202,6 +1248,16 @@ dependencies = [
  "cfg-expr",
  "guppy-workspace-hack",
  "target-lexicon",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,7 @@ dependencies = [
  "nextest-metadata",
  "nextest-runner",
  "owo-colors",
+ "serde_json",
  "shellwords",
  "supports-color",
 ]

--- a/cargo-nextest/Cargo.toml
+++ b/cargo-nextest/Cargo.toml
@@ -29,3 +29,8 @@ owo-colors = { version = "3.2.0", features = ["supports-colors"] }
 shellwords = "1.1.0"
 supports-color = "1.3.0"
 serde_json = "1.0.79"
+
+[dev-dependencies]
+tempdir = "0.3.7"
+regex = "1.5.4"
+once_cell = "1.9.0"

--- a/cargo-nextest/Cargo.toml
+++ b/cargo-nextest/Cargo.toml
@@ -28,3 +28,4 @@ nextest-metadata = { version = "0.1.0", path = "../nextest-metadata" }
 owo-colors = { version = "3.2.0", features = ["supports-colors"] }
 shellwords = "1.1.0"
 supports-color = "1.3.0"
+serde_json = "1.0.79"

--- a/cargo-nextest/src/lib.rs
+++ b/cargo-nextest/src/lib.rs
@@ -18,7 +18,12 @@ mod dispatch;
 mod errors;
 mod output;
 
+#[cfg(test)]
+mod tests_integration;
+
 #[doc(hidden)]
 pub use dispatch::*;
 #[doc(hidden)]
 pub use errors::*;
+#[doc(hidden)]
+pub use output::OutputWriter;

--- a/cargo-nextest/src/main.rs
+++ b/cargo-nextest/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use cargo_nextest::{CargoNextestApp, ExpectedError};
+use cargo_nextest::{CargoNextestApp, ExpectedError, OutputWriter};
 use clap::Parser;
 use color_eyre::Result;
 
@@ -10,7 +10,7 @@ fn main() -> Result<()> {
     let _ = enable_ansi_support::enable_ansi_support();
 
     let opts = CargoNextestApp::parse();
-    match opts.exec() {
+    match opts.exec(&mut OutputWriter::default()) {
         Ok(()) => Ok(()),
         Err(err) => {
             let expected_error: ExpectedError = err.downcast()?;

--- a/cargo-nextest/src/tests_integration/fixtures.rs
+++ b/cargo-nextest/src/tests_integration/fixtures.rs
@@ -1,0 +1,266 @@
+use super::temp_project::TempProject;
+use crate::{dispatch::CargoNextestApp, OutputWriter};
+use clap::StructOpt;
+use nextest_metadata::{BinaryListSummary, Platform, TestListSummary};
+use once_cell::sync::Lazy;
+use regex::Regex;
+use std::process::Command;
+
+pub struct TestInfo {
+    id: &'static str,
+    platform: Platform,
+    test_cases: Vec<(&'static str, bool)>,
+}
+
+impl TestInfo {
+    fn new(id: &'static str, platform: Platform, test_cases: Vec<(&'static str, bool)>) -> Self {
+        Self {
+            id,
+            platform,
+            test_cases,
+        }
+    }
+}
+
+pub static EXPECTED_LIST: Lazy<Vec<TestInfo>> = Lazy::new(|| {
+    vec![
+        TestInfo::new(
+            "nextest-tests::basic",
+            Platform::Target,
+            vec![
+                ("test_cargo_env_vars", false),
+                ("test_cwd", false),
+                ("test_failure_assert", false),
+                ("test_failure_error", false),
+                ("test_failure_should_panic", false),
+                ("test_flaky_mod_2", false),
+                ("test_flaky_mod_3", false),
+                ("test_ignored", true),
+                ("test_ignored_fail", true),
+                ("test_success", false),
+                ("test_success_should_panic", false),
+            ],
+        ),
+        TestInfo::new(
+            "nextest-derive::proc-macro/nextest-derive",
+            Platform::Host,
+            vec![("it_works", false)],
+        ),
+        TestInfo::new(
+            "nextest-tests::bin/nextest-tests",
+            Platform::Target,
+            vec![("tests::bin_success", false)],
+        ),
+        TestInfo::new(
+            "nextest-tests",
+            Platform::Target,
+            vec![("tests::unit_test_success", false)],
+        ),
+        TestInfo::new(
+            "nextest-tests::other",
+            Platform::Target,
+            vec![("other_test_success", false)],
+        ),
+        TestInfo::new(
+            "nextest-tests::bin/other",
+            Platform::Target,
+            vec![("tests::other_bin_success", false)],
+        ),
+        TestInfo::new(
+            "nextest-tests::example/nextest-tests",
+            Platform::Target,
+            vec![("tests::example_success", false)],
+        ),
+        TestInfo::new(
+            "nextest-tests::example/other",
+            Platform::Target,
+            vec![("tests::other_example_success", false)],
+        ),
+    ]
+});
+
+pub fn cargo_bin() -> String {
+    match std::env::var("CARGO") {
+        Ok(v) => v,
+        Err(std::env::VarError::NotPresent) => "cargo".to_owned(),
+        Err(err) => panic!("error obtaining CARGO env var: {}", err),
+    }
+}
+
+pub static ENABLE_EXPERIMENTAL: Lazy<()> = Lazy::new(enable_experimental);
+
+#[track_caller]
+fn enable_experimental() {
+    std::env::set_var("NEXTEST_EXPERIMENTAL_REUSE_BUILD", "1");
+}
+
+#[track_caller]
+pub fn save_cargo_metadata(p: &TempProject) {
+    let mut cmd = Command::new(cargo_bin());
+    cmd.args([
+        "metadata",
+        "--format-version=1",
+        "--all-features",
+        "--no-deps",
+        "--manifest-path",
+    ]);
+    cmd.arg(p.manifest_path());
+    let output = cmd.output().expect("cargo metadata could run");
+
+    assert_eq!(Some(0), output.status.code());
+    std::fs::write(p.cargo_metadata_path(), &output.stdout).unwrap();
+}
+
+#[track_caller]
+pub fn build_tests(p: &TempProject) {
+    let args = CargoNextestApp::parse_from([
+        "cargo",
+        "nextest",
+        "--manifest-path",
+        p.manifest_path().as_os_str().to_string_lossy().as_ref(),
+        "list",
+        "--workspace",
+        "--message-format",
+        "json",
+        "--list-type",
+        "binaries-only",
+    ]);
+
+    let mut output = OutputWriter::new_test();
+    args.exec(&mut output).unwrap();
+
+    std::fs::write(p.binaries_metadata_path(), output.stdout().unwrap()).unwrap();
+}
+
+#[track_caller]
+pub fn check_list_full_output(stdout: &[u8], platform: Option<Platform>) {
+    let result: TestListSummary = serde_json::from_slice(stdout).unwrap();
+
+    let host_binaries_count = 1;
+    let test_suite = &*EXPECTED_LIST;
+    match platform {
+        Some(Platform::Host) => assert_eq!(host_binaries_count, result.rust_suites.len()),
+        Some(Platform::Target) => assert_eq!(
+            test_suite.len() - host_binaries_count,
+            result.rust_suites.len()
+        ),
+        None => assert_eq!(test_suite.len(), result.rust_suites.len()),
+    }
+
+    for test in test_suite {
+        match platform {
+            Some(p) if test.platform != p => continue,
+            _ => {}
+        }
+
+        let entry = result.rust_suites.get(test.id);
+        let entry = match entry {
+            Some(e) => e,
+            _ => panic!("Missing binary: {}", test.id),
+        };
+
+        assert_eq!(test.test_cases.len(), entry.testcases.len());
+        for case in &test.test_cases {
+            let e = entry.testcases.get(case.0);
+            let e = match e {
+                Some(e) => e,
+                _ => panic!("Missing test case '{}' in '{}'", case.0, test.id),
+            };
+            assert_eq!(case.1, e.ignored);
+        }
+    }
+}
+
+#[track_caller]
+pub fn check_list_binaries_output(stdout: &[u8]) {
+    let result: BinaryListSummary = serde_json::from_slice(stdout).unwrap();
+
+    let test_suite = &*EXPECTED_LIST;
+    assert_eq!(test_suite.len(), result.rust_binaries.len());
+
+    for test in test_suite {
+        let entry = result
+            .rust_binaries
+            .iter()
+            .find(|(_, bin)| bin.binary_id == test.id);
+        let entry = match entry {
+            Some(e) => e,
+            _ => panic!("Missing binary: {}", test.id),
+        };
+
+        assert_eq!(test.platform, entry.1.platform);
+    }
+}
+
+fn make_check_result_regex(result: bool, name: &str) -> Regex {
+    let name = regex::escape(name);
+    if result {
+        Regex::new(&format!(r"PASS \[.*\] *{}", name)).unwrap()
+    } else {
+        Regex::new(&format!(r"FAIL \[.*\] *{}", name)).unwrap()
+    }
+}
+
+#[track_caller]
+pub fn check_run_output(stderr: &[u8], relocated: bool) {
+    // This could be made more robust with a machine-readable output,
+    // or maybe using quick-junit output
+
+    let output = String::from_utf8(stderr.to_vec()).unwrap();
+
+    println!("{}", output);
+
+    // Weirdly on macos test_cwd doesn't pass:
+    //   left: `"/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/nextest-fixture.Dy8Zva13W5UR"`
+    //  right: `"/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/nextest-fixture.Dy8Zva13W5UR"`
+
+    #[cfg(not(target_os = "macos"))]
+    let cwd_pass = !relocated;
+    #[cfg(target_os = "macos")]
+    let cwd_pass = false;
+    #[cfg(target_os = "macos")]
+    let _ = relocated;
+
+    let expected = &[
+        (true, "nextest-tests::basic test_cargo_env_vars"),
+        (false, "nextest-tests::basic test_failure_error"),
+        (false, "nextest-tests::basic test_flaky_mod_2"),
+        (true, "nextest-tests::bin/nextest-tests tests::bin_success"),
+        (false, "nextest-tests::basic test_failure_should_panic"),
+        (true, "nextest-tests::bin/nextest-tests tests::bin_success"),
+        (false, "nextest-tests::basic test_failure_should_panic"),
+        (true, "nextest-tests::bin/other tests::other_bin_success"),
+        (true, "nextest-tests::basic test_success_should_panic"),
+        (false, "nextest-tests::basic test_failure_assert"),
+        (false, "nextest-tests::basic test_flaky_mod_3"),
+        (cwd_pass, "nextest-tests::basic test_cwd"),
+        (
+            true,
+            "nextest-tests::example/nextest-tests tests::example_success",
+        ),
+        (true, "nextest-tests::other other_test_success"),
+        (true, "nextest-tests::basic test_success"),
+        (true, "nextest-derive::proc-macro/nextest-derive it_works"),
+        (
+            true,
+            "nextest-tests::example/other tests::other_example_success",
+        ),
+        (true, "nextest-tests tests::unit_test_success"),
+    ];
+
+    for (result, name) in expected {
+        let reg = make_check_result_regex(*result, name);
+        assert!(reg.is_match(&output), "{}: result didn't match", name);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    let summary_reg = if relocated {
+        Regex::new(r"Summary \[.*\] *16 tests run: 10 passed, 6 failed, 2 skipped").unwrap()
+    } else {
+        Regex::new(r"Summary \[.*\] *16 tests run: 11 passed, 5 failed, 2 skipped").unwrap()
+    };
+    #[cfg(target_os = "macos")]
+    let summary_reg =
+        Regex::new(r"Summary \[.*\] *16 tests run: 10 passed, 6 failed, 2 skipped").unwrap();
+    assert!(summary_reg.is_match(&output), "summary didn't match");
+}

--- a/cargo-nextest/src/tests_integration/mod.rs
+++ b/cargo-nextest/src/tests_integration/mod.rs
@@ -1,0 +1,279 @@
+//! Integration tests
+//!
+//! Those tests are not in "cargo-nextest/tests/integration/main.rs"
+//! as this would fail on CI on windows.
+//! If a crate with a binary has integration tests, cargo consider that
+//! it should rebuild the binary when building the tests.
+//! In our case, when running `cargo run -p cargo-nextest -- rnextest run`:
+//! - Execution of `cargo-nextest`
+//!     - Execution of `cargo test --no-run`
+//!         - Build `cargo-nextest`
+//! So we try to replace the binary we are currently running. This is forbidden on Windows.
+
+use crate::{dispatch::CargoNextestApp, OutputWriter};
+use clap::StructOpt;
+use nextest_metadata::{BinaryListSummary, Platform};
+
+mod fixtures;
+mod temp_project;
+
+use fixtures::*;
+use temp_project::TempProject;
+
+#[test]
+fn test_list_default() {
+    let p = TempProject::new().unwrap();
+
+    let args = CargoNextestApp::parse_from([
+        "cargo",
+        "nextest",
+        "--manifest-path",
+        p.manifest_path().as_os_str().to_string_lossy().as_ref(),
+        "list",
+        "--workspace",
+        "--message-format",
+        "json",
+    ]);
+
+    let mut output = OutputWriter::new_test();
+    args.exec(&mut output).unwrap();
+
+    check_list_full_output(output.stdout().unwrap(), None);
+}
+
+#[test]
+fn test_list_full() {
+    let p = TempProject::new().unwrap();
+
+    let args = CargoNextestApp::parse_from([
+        "cargo",
+        "nextest",
+        "--manifest-path",
+        p.manifest_path().as_os_str().to_string_lossy().as_ref(),
+        "list",
+        "--workspace",
+        "--message-format",
+        "json",
+        "--list-type",
+        "full",
+    ]);
+
+    let mut output = OutputWriter::new_test();
+    args.exec(&mut output).unwrap();
+
+    check_list_full_output(output.stdout().unwrap(), None);
+}
+
+#[test]
+fn test_list_binaries_only() {
+    let p = TempProject::new().unwrap();
+
+    let args = CargoNextestApp::parse_from([
+        "cargo",
+        "nextest",
+        "--manifest-path",
+        p.manifest_path().as_os_str().to_string_lossy().as_ref(),
+        "list",
+        "--workspace",
+        "--message-format",
+        "json",
+        "--list-type",
+        "binaries-only",
+    ]);
+
+    let mut output = OutputWriter::new_test();
+    args.exec(&mut output).unwrap();
+
+    check_list_binaries_output(output.stdout().unwrap());
+}
+
+#[test]
+fn test_list_full_after_build() {
+    let _ = &*ENABLE_EXPERIMENTAL;
+
+    let p = TempProject::new().unwrap();
+    build_tests(&p);
+
+    let args = CargoNextestApp::parse_from([
+        "cargo",
+        "nextest",
+        "--manifest-path",
+        p.manifest_path().as_os_str().to_string_lossy().as_ref(),
+        "list",
+        "--binaries-metadata",
+        p.binaries_metadata_path()
+            .as_os_str()
+            .to_string_lossy()
+            .as_ref(),
+        "--message-format",
+        "json",
+    ]);
+
+    let mut output = OutputWriter::new_test();
+    args.exec(&mut output).unwrap();
+
+    check_list_full_output(output.stdout().unwrap(), None);
+}
+
+#[test]
+fn test_list_host_after_build() {
+    let _ = &*ENABLE_EXPERIMENTAL;
+
+    let p = TempProject::new().unwrap();
+    build_tests(&p);
+
+    let args = CargoNextestApp::parse_from([
+        "cargo",
+        "nextest",
+        "--manifest-path",
+        p.manifest_path().as_os_str().to_string_lossy().as_ref(),
+        "list",
+        "--binaries-metadata",
+        p.binaries_metadata_path()
+            .as_os_str()
+            .to_string_lossy()
+            .as_ref(),
+        "--message-format",
+        "json",
+        "--platform-filter",
+        "host",
+    ]);
+
+    let mut output = OutputWriter::new_test();
+    args.exec(&mut output).unwrap();
+
+    check_list_full_output(output.stdout().unwrap(), Some(Platform::Host));
+}
+
+#[test]
+fn test_list_target_after_build() {
+    let _ = &*ENABLE_EXPERIMENTAL;
+
+    let p = TempProject::new().unwrap();
+    build_tests(&p);
+
+    let args = CargoNextestApp::parse_from([
+        "cargo",
+        "nextest",
+        "--manifest-path",
+        p.manifest_path().as_os_str().to_string_lossy().as_ref(),
+        "list",
+        "--binaries-metadata",
+        p.binaries_metadata_path()
+            .as_os_str()
+            .to_string_lossy()
+            .as_ref(),
+        "--message-format",
+        "json",
+        "--platform-filter",
+        "target",
+    ]);
+
+    let mut output = OutputWriter::new_test();
+    args.exec(&mut output).unwrap();
+
+    check_list_full_output(output.stdout().unwrap(), Some(Platform::Target));
+}
+
+#[test]
+fn test_run() {
+    let p = TempProject::new().unwrap();
+
+    let args = CargoNextestApp::parse_from([
+        "cargo",
+        "nextest",
+        "--manifest-path",
+        p.manifest_path().as_os_str().to_string_lossy().as_ref(),
+        "run",
+        "--workspace",
+    ]);
+
+    let mut output = OutputWriter::new_test();
+    let err = args.exec(&mut output).unwrap_err();
+    assert_eq!("test run failed\n", err.to_string());
+
+    check_run_output(output.stderr().unwrap(), false);
+}
+
+#[test]
+fn test_run_after_build() {
+    let _ = &*ENABLE_EXPERIMENTAL;
+
+    let p = TempProject::new().unwrap();
+    build_tests(&p);
+
+    let args = CargoNextestApp::parse_from([
+        "cargo",
+        "nextest",
+        "--manifest-path",
+        p.manifest_path().as_os_str().to_string_lossy().as_ref(),
+        "run",
+        "--binaries-metadata",
+        p.binaries_metadata_path()
+            .as_os_str()
+            .to_string_lossy()
+            .as_ref(),
+    ]);
+
+    let mut output = OutputWriter::new_test();
+    let err = args.exec(&mut output).unwrap_err();
+    assert_eq!("test run failed\n", err.to_string());
+
+    check_run_output(output.stderr().unwrap(), false);
+}
+
+#[test]
+fn test_relocated_run() {
+    let _ = &*ENABLE_EXPERIMENTAL;
+
+    let p = TempProject::new().unwrap();
+    save_cargo_metadata(&p);
+    build_tests(&p);
+
+    let p2 = TempProject::new().unwrap();
+    // copy metadata files
+    std::fs::copy(p.binaries_metadata_path(), p2.binaries_metadata_path()).unwrap();
+    std::fs::copy(p.cargo_metadata_path(), p2.cargo_metadata_path()).unwrap();
+
+    // copy test binaries
+    let raw_binary_list = std::fs::read_to_string(p.binaries_metadata_path()).unwrap();
+    let binary_list: BinaryListSummary = serde_json::from_str(&raw_binary_list).unwrap();
+    let tests_dir = p2.workspace_root().join("build-artifacts");
+    std::fs::create_dir(&tests_dir).unwrap();
+    for bin in binary_list.rust_binaries.values() {
+        std::fs::copy(
+            &bin.binary_path,
+            tests_dir.join(bin.binary_path.file_name().unwrap()),
+        )
+        .unwrap();
+    }
+
+    // Run relocated tests
+    let args = CargoNextestApp::parse_from([
+        "cargo",
+        "nextest",
+        "--manifest-path",
+        p2.manifest_path().as_os_str().to_string_lossy().as_ref(),
+        "run",
+        "--binaries-metadata",
+        p2.binaries_metadata_path()
+            .as_os_str()
+            .to_string_lossy()
+            .as_ref(),
+        "--cargo-metadata",
+        p2.cargo_metadata_path()
+            .as_os_str()
+            .to_string_lossy()
+            .as_ref(),
+        "--workspace-remap",
+        p2.workspace_root().as_os_str().to_string_lossy().as_ref(),
+        "--binaries-dir-remap",
+        tests_dir.as_os_str().to_string_lossy().as_ref(),
+    ]);
+
+    let mut output = OutputWriter::new_test();
+    let err = args.exec(&mut output).unwrap_err();
+    assert_eq!("test run failed\n", err.to_string());
+
+    check_run_output(output.stderr().unwrap(), true);
+}

--- a/cargo-nextest/src/tests_integration/temp_project.rs
+++ b/cargo-nextest/src/tests_integration/temp_project.rs
@@ -1,0 +1,60 @@
+use std::{
+    fs, io,
+    path::{Path, PathBuf},
+};
+use tempdir::TempDir;
+
+/// A temporary copy of the test project
+///
+/// This avoid concurrent accesses to the `target` folder.
+pub struct TempProject {
+    workspace_dir: TempDir,
+}
+
+fn copy_dir_all(src: &Path, dst: &Path, root: bool) -> io::Result<()> {
+    fs::create_dir_all(&dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        if ty.is_dir() {
+            if root && entry.path().file_name() == Some(std::ffi::OsStr::new("target")) {
+                continue;
+            }
+            copy_dir_all(&entry.path(), &dst.join(entry.file_name()), false)?;
+        } else {
+            fs::copy(entry.path(), dst.join(entry.file_name()))?;
+        }
+    }
+    Ok(())
+}
+
+impl TempProject {
+    pub fn new() -> std::io::Result<Self> {
+        let dir = TempDir::new("nextest-fixture")?;
+
+        let src_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("fixtures/nextest-tests");
+
+        copy_dir_all(&src_dir, dir.path(), true)?;
+
+        Ok(Self { workspace_dir: dir })
+    }
+
+    pub fn workspace_root(&self) -> &Path {
+        self.workspace_dir.path()
+    }
+
+    pub fn binaries_metadata_path(&self) -> PathBuf {
+        self.workspace_root().join("binaries_metadata.json")
+    }
+
+    pub fn cargo_metadata_path(&self) -> PathBuf {
+        self.workspace_root().join("cargo_metadata.json")
+    }
+
+    pub fn manifest_path(&self) -> PathBuf {
+        self.workspace_dir.path().join("Cargo.toml")
+    }
+}

--- a/nextest-metadata/src/exit_codes.rs
+++ b/nextest-metadata/src/exit_codes.rs
@@ -21,4 +21,7 @@ impl NextestExitCode {
 
     /// A user issue happened while setting up a nextest invocation.
     pub const SETUP_ERROR: i32 = 96;
+
+    /// An experimental feature was used without the environment variable to enable it.
+    pub const EXPERIMENTAL_FEATURE_NOT_ENABLED: i32 = 95;
 }

--- a/nextest-metadata/src/test_list.rs
+++ b/nextest-metadata/src/test_list.rs
@@ -117,14 +117,24 @@ impl TestListSummary {
     }
 }
 
-/// A serializable suite of tests within a Rust test binary.
-///
-/// Part of a [`TestListSummary`].
-#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+/// Binary platform (useful for cross-compilation)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
-pub struct RustTestSuiteSummary {
-    /// The name of this package in the workspace.
-    pub package_name: String,
+pub enum Platform {
+    /// Build for the host machine (the building machine)
+    Host,
+    /// Build for the target machine
+    Target,
+}
+
+/// A serializable Rust test binary.
+///
+/// Part of a [`RustTestSuiteSummary`] and [`RustBinaryListSummary`].
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct RustTestBinarySummary {
+    /// A unique binary ID.
+    pub binary_id: String,
 
     /// The name of the test binary within the package.
     pub binary_name: String,
@@ -136,6 +146,32 @@ pub struct RustTestSuiteSummary {
 
     /// The path to the test binary executable.
     pub binary_path: Utf8PathBuf,
+
+    /// Platform for which this binary was built.
+    /// (Proc-macro tests are built for the host.)
+    pub platform: Platform,
+}
+
+/// A serializable suite of test binaries.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct BinaryListSummary {
+    /// The list of Rust test binaries (indexed by binary-id).
+    pub rust_binaries: BTreeMap<String, RustTestBinarySummary>,
+}
+
+/// A serializable suite of tests within a Rust test binary.
+///
+/// Part of a [`TestListSummary`].
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct RustTestSuiteSummary {
+    /// The name of this package in the workspace.
+    pub package_name: String,
+
+    /// The binary within the package.
+    #[serde(flatten)]
+    pub binary: RustTestBinarySummary,
 
     /// The working directory that tests within this package are run in.
     pub cwd: Utf8PathBuf,

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -10,7 +10,7 @@ use nextest_metadata::{FilterMatch, MismatchReason};
 use nextest_runner::{
     reporter::TestEvent,
     runner::{ExecutionResult, ExecutionStatuses, RunStats, TestRunner},
-    test_list::RustTestArtifact,
+    test_list::{BinaryList, RustTestArtifact},
 };
 use once_cell::sync::Lazy;
 use std::{
@@ -152,8 +152,9 @@ fn init_fixture_targets() -> BTreeMap<String, RustTestArtifact<'static>> {
     .stdout_capture();
 
     let output = expr.run().expect("cargo test --no-run failed");
+    let binary_list = BinaryList::from_messages(Cursor::new(output.stdout), graph).unwrap();
     let test_artifacts =
-        RustTestArtifact::from_messages(graph, Cursor::new(output.stdout)).unwrap();
+        RustTestArtifact::from_binary_list(graph, binary_list, None, None).unwrap();
 
     test_artifacts
         .into_iter()

--- a/site/src/book/reusing-build.md
+++ b/site/src/book/reusing-build.md
@@ -1,5 +1,7 @@
 # Reusing build
 
+**This is an experimental feature: set the environment variable `NEXTEST_EXPERIMENTAL_REUSE_BUILD=1` to use it.**
+
 In some cases, it can be useful to split tests building and tests running in two steps. This includes:
 
 - Cross compilation: the build machine is not the same as the target machine

--- a/site/src/book/reusing-build.md
+++ b/site/src/book/reusing-build.md
@@ -1,0 +1,34 @@
+# Reusing build
+
+In some cases, it can be useful to split tests building and tests running in two steps. This includes:
+
+- Cross compilation: the build machine is not the same as the target machine
+- Partitioned execution: build once and partition the execution
+- Saving execution time on a machine: do not build on a GPU machine, ...
+
+Requirement:
+
+- the project source must be checkout on the running machine: this might be needed for tests assets and we do apply the right working directory relative to the workspace root when executing the tests.
+- cargo does not need to be install on the running machine (in which case replace `cargo nextest` by `cargo-nextest nextest` in the following commands)
+
+## Simple build/run split
+
+1. Build the tests and save the binaries metadata: `cargo nextest list --no-query --message-format json > target/binaries-metadata.json`
+2. List the tests: `cargo nextest list --binaries-metadata target/binaries-metadata.json`
+3. Run the tests: `cargo nextest run --binaries-metadata target/binaries-metadata.json`
+
+## Cross-compilation
+
+Some tests still needs to be run on the host machine, this include proc-macro tests.
+
+1. On the build machine
+    1. Save the project cargo metadata: `cargo metadata --format-version=1 --all-features --no-deps > target/cargo-metadata.json`
+    2. Build the tests and save the binaries metadata: `cargo nextest list --no-query --target <TARGET> --message-format json > target/binaries-metadata.json`
+    3. List host-only tests: `cargo nextest list --platform-filter host --binaries-metadata target/binaries-metadata.json --cargo-metadata target/cargo-metadata.json`
+    3. Run host-only tests: `cargo nextest run --platform-filter host --binaries-metadata target/binaries-metadata.json --cargo-metadata target/cargo-metadata.json`
+    4. Archive artifacts: both json files and the tests binaries (listing `cat target/binaries-metadata.json | jq '."rust-binaries" | .[] . "binary-path"`)
+2. On the target machine
+    1. Clone the project repo
+    2. Extract artifacts
+    3. List target-only tests: `cargo nextest list --platform-filter target --binaries-metadata <PATH>/binaries-metadata.json --cargo-metadata <PATH>/cargo-metadata.json --workspace-remap <REPO-PATH> --binaries-directory-remap <TESTS-FOLDER-PATH>`
+    4. Run target-only tests: `cargo nextest run --platform-filter target --binaries-metadata <PATH>/binaries-metadata.json --cargo-metadata <PATH>/cargo-metadata.json --workspace-remap <REPO-PATH> --binaries-directory-remap <TESTS-FOLDER-PATH>`


### PR DESCRIPTION
Implements https://github.com/nextest-rs/nextest/issues/44

This is still work in progress, but I just wanted to be sure I was on the right tracks from your point of view.

I have the basic feature working:
```sh
# builds and list binaries
> cargo nextest list-bins --message-format json > binaries.json
# runs without building
> cargo nextest run --test-list binaries.json
```

Still to do:
- [x] add path remapping
- [x] add tests

At the moment, I'm still creating the graph when running, I'm wondering if I should save it (or at least the needed part). This could allow me to use the runner without `cargo`  installed (which could be great for my use case, but not indispensable for the moment).