### PR TITLE
Add artifact kind to binary_id if it's not 'lib'

### DIFF
--- a/fixtures/nextest-tests/Cargo.toml
+++ b/fixtures/nextest-tests/Cargo.toml
@@ -13,6 +13,10 @@ license-file = "foo.md"
 repository = "https://example.com/fake/repository"
 edition = "2018"
 
+[[bin]]
+name = "nextest-tests"
+path = "src/main.rs"
+
 # Make this crate its own workspace.
 [workspace]
 

--- a/fixtures/nextest-tests/Cargo.toml
+++ b/fixtures/nextest-tests/Cargo.toml
@@ -13,9 +13,13 @@ license-file = "foo.md"
 repository = "https://example.com/fake/repository"
 edition = "2018"
 
-[[bin]]
+[[example]]
 name = "nextest-tests"
-path = "src/main.rs"
+test = true
+
+[[example]]
+name = "other"
+test = true
 
 # Make this crate its own workspace.
 [workspace]

--- a/fixtures/nextest-tests/examples/nextest-tests.rs
+++ b/fixtures/nextest-tests/examples/nextest-tests.rs
@@ -1,0 +1,11 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+fn main() {}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn example_success() {
+    }
+}

--- a/fixtures/nextest-tests/examples/other.rs
+++ b/fixtures/nextest-tests/examples/other.rs
@@ -1,0 +1,11 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+fn main() {}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn other_example_success() {
+    }
+}

--- a/fixtures/nextest-tests/src/bin/nextest-tests.rs
+++ b/fixtures/nextest-tests/src/bin/nextest-tests.rs
@@ -1,0 +1,11 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+fn main() {}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn bin_success() {
+    }
+}

--- a/fixtures/nextest-tests/src/bin/other.rs
+++ b/fixtures/nextest-tests/src/bin/other.rs
@@ -1,0 +1,11 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+fn main() {}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn other_bin_success() {
+    }
+}

--- a/fixtures/nextest-tests/src/main.rs
+++ b/fixtures/nextest-tests/src/main.rs
@@ -1,0 +1,8 @@
+fn main() {}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn bin_test_success() {
+    }
+}

--- a/fixtures/nextest-tests/src/main.rs
+++ b/fixtures/nextest-tests/src/main.rs
@@ -1,8 +1,0 @@
-fn main() {}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn bin_test_success() {
-    }
-}

--- a/fixtures/nextest-tests/tests/other.rs
+++ b/fixtures/nextest-tests/tests/other.rs
@@ -1,0 +1,5 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#[test]
+fn other_test_success() {}

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -206,6 +206,14 @@ pub enum FromMessagesError {
 
     /// An error occurred while querying the package graph.
     PackageGraph(guppy::Error),
+
+    /// A target in the package graph was missing `kind` information.
+    MissingTargetKind {
+        /// The name of the malformed package.
+        package_name: String,
+        /// The name of the malformed target within the package.
+        binary_name: String,
+    },
 }
 
 impl fmt::Display for FromMessagesError {
@@ -217,6 +225,16 @@ impl fmt::Display for FromMessagesError {
             FromMessagesError::PackageGraph(_) => {
                 write!(f, "error querying package graph")
             }
+            FromMessagesError::MissingTargetKind {
+                package_name,
+                binary_name,
+            } => {
+                write!(
+                    f,
+                    "missing kind for target {} in package {}",
+                    binary_name, package_name
+                )
+            }
         }
     }
 }
@@ -226,6 +244,7 @@ impl error::Error for FromMessagesError {
         match self {
             FromMessagesError::ReadMessages(error) => Some(error),
             FromMessagesError::PackageGraph(error) => Some(error),
+            FromMessagesError::MissingTargetKind { .. } => None,
         }
     }
 }

--- a/nextest-runner/src/test_list.rs
+++ b/nextest-runner/src/test_list.rs
@@ -68,7 +68,6 @@ impl<'g> RustTestArtifact<'g> {
                         let package = graph
                             .metadata(&package_id)
                             .map_err(FromMessagesError::PackageGraph)?;
-
                         // Tests are run in the directory containing Cargo.toml
                         let cwd = package
                             .manifest_path()
@@ -86,6 +85,11 @@ impl<'g> RustTestArtifact<'g> {
                         if artifact.target.name != package.name() {
                             binary_id.push_str("::");
                             binary_id.push_str(&artifact.target.name);
+                        } else if !artifact.target.kind.contains(&"lib".to_owned()) {
+                            if let Some(kind) = artifact.target.kind.get(0) {
+                                binary_id.push_str("::");
+                                binary_id.push_str(kind);
+                            }
                         }
 
                         binaries.push(RustTestArtifact {

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -66,6 +66,7 @@ impl FixtureStatus {
 pub(crate) static EXPECTED_TESTS: Lazy<BTreeMap<&'static str, Vec<TestFixture>>> = Lazy::new(
     || {
         btreemap! {
+            // Integration tests
             "nextest-tests::basic" => vec![
                 TestFixture { name: "test_cargo_env_vars", status: FixtureStatus::Pass },
                 TestFixture { name: "test_cwd", status: FixtureStatus::Pass },
@@ -79,11 +80,26 @@ pub(crate) static EXPECTED_TESTS: Lazy<BTreeMap<&'static str, Vec<TestFixture>>>
                 TestFixture { name: "test_success", status: FixtureStatus::Pass },
                 TestFixture { name: "test_success_should_panic", status: FixtureStatus::Pass },
             ],
+            "nextest-tests::other" => vec![
+                TestFixture { name: "other_test_success", status: FixtureStatus::Pass },
+            ],
+            // Unit tests
             "nextest-tests" => vec![
                 TestFixture { name: "tests::unit_test_success", status: FixtureStatus::Pass },
             ],
-            "nextest-tests::bin" => vec![
-                TestFixture { name: "tests::bin_test_success", status: FixtureStatus::Pass },
+            // Binary tests
+            "nextest-tests::bin/nextest-tests" => vec![
+                TestFixture { name: "tests::bin_success", status: FixtureStatus::Pass },
+            ],
+            "nextest-tests::bin/other" => vec![
+                TestFixture { name: "tests::other_bin_success", status: FixtureStatus::Pass },
+            ],
+            // Example tests
+            "nextest-tests::example/nextest-tests" => vec![
+                TestFixture { name: "tests::example_success", status: FixtureStatus::Pass },
+            ],
+            "nextest-tests::example/other" => vec![
+                TestFixture { name: "tests::other_example_success", status: FixtureStatus::Pass },
             ],
         }
     },

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -82,6 +82,9 @@ pub(crate) static EXPECTED_TESTS: Lazy<BTreeMap<&'static str, Vec<TestFixture>>>
             "nextest-tests" => vec![
                 TestFixture { name: "tests::unit_test_success", status: FixtureStatus::Pass },
             ],
+            "nextest-tests::bin" => vec![
+                TestFixture { name: "tests::bin_test_success", status: FixtureStatus::Pass },
+            ],
         }
     },
 );


### PR DESCRIPTION
In a crate with multiple targets that have the same name as the package, if both have tests, tests from one of the targets will be missing from the JSON output. I ran into this is in a lib + bin package. You can see a minimal example [here](https://github.com/pmsanford/nextest-json-suite-overwrite).

This is because of the way `RustTestArtifact.binary_id` is constructed. Currently, if the target name is equal to the package name, the package name is taken as the `binary_id`. There are cases (such as lib + bin) where two targets will have the same name as the package name. This results in `binary_id` being non-unique in those cases, and the doc comment for `binary_id` says it should be unique. Currently this only seems to affect the JSON output of the list command - the human readable output of list is still correct and all the tests are still run.

The approach this PR takes is, in cases where the target name is equal to the package name, check the target type. If it's anything other than lib, append the type to the name to build the binary ID. I also considered fixing this at the point where the summaries are built for serialization, but it seems like `binary_id` is truly intended to uniquely identify a test suite, so I thought this was a more appropriate place.