### PR TITLE
Add proc-macro lib in tests fixtures

### DIFF
--- a/fixtures/nextest-tests/Cargo.toml
+++ b/fixtures/nextest-tests/Cargo.toml
@@ -23,5 +23,8 @@ test = true
 
 # Make this crate its own workspace.
 [workspace]
+members = [
+    "derive"
+]
 
 [dependencies]

--- a/fixtures/nextest-tests/derive/Cargo.toml
+++ b/fixtures/nextest-tests/derive/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "nextest-derive"
+version = "0.1.0"
+
+[lib]
+proc-macro = true
+
+[dependencies]

--- a/fixtures/nextest-tests/derive/src/lib.rs
+++ b/fixtures/nextest-tests/derive/src/lib.rs
@@ -1,0 +1,10 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+
+#[proc_macro]
+pub fn make_answer(_item: TokenStream) -> TokenStream {
+    "fn answer( ) -> u32 { 42 }".parse().unwrap()
+}
+
+#[test]
+fn it_works() {}

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -101,6 +101,9 @@ pub(crate) static EXPECTED_TESTS: Lazy<BTreeMap<&'static str, Vec<TestFixture>>>
             "nextest-tests::example/other" => vec![
                 TestFixture { name: "tests::other_example_success", status: FixtureStatus::Pass },
             ],
+            "nextest-derive::proc-macro/nextest-derive" => vec![
+                TestFixture { name: "it_works", status: FixtureStatus::Pass },
+            ],
         }
     },
 );
@@ -141,6 +144,7 @@ fn init_fixture_targets() -> BTreeMap<String, RustTestArtifact<'static>> {
         cmd_name,
         "test",
         "--no-run",
+        "--workspace",
         "--message-format",
         "json-render-diagnostics"
     )


### PR DESCRIPTION
Adding a proc-macro lib in the workspace used as tests input makes `nextest-runner::integration target_runner::run::test_run_with_target_runner` fail on MacOS.

I'm not yet sure why.