### PR TITLE
[cargo-nextest] remove allow attribute

### DIFF
--- a/cargo-nextest/src/cargo_cli.rs
+++ b/cargo-nextest/src/cargo_cli.rs
@@ -261,7 +261,6 @@ impl<'a> CargoCli<'a> {
         self
     }
 
-    #[allow(dead_code)]
     pub(crate) fn all_args(&self) -> Vec<&str> {
         let mut all_args = vec![self.cargo_path.as_str(), self.command];
         all_args.extend_from_slice(&self.args);


### PR DESCRIPTION
`CargoCli::all_args()` is used in `TestBuildFilter::compute()`
https://github.com/nextest-rs/nextest/blob/4d8c9200bc3415b38debb2084ce6c4a45bf1d18a/cargo-nextest/src/dispatch.rs#L210