### PR TITLE
[nextest-runner] bring our own passthrough test binary

### DIFF
--- a/fixtures/passthrough
+++ b/fixtures/passthrough
@@ -1,9 +1,0 @@
-#!/bin/sh
-if [ "$1" != "--ensure-this-arg-is-sent" ] ; then
-    exit 1
-fi
-
-bin="$2"
-shift 2
-
-$bin "$@"

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -49,3 +49,7 @@ pretty_assertions = "1.1.0"
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
 tempfile = "3.3.0"
+
+[[bin]]
+name = "passthrough"
+path = "test-helpers/passthrough.rs"

--- a/nextest-runner/test-helpers/passthrough.rs
+++ b/nextest-runner/test-helpers/passthrough.rs
@@ -1,0 +1,36 @@
+//! A small passthrough script used for testing. We can't use bash here because of System Integrity
+//! Protection on macOS: https://github.com/nextest-rs/nextest/pull/84#issuecomment-1057287763
+
+use std::{
+    env,
+    process::{exit, Command},
+};
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    eprintln!("[passthrough] args: {:?}", args);
+
+    if args[1] != "--ensure-this-arg-is-sent" {
+        eprintln!("[passthrough] --ensure-this-arg-is-sent not passed as the first element");
+        exit(1);
+    }
+
+    match Command::new(&args[2]).args(&args[3..]).status() {
+        Ok(status) => match status.code() {
+            Some(code) => {
+                exit(code);
+            }
+            None => {
+                eprintln!("[passthrough] process did not exit with a code, exiting with 101");
+                exit(101);
+            }
+        },
+        Err(err) => {
+            eprintln!(
+                "[passthrough] failed to spawn subprocess '{}': {}, exiting with 102",
+                args[2], err
+            );
+            exit(102);
+        }
+    }
+}

--- a/nextest-runner/tests/integration/target_runner.rs
+++ b/nextest-runner/tests/integration/target_runner.rs
@@ -164,7 +164,7 @@ fn fallsback_to_cargo_config() {
 mod run {
     use super::*;
     use crate::fixtures::*;
-    use camino::{Utf8Path, Utf8PathBuf};
+    use camino::Utf8Path;
     use color_eyre::Result;
     use nextest_runner::{
         config::NextestConfig,
@@ -176,13 +176,7 @@ mod run {
     use target_spec::Platform;
 
     fn passthrough_path() -> &'static Utf8Path {
-        static PP: once_cell::sync::OnceCell<Utf8PathBuf> = once_cell::sync::OnceCell::new();
-        PP.get_or_init(|| {
-            Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .parent()
-                .unwrap()
-                .join("fixtures/passthrough")
-        })
+        Utf8Path::new(env!("CARGO_BIN_EXE_passthrough"))
     }
 
     fn current_runner_env_var() -> String {


### PR DESCRIPTION
Using a shell script causes issues on macOS because of SIP. See
#84 for more.