### PR TITLE
[cargo-nextest] change binaries-dir-remap to target-dir-remap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,8 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        # 1.54 is the MSRV
-        rust-version: [ 1.54, stable ]
+        # 1.56 is the MSRV
+        rust-version: [ 1.56, stable ]
       fail-fast: false
     env:
       RUSTFLAGS: -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,7 @@ dependencies = [
  "duct",
  "enable-ansi-support",
  "env_logger",
+ "fs_extra",
  "guppy",
  "log",
  "nextest-metadata",
@@ -407,6 +408,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
 name = "getrandom"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "guppy"
-version = "0.13.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6570bfb78ea4e0c039bd212e353a3de840f5ef0fa5439356b5451f6e0df7678d"
+checksum = "cbbda4f76555041b3730035c987a24a9d41e8e0b2c7fe1d512c0cab82e753146"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -457,6 +457,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "static_assertions",
  "target-spec",
 ]
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repository contains the source code for:
 
 ## Minimum supported Rust version
 
-The minimum supported Rust version is **Rust 1.54.**
+The minimum supported Rust version is **Rust 1.56.**
 
 While a crate is pre-release status (0.x.x) it may have its MSRV bumped in a patch release. Once a
 crate has reached 1.x, any MSRV bump will be accompanied with a new minor version.

--- a/cargo-nextest/Cargo.toml
+++ b/cargo-nextest/Cargo.toml
@@ -31,6 +31,7 @@ supports-color = "1.3.0"
 serde_json = "1.0.79"
 
 [dev-dependencies]
+fs_extra = "1.2.0"
 tempfile = "3.3.0"
 regex = "1.5.5"
 once_cell = "1.10.0"

--- a/cargo-nextest/Cargo.toml
+++ b/cargo-nextest/Cargo.toml
@@ -8,8 +8,8 @@ repository = "https://github.com/nextest-rs/nextest"
 documentation = "https://nexte.st"
 keywords = ["nextest", "test-runner", "flaky-tests", "junit"]
 categories = ["development-tools::cargo-plugins", "development-tools::testing"]
-edition = "2018"
-rust-version = "1.54"
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 camino = "1.0.7"

--- a/cargo-nextest/Cargo.toml
+++ b/cargo-nextest/Cargo.toml
@@ -21,7 +21,7 @@ duct = "0.13.5"
 enable-ansi-support = "0.1.2"
 # we don't use the default formatter so we don't need default features
 env_logger = { version = "0.9.0", default-features = false }
-guppy = "0.13.0"
+guppy = "0.14.1"
 log = "0.4.14"
 nextest-runner = { version = "0.4.0", path = "../nextest-runner" }
 nextest-metadata = { version = "0.2.1", path = "../nextest-metadata" }

--- a/cargo-nextest/src/cargo_cli.rs
+++ b/cargo-nextest/src/cargo_cli.rs
@@ -93,7 +93,7 @@ pub(crate) struct CargoOptions {
 
     /// Directory for all generated artifacts
     #[clap(long, value_name = "DIR", conflicts_with = "binaries-metadata")]
-    target_dir: Option<String>,
+    pub(crate) target_dir: Option<Utf8PathBuf>,
 
     /// Ignore `rust-version` specification in packages
     #[clap(long, conflicts_with = "binaries-metadata")]
@@ -227,7 +227,7 @@ impl<'a> CargoCli<'a> {
             self.args.extend(["--target", target]);
         }
         if let Some(target_dir) = &options.target_dir {
-            self.args.extend(["--target-dir", target_dir]);
+            self.args.extend(["--target-dir", target_dir.as_str()]);
         }
         if options.ignore_rust_version {
             self.args.push("--ignore-rust-version");

--- a/cargo-nextest/src/cargo_cli.rs
+++ b/cargo-nextest/src/cargo_cli.rs
@@ -6,7 +6,7 @@
 use crate::output::OutputContext;
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::{AppSettings, Args};
-use std::{convert::TryInto, path::PathBuf};
+use std::path::PathBuf;
 
 /// Options passed down to cargo.
 #[derive(Debug, Args)]

--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -314,7 +314,7 @@ impl TestBuildFilter {
         runner: &TargetRunner,
         reuse_build: &ReuseBuildOpts,
     ) -> Result<TestList<'g>> {
-        let path_mapper = reuse_build.make_path_mapper(graph);
+        let path_mapper = reuse_build.make_path_mapper(graph, &binary_list.rust_target_directory);
         let test_artifacts = RustTestArtifact::from_binary_list(
             graph,
             binary_list,
@@ -353,7 +353,11 @@ impl TestBuildFilter {
             )));
         }
 
-        let test_binaries = BinaryList::from_messages(Cursor::new(output.stdout), graph)?;
+        let test_binaries = BinaryList::from_messages(
+            Cursor::new(output.stdout),
+            graph,
+            self.cargo_options.target_dir.as_deref(),
+        )?;
         Ok(test_binaries)
     }
 }

--- a/cargo-nextest/src/reuse_build.rs
+++ b/cargo-nextest/src/reuse_build.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::{output::OutputContext, ExpectedError};
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 use clap::Args;
 use color_eyre::eyre::{Report, Result};
 use guppy::graph::PackageGraph;
@@ -15,14 +15,14 @@ pub(crate) struct ReuseBuildOpts {
     #[clap(long, value_name = "PATH", env = "NEXTEST_BINARIES_METADATA")]
     pub(crate) binaries_metadata: Option<Utf8PathBuf>,
 
-    /// Remapping for the test binaries directory
+    /// Remapping for the target directory
     #[clap(
         long,
         requires("binaries-metadata"),
         value_name = "PATH",
-        env = "NEXTEST_BINARIES_DIR_REMAP"
+        env = "NEXTEST_TARGET_DIR_REMAP"
     )]
-    pub(crate) binaries_dir_remap: Option<Utf8PathBuf>,
+    pub(crate) target_dir_remap: Option<Utf8PathBuf>,
 
     /// Path to cargo metadata JSON
     #[clap(
@@ -50,7 +50,7 @@ impl ReuseBuildOpts {
     // before calling this method)
     pub(crate) fn check_experimental(&self, _output: OutputContext) -> Result<()> {
         let used = self.binaries_metadata.is_some()
-            || self.binaries_dir_remap.is_some()
+            || self.target_dir_remap.is_some()
             || self.cargo_metadata.is_some()
             || self.workspace_remap.is_some();
 
@@ -66,11 +66,16 @@ impl ReuseBuildOpts {
         }
     }
 
-    pub(crate) fn make_path_mapper(&self, graph: &PackageGraph) -> Option<PathMapper> {
+    pub(crate) fn make_path_mapper(
+        &self,
+        graph: &PackageGraph,
+        orig_target_dir: &Utf8Path,
+    ) -> Option<PathMapper> {
         PathMapper::new(
             graph,
             self.workspace_remap.clone(),
-            self.binaries_dir_remap.clone(),
+            orig_target_dir,
+            self.target_dir_remap.clone(),
         )
     }
 }

--- a/cargo-nextest/src/tests_integration/fixtures.rs
+++ b/cargo-nextest/src/tests_integration/fixtures.rs
@@ -124,13 +124,15 @@ pub fn build_tests(p: &TempProject) {
         "cargo",
         "nextest",
         "--manifest-path",
-        p.manifest_path().as_os_str().to_string_lossy().as_ref(),
+        p.manifest_path().as_str(),
         "list",
         "--workspace",
         "--message-format",
         "json",
         "--list-type",
         "binaries-only",
+        "--target-dir",
+        p.target_dir().as_str(),
     ]);
 
     let mut output = OutputWriter::new_test();

--- a/cargo-nextest/src/tests_integration/temp_project.rs
+++ b/cargo-nextest/src/tests_integration/temp_project.rs
@@ -1,65 +1,87 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::{
-    fs, io,
-    path::{Path, PathBuf},
-};
+use camino::{Utf8Path, Utf8PathBuf};
+use fs_extra::dir::CopyOptions;
+use std::convert::TryInto;
 use tempfile::TempDir;
 
 /// A temporary copy of the test project
 ///
 /// This avoid concurrent accesses to the `target` folder.
 pub struct TempProject {
-    workspace_dir: TempDir,
-}
-
-fn copy_dir_all(src: &Path, dst: &Path, root: bool) -> io::Result<()> {
-    fs::create_dir_all(&dst)?;
-    for entry in fs::read_dir(src)? {
-        let entry = entry?;
-        let ty = entry.file_type()?;
-        if ty.is_dir() {
-            if root && entry.path().file_name() == Some(std::ffi::OsStr::new("target")) {
-                continue;
-            }
-            copy_dir_all(&entry.path(), &dst.join(entry.file_name()), false)?;
-        } else {
-            fs::copy(entry.path(), dst.join(entry.file_name()))?;
-        }
-    }
-    Ok(())
+    #[allow(dead_code)]
+    temp_dir: TempDir,
+    workspace_root: Utf8PathBuf,
+    target_dir: Utf8PathBuf,
 }
 
 impl TempProject {
-    pub fn new() -> std::io::Result<Self> {
-        let dir = tempfile::Builder::new()
+    pub fn new() -> color_eyre::Result<Self> {
+        Self::new_impl(None)
+    }
+
+    pub fn new_custom_target_dir(target_dir: &Utf8Path) -> color_eyre::Result<Self> {
+        Self::new_impl(Some(target_dir.to_path_buf()))
+    }
+
+    fn new_impl(custom_target_dir: Option<Utf8PathBuf>) -> color_eyre::Result<Self> {
+        let temp_dir = tempfile::Builder::new()
             .prefix("nextest-fixture")
             .tempdir()?;
+        let utf8_path: Utf8PathBuf = temp_dir
+            .path()
+            .to_path_buf()
+            .try_into()
+            .expect("tempdir should be valid UTF-8");
 
-        let src_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        let src_dir = Utf8Path::new(env!("CARGO_MANIFEST_DIR"))
             .parent()
             .unwrap()
             .join("fixtures/nextest-tests");
 
-        copy_dir_all(&src_dir, dir.path(), true)?;
+        fs_extra::copy_items(&[&src_dir], &utf8_path, &CopyOptions::new())?;
 
-        Ok(Self { workspace_dir: dir })
+        let workspace_root = utf8_path.join("nextest-tests");
+
+        let target_dir = custom_target_dir.unwrap_or_else(|| workspace_root.join("target"));
+        match std::fs::remove_dir_all(&target_dir) {
+            Ok(()) => {}
+            Err(err) => {
+                if err.kind() != std::io::ErrorKind::NotFound {
+                    color_eyre::eyre::bail!(err);
+                }
+            }
+        }
+
+        Ok(Self {
+            temp_dir,
+            workspace_root,
+            target_dir,
+        })
     }
 
-    pub fn workspace_root(&self) -> &Path {
-        self.workspace_dir.path()
+    pub fn workspace_root(&self) -> &Utf8Path {
+        &self.workspace_root
     }
 
-    pub fn binaries_metadata_path(&self) -> PathBuf {
-        self.workspace_root().join("binaries_metadata.json")
+    pub fn target_dir(&self) -> &Utf8Path {
+        &self.target_dir
     }
 
-    pub fn cargo_metadata_path(&self) -> PathBuf {
-        self.workspace_root().join("cargo_metadata.json")
+    pub fn set_target_dir(&mut self, target_dir: impl Into<Utf8PathBuf>) {
+        self.target_dir = target_dir.into();
     }
 
-    pub fn manifest_path(&self) -> PathBuf {
-        self.workspace_dir.path().join("Cargo.toml")
+    pub fn binaries_metadata_path(&self) -> Utf8PathBuf {
+        self.target_dir.join("binaries_metadata.json")
+    }
+
+    pub fn cargo_metadata_path(&self) -> Utf8PathBuf {
+        self.target_dir.join("cargo_metadata.json")
+    }
+
+    pub fn manifest_path(&self) -> Utf8PathBuf {
+        self.workspace_root.join("Cargo.toml")
     }
 }

--- a/nextest-metadata/Cargo.toml
+++ b/nextest-metadata/Cargo.toml
@@ -3,13 +3,13 @@ name = "nextest-metadata"
 version = "0.2.1"
 description = "Structured access to nextest machine-readable output."
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 repository = "https://github.com/nextest-rs/nextest"
 documentation = "https://docs.rs/nextest-metadata"
 keywords = ["nextest", "test-runner"]
 categories = ["development-tools::testing"]
-rust-version = "1.54"
+rust-version = "1.56"
 
 [dependencies]
 camino = { version = "1.0.7", features = ["serde1"] }

--- a/nextest-metadata/README.md
+++ b/nextest-metadata/README.md
@@ -32,7 +32,7 @@ println!("{:?}", test_list);
 
 ## Minimum supported Rust version (MSRV)
 
-The minimum supported Rust version is **Rust 1.54.**
+The minimum supported Rust version is **Rust 1.56.**
 
 While this crate is a pre-release (0.x.x) it may have its MSRV bumped in a patch release.
 Once a crate has reached 1.x, any MSRV bump will be accompanied with a new minor version.

--- a/nextest-metadata/src/lib.rs
+++ b/nextest-metadata/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! # Minimum supported Rust version (MSRV)
 //!
-//! The minimum supported Rust version is **Rust 1.54.**
+//! The minimum supported Rust version is **Rust 1.56.**
 //!
 //! While this crate is a pre-release (0.x.x) it may have its MSRV bumped in a patch release.
 //! Once a crate has reached 1.x, any MSRV bump will be accompanied with a new minor version.

--- a/nextest-metadata/src/test_list.rs
+++ b/nextest-metadata/src/test_list.rs
@@ -182,6 +182,9 @@ pub struct RustTestBinarySummary {
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct BinaryListSummary {
+    /// The target directory for Rust artifacts.
+    pub rust_target_directory: Utf8PathBuf,
+
     /// The list of Rust test binaries (indexed by binary-id).
     pub rust_binaries: BTreeMap<String, RustTestBinarySummary>,
 }

--- a/nextest-runner/CHANGELOG.md
+++ b/nextest-runner/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- MSRV bumped to Rust 1.56.
+
 ## [0.4.0] - 2022-03-07
 
 Thanks to [Guiguiprim](https://github.com/Guiguiprim) for their contributions to this release!

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -19,7 +19,7 @@ crossbeam-channel = "0.5.3"
 ctrlc = { version = "3.2.1", features = ["termination"] }
 debug-ignore = "1.0.2"
 duct = "0.13.5"
-guppy = "0.13.0"
+guppy = "0.14.1"
 # Used to find the cargo root directory, which is needed in case the user has
 # added a config.toml there
 home = "0.5.3"

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -6,8 +6,8 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/nextest-rs/nextest"
 documentation = "https://docs.rs/nextest-runner"
-edition = "2018"
-rust-version = "1.54"
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 aho-corasick = "0.7.18"

--- a/nextest-runner/src/target_runner.rs
+++ b/nextest-runner/src/target_runner.rs
@@ -375,7 +375,6 @@ impl PlatformRunner {
 mod tests {
     use super::*;
     use color_eyre::eyre::{Context, Result};
-    use std::convert::TryFrom;
     use target_spec::TargetFeatures;
     use tempfile::TempDir;
 

--- a/nextest-runner/tests/integration/basic.rs
+++ b/nextest-runner/tests/integration/basic.rs
@@ -19,7 +19,7 @@ use std::io::Cursor;
 fn test_list_binaries() -> Result<()> {
     let graph = &*PACKAGE_GRAPH;
     let binary_list =
-        BinaryList::from_messages(Cursor::new(&*FIXTURE_RAW_CARGO_TEST_OUTPUT), graph)?;
+        BinaryList::from_messages(Cursor::new(&*FIXTURE_RAW_CARGO_TEST_OUTPUT), graph, None)?;
 
     for (id, name, platform_is_target) in &EXPECTED_BINARY_LIST {
         let bin = binary_list

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -178,7 +178,8 @@ pub(crate) static FIXTURE_TARGETS: Lazy<BTreeMap<String, RustTestArtifact<'stati
 fn init_fixture_targets() -> BTreeMap<String, RustTestArtifact<'static>> {
     let graph = &*PACKAGE_GRAPH;
     let binary_list =
-        BinaryList::from_messages(Cursor::new(&*FIXTURE_RAW_CARGO_TEST_OUTPUT), graph).unwrap();
+        BinaryList::from_messages(Cursor::new(&*FIXTURE_RAW_CARGO_TEST_OUTPUT), graph, None)
+            .unwrap();
     let test_artifacts =
         RustTestArtifact::from_binary_list(graph, binary_list, None, None).unwrap();
 

--- a/quick-junit/CHANGELOG.md
+++ b/quick-junit/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- MSRV bumped to Rust 1.56.
+
 ## [0.1.5] - 2022-02-14
 
 ### Changed

--- a/quick-junit/Cargo.toml
+++ b/quick-junit/Cargo.toml
@@ -8,8 +8,8 @@ repository = "https://github.com/nextest-rs/nextest"
 documentation = "https://docs.rs/quick-junit"
 keywords = ["junit", "xunit", "xml", "serializer", "flaky-tests"]
 categories = ["encoding", "development-tools"]
-edition = "2018"
-rust-version = "1.54"
+edition = "2021"
+rust-version = "1.56"
 
 [dependencies]
 chrono = "0.4.19"

--- a/quick-junit/README.md
+++ b/quick-junit/README.md
@@ -65,7 +65,7 @@ For a more comprehensive example, including reruns and flaky tests, see
 
 ## Minimum supported Rust version (MSRV)
 
-The minimum supported Rust version is **Rust 1.54.**
+The minimum supported Rust version is **Rust 1.56.**
 
 While this crate is a pre-release (0.x.x) it may have its MSRV bumped in a patch release.
 Once a crate has reached 1.x, any MSRV bump will be accompanied with a new minor version.

--- a/quick-junit/src/lib.rs
+++ b/quick-junit/src/lib.rs
@@ -61,7 +61,7 @@
 //!
 //! # Minimum supported Rust version (MSRV)
 //!
-//! The minimum supported Rust version is **Rust 1.54.**
+//! The minimum supported Rust version is **Rust 1.56.**
 //!
 //! While this crate is a pre-release (0.x.x) it may have its MSRV bumped in a patch release.
 //! Once a crate has reached 1.x, any MSRV bump will be accompanied with a new minor version.


### PR DESCRIPTION
This is required because `binaries-dir-remap` is insufficient to model
situations with shared libraries (https://github.com/nextest-rs/nextest/issues/82).

As part of this, we're going to change the reuse-build instructions to
recommend archiving the entire target directory. In the future, we may
be able to build a better archiving tool into nextest.