### PR TITLE
Add `/` escaping in regex, remove useless whitespace escaping in unicode string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,6 +699,8 @@ checksum = "ca2b420f638f07fe83056b55ea190bb815f609ec5a35e7017884a10f78839c9e"
 name = "nextest-filtering"
 version = "0.1.0"
 dependencies = [
+ "camino",
+ "clap",
  "guppy",
  "miette",
  "nom 7.1.1",

--- a/nextest-filtering/Cargo.toml
+++ b/nextest-filtering/Cargo.toml
@@ -24,3 +24,7 @@ nom-tracable = "0.8.0"
 nom_locate = "4.0.0"
 regex = "1.5.5"
 thiserror = "1.0.30"
+
+[dev-dependencies]
+clap = { version = "3.1.8", features = ["derive"] }
+camino = "1.0.7"

--- a/nextest-filtering/examples/parser.rs
+++ b/nextest-filtering/examples/parser.rs
@@ -1,0 +1,59 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Standalone expression parser
+//!
+//! Useful for manually testing the parsing result
+
+use camino::Utf8PathBuf;
+use clap::Parser;
+use guppy::graph::PackageGraph;
+
+#[derive(Debug, Parser)]
+struct Args {
+    /// Path to a cargo metadata json file
+    #[clap(short = 'g')]
+    cargo_metadata: Option<Utf8PathBuf>,
+
+    /// The expression to parse
+    expr: String,
+}
+
+const EMPTY_GRAPH: &str = r#"{
+        "packages": [],
+        "workspace_members": [],
+        "workspace_root": "",
+        "target_directory": "",
+        "version": 1
+    }"#;
+
+fn load_graph(path: Option<Utf8PathBuf>) -> PackageGraph {
+    let json = match path {
+        Some(path) => match std::fs::read_to_string(path) {
+            Ok(json) => json,
+            Err(err) => {
+                eprintln!("Failed to read cargo-metadata file: {}", err);
+                std::process::exit(1);
+            }
+        },
+        None => EMPTY_GRAPH.to_string(),
+    };
+
+    match PackageGraph::from_json(&json) {
+        Ok(graph) => graph,
+        Err(err) => {
+            eprintln!("Failed to parse cargo-metadata: {}", err);
+            std::process::exit(1);
+        }
+    }
+}
+
+fn main() {
+    let args = Args::parse();
+
+    let graph = load_graph(args.cargo_metadata);
+    match nextest_filtering::FilteringExpr::parse(&args.expr, &graph) {
+        Ok(expr) => println!("{:?}", expr),
+        Err(_) => std::process::exit(1),
+    }
+}

--- a/site/src/book/filtering-expression.md
+++ b/site/src/book/filtering-expression.md
@@ -72,9 +72,7 @@ The *contains* and *equality* name matchers can contain escape sequences, preced
 
 All other escape sequences are invalid.
 
-The *regular expression* matcher supports the same escape sequences that [the regex crate does](https://docs.rs/regex/latest/regex/#escape-sequences).
-
-TODO: add a way to escape `/` in regexes.
+The *regular expression* matcher supports the same escape sequences that [the regex crate does](https://docs.rs/regex/latest/regex/#escape-sequences), additionally `\/` is read as an escaped `/`.
 
 ### Operators
 


### PR DESCRIPTION
Fix for #144

- Adds the `/` for regex
- Removes the whitespace escaping from unicode string
- Adds a small example for quick manual filtering expression parsing test