### PR TITLE
[nextest-filtering] Add comma support, change matcher default, ...

### DIFF
--- a/nextest-filtering/src/errors.rs
+++ b/nextest-filtering/src/errors.rs
@@ -53,6 +53,10 @@ pub enum ParseSingleError {
     #[error("unexpected argument")]
     UnexpectedArgument(#[label("this set doesn't take an argument")] SourceSpan),
 
+    /// An unexpected comma was found.
+    #[error("unexpected comma")]
+    UnexpectedComma(#[label("this set doesn't take multiple arguments")] SourceSpan),
+
     /// An invalid string was found.
     #[error("invalid string")]
     InvalidString(#[label("invalid string")] SourceSpan),

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -69,13 +69,14 @@ fn parse_escaped_char(input: Span) -> IResult<char> {
             value('\\', char('\\')),
             value('/', char('/')),
             value(')', char(')')),
+            value(',', char(',')),
         )),
     )(input)
 }
 
 #[tracable_parser]
 fn parse_literal(input: Span) -> IResult<Span> {
-    let not_quote_slash = is_not(")\\");
+    let not_quote_slash = is_not(",)\\");
     verify(not_quote_slash, |s: &Span| !s.fragment().is_empty())(input)
 }
 

--- a/nextest-filtering/tests/match.rs
+++ b/nextest-filtering/tests/match.rs
@@ -23,7 +23,7 @@ fn mk_pid(c: char) -> PackageId {
 #[test]
 fn test_expr_package_contains() {
     let graph = load_graph();
-    let expr = FilteringExpr::parse("package(contains:_a)", &graph).unwrap();
+    let expr = FilteringExpr::parse("package(~_a)", &graph).unwrap();
     println!("{:?}", expr);
 
     assert!(expr.includes(&mk_pid('a'), "test_something"));

--- a/nextest-filtering/tests/match.rs
+++ b/nextest-filtering/tests/match.rs
@@ -23,7 +23,7 @@ fn mk_pid(c: char) -> PackageId {
 #[test]
 fn test_expr_package_contains() {
     let graph = load_graph();
-    let expr = FilteringExpr::parse("package(_a)", &graph).unwrap();
+    let expr = FilteringExpr::parse("package(contains:_a)", &graph).unwrap();
     println!("{:?}", expr);
 
     assert!(expr.includes(&mk_pid('a'), "test_something"));

--- a/site/src/book/filter-expressions.md
+++ b/site/src/book/filter-expressions.md
@@ -52,14 +52,14 @@ This section contains the full set of operators supported by the DSL.
 
 ### Name matchers
 
-- `contains:string`: match a package or test name containing `string`
+- `~string` or `contains:string`: match a package or test name containing `string`
 - `=string`: match a package or test name that's equal to `string`
 - `/regex/`: match a package or test name if any part of it matches the regular expression `regex`. To match the entire string against a regular expression, use `/^regex$/`. The implementation uses the regex crate.
 - `string`: default matching strategy
     - for tests (`test()`) this is a `contain`
     - for packages (`package()`, `deps()` and `rdeps()`) this is an `equal`
 
-To match a string beginning with `=` or `/`, or if you're constructing a filter expression in a programmatic context, use the `contains:` prefix.
+To match a string beginning with `=`, `~` or `/`, or if you're constructing a filter expression in a programmatic context, use the `contains:` prefix.
 
 #### Escape sequences
 

--- a/site/src/book/filter-expressions.md
+++ b/site/src/book/filter-expressions.md
@@ -52,9 +52,12 @@ This section contains the full set of operators supported by the DSL.
 
 ### Name matchers
 
-- `string` or `contains:string`: match a package or test name containing `string`
+- `contains:string`: match a package or test name containing `string`
 - `=string`: match a package or test name that's equal to `string`
 - `/regex/`: match a package or test name if any part of it matches the regular expression `regex`. To match the entire string against a regular expression, use `/^regex$/`. The implementation uses the regex crate.
+- `string`: default matching strategy
+    - for tests (`test()`) this is a `contain`
+    - for packages (`package()`, `deps()` and `rdeps()`) this is an `equal`
 
 To match a string beginning with `=` or `/`, or if you're constructing a filter expression in a programmatic context, use the `contains:` prefix.
 

--- a/site/src/book/filter-expressions.md
+++ b/site/src/book/filter-expressions.md
@@ -68,6 +68,7 @@ The *contains* and *equality* name matchers can contain escape sequences, preced
 * `\\`: backslash
 * `\/`: forward slash
 * `\)`: closing parenthesis
+* `\,`: comma
 * `\u{7FFF}`: 24-bit Unicode character code (up to 6 hex digits)
 
 All other escape sequences are invalid.


### PR DESCRIPTION
Fixes #153 and #155

- Fix `parser` example output following some refactoring of error handling
- Generate error on empty strings like `test()` and `test(=)` (I think we should ?)
- Add support for `,` as an arguments separator
- Changes default matching strategy to `equal` for packages sets
- Add `~` as a shorter way of creating `contains` matcher