### PR TITLE
Fix nextest-filtering badge version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This repository contains the source code for:
     [![Documentation (latest release)](https://img.shields.io/badge/docs-latest-brightgreen)](https://docs.rs/nextest-metadata)
     [![Documentation (main)](https://img.shields.io/badge/docs-main-purple)](https://nexte.st/rustdoc/nextest_metadata)
   * [**nextest-filtering**](nextest-filtering): parser and evaluator for [filter expressions](https://nexte.st/book/filter-expressions)
-    [![nextest-filtering on crates.io](https://img.shields.io/crates/v/nextest-metadata)](https://crates.io/crates/nextest-filtering)
+    [![nextest-filtering on crates.io](https://img.shields.io/crates/v/nextest-filtering)](https://crates.io/crates/nextest-filtering)
     [![Documentation (latest release)](https://img.shields.io/badge/docs-latest-brightgreen)](https://docs.rs/nextest-filtering)
     [![Documentation (main)](https://img.shields.io/badge/docs-main-purple)](https://nexte.st/rustdoc/nextest_filtering)
 * [**quick-junit**](quick-junit): a data model, serializer (and in the future deserializer) for JUnit/XUnit XML


### PR DESCRIPTION
Small fix in the root README. the badge was not showing the right version number.