### PR TITLE
add support for creating and using archives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomicwrites"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb8f2cd6962fa53c0e2a9d3f97eaa7dbd1e3cbbeeb4745403515b42ae07b3ff6"
+dependencies = [
+ "tempfile",
+ "winapi",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +199,9 @@ name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-expr"
@@ -424,6 +437,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0408e2626025178a6a7f7ffc05a25bc47103229f19c113755de7bf63816290c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "winapi",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +624,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +771,7 @@ name = "nextest-runner"
 version = "0.7.0"
 dependencies = [
  "aho-corasick",
+ "atomicwrites",
  "camino",
  "cargo_metadata",
  "chrono",
@@ -769,10 +804,12 @@ dependencies = [
  "serde",
  "serde_json",
  "strip-ansi-escapes",
+ "tar",
  "target-spec",
  "tempfile",
  "toml",
  "twox-hash",
+ "zstd",
 ]
 
 [[package]]
@@ -780,6 +817,7 @@ name = "nextest-workspace-hack"
 version = "0.1.0"
 dependencies = [
  "backtrace",
+ "cc",
  "clap",
  "indexmap",
  "libc",
@@ -1381,6 +1419,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,3 +1645,41 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.1+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+dependencies = [
+ "cc",
+ "libc",
+]

--- a/cargo-nextest/src/errors.rs
+++ b/cargo-nextest/src/errors.rs
@@ -4,7 +4,10 @@
 use camino::Utf8PathBuf;
 use nextest_filtering::errors::FilterExpressionParseErrors;
 use nextest_metadata::NextestExitCode;
-use nextest_runner::errors::{ConfigParseError, PathMapperConstructError, ProfileNotFound};
+use nextest_runner::errors::{
+    ArchiveCreateError, ArchiveExtractError, ConfigParseError, PathMapperConstructError,
+    ProfileNotFound,
+};
 use owo_colors::{OwoColorize, Stream};
 use std::{
     error::{self, Error},
@@ -26,6 +29,14 @@ pub enum ExpectedError {
         arg_name: &'static str,
         file_name: Utf8PathBuf,
         err: std::io::Error,
+    },
+    ArchiveCreateError {
+        archive_file: Utf8PathBuf,
+        err: ArchiveCreateError,
+    },
+    ArchiveExtractError {
+        archive_file: Utf8PathBuf,
+        err: ArchiveExtractError,
     },
     PathMapperConstructError {
         arg_name: &'static str,
@@ -132,11 +143,13 @@ impl ExpectedError {
             Self::ProfileNotFound { .. }
             | Self::ConfigParseError { .. }
             | Self::ArgumentFileReadError { .. }
+            | Self::ArchiveExtractError { .. }
             | Self::PathMapperConstructError { .. }
             | Self::ArgumentJsonParseError { .. }
             | Self::CargoMetadataParseError { .. } => NextestExitCode::SETUP_ERROR,
             Self::BuildFailed { .. } => NextestExitCode::BUILD_FAILED,
             Self::TestRunFailed => NextestExitCode::TEST_RUN_FAILED,
+            Self::ArchiveCreateError { .. } => NextestExitCode::ARCHIVE_CREATION_FAILED,
             Self::ExperimentalFeatureNotEnabled { .. } => {
                 NextestExitCode::EXPERIMENTAL_FEATURE_NOT_ENABLED
             }
@@ -168,6 +181,20 @@ impl ExpectedError {
                     "argument {} specified file `{}` that couldn't be read",
                     format!("--{}", arg_name).if_supports_color(Stream::Stderr, |x| x.bold()),
                     file_name.if_supports_color(Stream::Stderr, |x| x.bold()),
+                );
+                Some(err as &dyn Error)
+            }
+            Self::ArchiveCreateError { archive_file, err } => {
+                log::error!(
+                    "error creating archive `{}`",
+                    archive_file.if_supports_color(Stream::Stderr, |x| x.bold())
+                );
+                Some(err as &dyn Error)
+            }
+            Self::ArchiveExtractError { archive_file, err } => {
+                log::error!(
+                    "error extracting archive `{}`",
+                    archive_file.if_supports_color(Stream::Stderr, |x| x.bold())
                 );
                 Some(err as &dyn Error)
             }
@@ -256,12 +283,14 @@ impl ExpectedError {
 
 impl fmt::Display for ExpectedError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // This should generally not be called, but provide a stub implementation it is
+        // This should generally not be called, but provide a stub implementation if it is
         match self {
             Self::CargoMetadataFailed => writeln!(f, "cargo metadata failed"),
             Self::ProfileNotFound { .. } => writeln!(f, "profile not found"),
             Self::ConfigParseError { .. } => writeln!(f, "config read error"),
             Self::ArgumentFileReadError { .. } => writeln!(f, "argument file error"),
+            Self::ArchiveCreateError { .. } => writeln!(f, "archive create error"),
+            Self::ArchiveExtractError { .. } => writeln!(f, "archive extract error"),
             Self::PathMapperConstructError { .. } => writeln!(f, "path mapper construct error"),
             Self::ArgumentJsonParseError { .. } => writeln!(f, "argument json decode error"),
             Self::CargoMetadataParseError { .. } => writeln!(f, "cargo metadata parse error"),

--- a/nextest-metadata/src/exit_codes.rs
+++ b/nextest-metadata/src/exit_codes.rs
@@ -19,6 +19,9 @@ impl NextestExitCode {
     /// One or more tests failed.
     pub const TEST_RUN_FAILED: i32 = 100;
 
+    /// Creating an archive produced an error.
+    pub const ARCHIVE_CREATION_FAILED: i32 = 103;
+
     /// A user issue happened while setting up a nextest invocation.
     pub const SETUP_ERROR: i32 = 96;
 

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 rust-version = "1.59"
 
 [dependencies]
+atomicwrites = "0.3.1"
 aho-corasick = "0.7.18"
 camino = { version = "1.0.9", features = ["serde1"] }
 config = { version = "0.13.1", default-features = false, features = ["toml"] }
@@ -34,11 +35,14 @@ rayon = "1.5.3"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 strip-ansi-escapes = "0.1.1"
+tar = "0.4.38"
 # For cfg expression evaluation for [target.'cfg()'] expressions
 target-spec = "1.0"
+tempfile = "3.3.0"
 # For parsing of .cargo/config.toml files
 toml = "0.5.9"
 twox-hash = { version = "1.6.3", default-features = false }
+zstd = { version = "0.11.2", features = ["zstdmt"] }
 
 nextest-filtering = { version = "0.1.0", path = "../nextest-filtering" }
 nextest-metadata = { version = "0.3.1", path = "../nextest-metadata" }
@@ -53,7 +57,6 @@ pathdiff = { version = "0.2.1", features = ["camino"] }
 pretty_assertions = "1.2.1"
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
-tempfile = "3.3.0"
 
 [[bin]]
 name = "passthrough"

--- a/nextest-runner/src/reuse_build/archive_reporter.rs
+++ b/nextest-runner/src/reuse_build/archive_reporter.rs
@@ -1,0 +1,207 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::io::{self, Write};
+
+use camino::Utf8Path;
+use owo_colors::{OwoColorize, Style};
+
+#[derive(Debug)]
+/// Reporter for archive operations.
+pub struct ArchiveReporter {
+    styles: Styles,
+    // TODO: message-format json?
+}
+
+impl ArchiveReporter {
+    /// Creates a new reporter for archive events.
+    pub fn new(_verbose: bool) -> Self {
+        Self {
+            styles: Styles::default(),
+        }
+    }
+
+    /// Colorizes output.
+    pub fn colorize(&mut self) {
+        self.styles.colorize();
+    }
+
+    /// Reports an archive event.
+    pub fn report_event(
+        &mut self,
+        event: ArchiveEvent<'_>,
+        mut writer: impl Write,
+    ) -> io::Result<()> {
+        match event {
+            ArchiveEvent::ArchiveStarted {
+                test_binary_count,
+                non_test_binary_count,
+                linked_path_count,
+                output_file,
+            } => {
+                write!(writer, "{:>12} ", "Archiving".style(self.styles.success))?;
+
+                self.report_binary_counts(
+                    test_binary_count,
+                    non_test_binary_count,
+                    linked_path_count,
+                    &mut writer,
+                )?;
+
+                writeln!(writer, " to {}", output_file.style(self.styles.bold))?;
+            }
+            ArchiveEvent::Archived {
+                file_count,
+                output_file,
+            } => {
+                write!(writer, "{:>12} ", "Archived".style(self.styles.success))?;
+                writeln!(
+                    writer,
+                    "{} files to {}",
+                    file_count.style(self.styles.bold),
+                    output_file.style(self.styles.bold)
+                )?;
+            }
+            ArchiveEvent::ExtractStarted {
+                file_count,
+                test_binary_count,
+                non_test_binary_count,
+                linked_path_count,
+                dest_dir: destination_dir,
+            } => {
+                write!(writer, "{:>12} ", "Extracting".style(self.styles.success))?;
+
+                self.report_binary_counts(
+                    test_binary_count,
+                    non_test_binary_count,
+                    linked_path_count,
+                    &mut writer,
+                )?;
+
+                writeln!(
+                    writer,
+                    " ({} files total) to {}",
+                    file_count.style(self.styles.bold),
+                    destination_dir.style(self.styles.bold),
+                )?;
+            }
+            ArchiveEvent::Extracted {
+                file_count,
+                dest_dir: destination_dir,
+            } => {
+                write!(writer, "{:>12} ", "Extracted".style(self.styles.success))?;
+                writeln!(
+                    writer,
+                    "{} files to {}",
+                    file_count.style(self.styles.bold),
+                    destination_dir.style(self.styles.bold)
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn report_binary_counts(
+        &mut self,
+        test_binary_count: usize,
+        non_test_binary_count: usize,
+        linked_path_count: usize,
+        mut writer: impl Write,
+    ) -> io::Result<()> {
+        let total_binary_count = test_binary_count + non_test_binary_count;
+        let non_test_text = if non_test_binary_count > 0 {
+            format!(
+                " (including {} non-test binaries)",
+                non_test_binary_count.style(self.styles.bold)
+            )
+        } else {
+            "".to_owned()
+        };
+        let linked_path_text = if linked_path_count > 0 {
+            format!(
+                " and {} linked paths",
+                linked_path_count.style(self.styles.bold)
+            )
+        } else {
+            "".to_owned()
+        };
+
+        write!(
+            writer,
+            "{} binaries{non_test_text}{linked_path_text}",
+            total_binary_count.style(self.styles.bold),
+        )
+    }
+}
+
+#[derive(Debug, Default)]
+struct Styles {
+    bold: Style,
+    success: Style,
+}
+
+impl Styles {
+    fn colorize(&mut self) {
+        self.bold = Style::new().bold();
+        self.success = Style::new().green().bold();
+    }
+}
+
+/// An archive event.
+///
+/// Events are produced by archive and extract operations, and consumed by an [`ArchiveReporter`].
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum ArchiveEvent<'a> {
+    /// The archive process started.
+    ArchiveStarted {
+        /// The number of test binaries to archive.
+        test_binary_count: usize,
+
+        /// The number of non-test binaries to archive.
+        non_test_binary_count: usize,
+
+        /// The number of linked paths to archive.
+        linked_path_count: usize,
+
+        /// The archive output file.
+        output_file: &'a Utf8Path,
+    },
+
+    /// The archive operation completed successfully.
+    Archived {
+        /// The number of files archived.
+        file_count: usize,
+
+        /// The archive output file.
+        output_file: &'a Utf8Path,
+    },
+
+    /// The extraction process started.
+    ExtractStarted {
+        /// The number of files in the archive.
+        file_count: usize,
+
+        /// The number of test binaries to extract.
+        test_binary_count: usize,
+
+        /// The number of non-test binaries to extract.
+        non_test_binary_count: usize,
+
+        /// The number of linked paths to extract.
+        linked_path_count: usize,
+
+        /// The destination directory.
+        dest_dir: &'a Utf8Path,
+    },
+
+    /// The extraction process completed successfully.
+    Extracted {
+        /// The number of files extracted.
+        file_count: usize,
+
+        /// The destination directory.
+        dest_dir: &'a Utf8Path,
+    },
+}

--- a/nextest-runner/src/reuse_build/archiver.rs
+++ b/nextest-runner/src/reuse_build/archiver.rs
@@ -1,0 +1,215 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use super::{ArchiveEvent, Unarchiver, BINARIES_METADATA_FILE_NAME, CARGO_METADATA_FILE_NAME};
+use crate::{
+    errors::{ArchiveCreateError, ArchiveReadError},
+    helpers::convert_rel_path_to_forward_slash,
+    list::{BinaryList, OutputFormat, SerializableFormat},
+    reuse_build::PathMapper,
+};
+use atomicwrites::{AtomicFile, OverwriteBehavior};
+use camino::Utf8Path;
+use std::{
+    io::{self, BufWriter, Write},
+    time::SystemTime,
+};
+use zstd::Encoder;
+
+/// Archives test binaries along with metadata to the given file.
+///
+/// The output file is a Zstandard-compressed tarball (`.tar.zst`).
+pub fn archive_to_file<'a, F>(
+    binary_list: &'a BinaryList,
+    cargo_metadata: &'a str,
+    path_mapper: &'a PathMapper,
+    compression_level: i32,
+    output_file: &'a Utf8Path,
+    mut callback: F,
+) -> Result<(), ArchiveCreateError>
+where
+    F: FnMut(ArchiveEvent<'a>) -> io::Result<()>,
+{
+    let file = AtomicFile::new(output_file, OverwriteBehavior::AllowOverwrite);
+    let test_binary_count = binary_list.rust_binaries.len();
+    let non_test_binary_count = binary_list.rust_build_meta.non_test_binaries.len();
+    let linked_path_count = binary_list.rust_build_meta.linked_paths.len();
+
+    file.write(|file| {
+        callback(ArchiveEvent::ArchiveStarted {
+            test_binary_count,
+            non_test_binary_count,
+            linked_path_count,
+            output_file,
+        })
+        .map_err(ArchiveCreateError::ReporterIo)?;
+        // Write out the archive.
+        let archiver = Archiver::new(
+            binary_list,
+            cargo_metadata,
+            path_mapper,
+            compression_level,
+            file,
+        )?;
+        archiver.archive()?;
+
+        Ok(())
+    })
+    .map_err(|err| match err {
+        atomicwrites::Error::Internal(err) => ArchiveCreateError::OutputFileIo(err),
+        atomicwrites::Error::User(err) => err,
+    })?;
+
+    // Read the archive to validate it and grab data. TODO: move this to the AtomicFile block once
+    // https://github.com/untitaker/rust-atomicwrites/pull/53 is released.
+    let mut file = std::fs::File::open(output_file)
+        .map_err(|error| ArchiveCreateError::Validation(ArchiveReadError::Io(error)))?;
+    let mut unarchiver = Unarchiver::new(&mut file);
+    let info = unarchiver
+        .get_info()
+        .map_err(ArchiveCreateError::Validation)?;
+
+    callback(ArchiveEvent::Archived {
+        // TODO: obtain file count from archive
+        file_count: info.file_count,
+        output_file,
+    })
+    .map_err(ArchiveCreateError::ReporterIo)?;
+
+    Ok(())
+}
+
+struct Archiver<'a, W: Write> {
+    binary_list: &'a BinaryList,
+    cargo_metadata: &'a str,
+    path_mapper: &'a PathMapper,
+    builder: tar::Builder<Encoder<'static, BufWriter<W>>>,
+    unix_timestamp: u64,
+}
+
+impl<'a, W: Write> Archiver<'a, W> {
+    fn new(
+        binary_list: &'a BinaryList,
+        cargo_metadata: &'a str,
+        path_mapper: &'a PathMapper,
+        compression_level: i32,
+        writer: W,
+    ) -> Result<Self, ArchiveCreateError> {
+        let buf_writer = BufWriter::new(writer);
+        let mut encoder = zstd::Encoder::new(buf_writer, compression_level)
+            .map_err(ArchiveCreateError::OutputFileIo)?;
+        encoder
+            .include_checksum(true)
+            .map_err(ArchiveCreateError::OutputFileIo)?;
+        encoder
+            .multithread(num_cpus::get() as u32)
+            .map_err(ArchiveCreateError::OutputFileIo)?;
+        let builder = tar::Builder::new(encoder);
+
+        let unix_timestamp = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("current time should be after 1970-01-01")
+            .as_secs();
+
+        Ok(Self {
+            binary_list,
+            cargo_metadata,
+            path_mapper,
+            builder,
+            unix_timestamp,
+        })
+    }
+
+    fn archive(mut self) -> Result<W, ArchiveCreateError> {
+        self.add_file(CARGO_METADATA_FILE_NAME, self.cargo_metadata)?;
+
+        let binaries_metadata = self
+            .binary_list
+            .to_string(OutputFormat::Serializable(SerializableFormat::JsonPretty))
+            .map_err(ArchiveCreateError::CreateBinaryList)?;
+
+        self.add_file(BINARIES_METADATA_FILE_NAME, &binaries_metadata)?;
+
+        // Write all discovered binaries into the archive.
+        let target_dir = &self.binary_list.rust_build_meta.target_directory;
+        for binary in &self.binary_list.rust_binaries {
+            let rel_path = binary
+                .path
+                .strip_prefix(target_dir.parent().expect("target dir cannot be the root"))
+                .expect("binary paths must be within target directory");
+            let rel_path = convert_rel_path_to_forward_slash(rel_path);
+            self.builder
+                .append_path_with_name(&binary.path, &rel_path)
+                .map_err(ArchiveCreateError::OutputFileIo)?;
+        }
+        for non_test_binary in self
+            .binary_list
+            .rust_build_meta
+            .non_test_binaries
+            .iter()
+            .flat_map(|(_, binaries)| binaries)
+        {
+            let src_path = self
+                .binary_list
+                .rust_build_meta
+                .target_directory
+                .join(&non_test_binary.path);
+            let src_path = self.path_mapper.map_binary(src_path);
+
+            let rel_path = Utf8Path::new("target").join(&non_test_binary.path);
+            let rel_path = convert_rel_path_to_forward_slash(&rel_path);
+
+            self.builder
+                .append_path_with_name(&src_path, &rel_path)
+                .map_err(ArchiveCreateError::OutputFileIo)?;
+        }
+
+        // Write linked paths to the archive.
+        for linked_path in &self.binary_list.rust_build_meta.linked_paths {
+            // linked paths are e.g. debug/foo/bar. We need to prepend the target directory.
+            let src_path = self
+                .binary_list
+                .rust_build_meta
+                .target_directory
+                .join(linked_path);
+            let src_path = self.path_mapper.map_binary(src_path);
+
+            let rel_path = Utf8Path::new("target").join(linked_path);
+            let rel_path = convert_rel_path_to_forward_slash(&rel_path);
+            self.builder
+                .append_dir_all(&rel_path, &src_path)
+                .map_err(ArchiveCreateError::OutputFileIo)?;
+        }
+
+        // TODO: add extra files.
+
+        // Finish writing the archive.
+        let encoder = self
+            .builder
+            .into_inner()
+            .map_err(ArchiveCreateError::OutputFileIo)?;
+        // Finish writing the zstd stream.
+        let buf_writer = encoder.finish().map_err(ArchiveCreateError::OutputFileIo)?;
+        let writer = buf_writer
+            .into_inner()
+            .map_err(|err| ArchiveCreateError::OutputFileIo(err.into_error()))?;
+
+        Ok(writer)
+    }
+
+    // ---
+    // Helper methods
+    // ---
+
+    fn add_file(&mut self, name: &str, contents: &str) -> Result<(), ArchiveCreateError> {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(contents.len() as u64);
+        header.set_mtime(self.unix_timestamp);
+        header.set_mode(0o664);
+        header.set_cksum();
+
+        self.builder
+            .append_data(&mut header, name, io::Cursor::new(contents))
+            .map_err(ArchiveCreateError::OutputFileIo)
+    }
+}

--- a/nextest-runner/src/reuse_build/unarchiver.rs
+++ b/nextest-runner/src/reuse_build/unarchiver.rs
@@ -1,0 +1,333 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use super::{ArchiveEvent, BINARIES_METADATA_FILE_NAME, CARGO_METADATA_FILE_NAME};
+use crate::{
+    errors::{ArchiveExtractError, ArchiveReadError},
+    list::BinaryList,
+};
+use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
+use guppy::graph::PackageGraph;
+use itertools::Either;
+use nextest_metadata::BinaryListSummary;
+use std::{
+    fs,
+    io::{self, Read, Seek},
+};
+use tempfile::TempDir;
+
+#[derive(Clone, Debug)]
+pub(crate) struct ArchiveInfo {
+    pub binary_list: BinaryList,
+    pub file_count: usize,
+}
+
+#[derive(Debug)]
+pub(crate) struct Unarchiver<'a> {
+    file: &'a mut fs::File,
+}
+
+impl<'a> Unarchiver<'a> {
+    pub(crate) fn new(file: &'a mut fs::File) -> Self {
+        Self { file }
+    }
+
+    pub(crate) fn get_info(&mut self) -> Result<ArchiveInfo, ArchiveReadError> {
+        self.file
+            .seek(io::SeekFrom::Start(0))
+            .map_err(ArchiveReadError::Io)?;
+        let mut archive_reader = ArchiveReader::new(self.file)?;
+
+        let mut file_count = 0;
+        let mut binary_list = None;
+        let mut found_cargo_metadata = false;
+
+        let binaries_metadata_path = Utf8Path::new(BINARIES_METADATA_FILE_NAME);
+        let cargo_metadata_path = Utf8Path::new(CARGO_METADATA_FILE_NAME);
+
+        for entry in archive_reader.entries()? {
+            let (entry, path) = entry?;
+            file_count += 1;
+
+            if path == binaries_metadata_path {
+                // Try reading the binary list out of this entry.
+                let summary: BinaryListSummary =
+                    serde_json::from_reader(entry).map_err(|error| {
+                        ArchiveReadError::MetadataDeserializeError {
+                            path: binaries_metadata_path,
+                            error,
+                        }
+                    })?;
+                binary_list = Some(BinaryList::from_summary(summary));
+            } else if path == cargo_metadata_path {
+                found_cargo_metadata = true;
+            }
+        }
+
+        let binary_list = match binary_list {
+            Some(binary_list) => binary_list,
+            None => {
+                return Err(ArchiveReadError::MetadataFileNotFound(
+                    binaries_metadata_path,
+                ))
+            }
+        };
+        if !found_cargo_metadata {
+            return Err(ArchiveReadError::MetadataFileNotFound(cargo_metadata_path));
+        }
+
+        Ok(ArchiveInfo {
+            file_count,
+            binary_list,
+        })
+    }
+
+    pub(crate) fn extract<F>(
+        &mut self,
+        dest: ExtractDestination,
+        mut callback: F,
+    ) -> Result<ExtractInfo, ArchiveExtractError>
+    where
+        F: for<'e> FnMut(ArchiveEvent<'e>) -> io::Result<()>,
+    {
+        let (dest_dir, temp_dir) = match dest {
+            ExtractDestination::TempDir { persist } => {
+                // Create a new temporary directory and extract contents to it.
+                let temp_dir = tempfile::Builder::new()
+                    .prefix("nextest-archive-")
+                    .tempdir()
+                    .map_err(ArchiveExtractError::TempDirCreate)?;
+                let dest_dir: Utf8PathBuf =
+                    temp_dir.path().to_path_buf().try_into().map_err(|err| {
+                        ArchiveExtractError::TempDirCreate(std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            err,
+                        ))
+                    })?;
+
+                let dest_dir = dest_dir.canonicalize_utf8().map_err(|error| {
+                    ArchiveExtractError::DestDirCanonicalization {
+                        dir: dest_dir.to_owned(),
+                        error,
+                    }
+                })?;
+
+                let temp_dir = if persist {
+                    // Persist the temporary directory.
+                    let _ = temp_dir.into_path();
+                    None
+                } else {
+                    Some(temp_dir)
+                };
+
+                (dest_dir, temp_dir)
+            }
+            ExtractDestination::Destination { dir, overwrite } => {
+                // Extract contents to the destination directory.
+                let dest_dir = dir
+                    .canonicalize_utf8()
+                    .map_err(|error| ArchiveExtractError::DestDirCanonicalization { dir, error })?;
+
+                let dest_target = dest_dir.join("target");
+                if dest_target.exists() && !overwrite {
+                    return Err(ArchiveExtractError::DestinationExists(dest_target));
+                }
+
+                (dest_dir, None)
+            }
+        };
+
+        // Read archive and validate it.
+        let archive_info = self.get_info().map_err(ArchiveExtractError::Read)?;
+        let file_count = archive_info.file_count;
+        let binary_list = archive_info.binary_list;
+        let test_binary_count = binary_list.rust_binaries.len();
+        let non_test_binary_count = binary_list.rust_build_meta.non_test_binaries.len();
+        let linked_path_count = binary_list.rust_build_meta.linked_paths.len();
+
+        // Report begin extraction.
+        callback(ArchiveEvent::ExtractStarted {
+            file_count,
+            test_binary_count,
+            non_test_binary_count,
+            linked_path_count,
+            dest_dir: &dest_dir,
+        })
+        .map_err(ArchiveExtractError::ReporterIo)?;
+
+        // Extract the archive.
+        self.file
+            .seek(io::SeekFrom::Start(0))
+            .map_err(|error| ArchiveExtractError::Read(ArchiveReadError::Io(error)))?;
+        let mut archive_reader =
+            ArchiveReader::new(self.file).map_err(ArchiveExtractError::Read)?;
+
+        // Will be filled out by the for loop below
+        let mut cargo_metadata = None;
+        let cargo_metadata_path = Utf8Path::new(CARGO_METADATA_FILE_NAME);
+
+        for entry in archive_reader
+            .entries()
+            .map_err(ArchiveExtractError::Read)?
+        {
+            let (mut entry, path) = entry.map_err(ArchiveExtractError::Read)?;
+            if path == Utf8Path::new(BINARIES_METADATA_FILE_NAME) {
+                // The BinaryList was already read in the ArchiveInfo above -- no need to re-read or
+                // extract it.
+                continue;
+            } else if path == Utf8Path::new(CARGO_METADATA_FILE_NAME) {
+                // Parse the input Cargo metadata as a `PackageGraph`.
+                let mut json = String::with_capacity(entry.size() as usize);
+                entry
+                    .read_to_string(&mut json)
+                    .map_err(|error| ArchiveExtractError::Read(ArchiveReadError::Io(error)))?;
+
+                let package_graph = PackageGraph::from_json(&json).map_err(|error| {
+                    ArchiveExtractError::Read(ArchiveReadError::PackageGraphConstructError {
+                        path: cargo_metadata_path,
+                        error,
+                    })
+                })?;
+                cargo_metadata = Some((json, package_graph));
+                continue;
+            }
+
+            // Extract all other files.
+            entry
+                .unpack_in(&dest_dir)
+                .map_err(|error| ArchiveExtractError::WriteFile { path, error })?;
+        }
+
+        let (cargo_metadata_json, graph) =
+            cargo_metadata.expect("get_info already verified that Cargo metadata exists");
+
+        // Report end extraction.
+        callback(ArchiveEvent::Extracted {
+            file_count,
+            dest_dir: &dest_dir,
+        })
+        .map_err(ArchiveExtractError::ReporterIo)?;
+
+        Ok(ExtractInfo {
+            dest_dir,
+            temp_dir,
+            binary_list,
+            cargo_metadata_json,
+            graph,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ExtractInfo {
+    /// The destination directory.
+    pub dest_dir: Utf8PathBuf,
+
+    /// An optional [`TempDir`], used for cleanup.
+    pub temp_dir: Option<TempDir>,
+
+    /// The [`BinaryList`] read from the archive.
+    pub binary_list: BinaryList,
+
+    /// The Cargo metadata JSON.
+    pub cargo_metadata_json: String,
+
+    /// The [`PackageGraph`] read from the archive.
+    pub graph: PackageGraph,
+}
+
+struct ArchiveReader<'a> {
+    archive: tar::Archive<zstd::Decoder<'static, io::BufReader<&'a mut fs::File>>>,
+}
+
+impl<'a> ArchiveReader<'a> {
+    fn new(file: &'a mut fs::File) -> Result<Self, ArchiveReadError> {
+        let decoder = zstd::Decoder::new(file).map_err(ArchiveReadError::Io)?;
+        let archive = tar::Archive::new(decoder);
+        Ok(Self { archive })
+    }
+
+    fn entries<'r>(
+        &'r mut self,
+    ) -> Result<
+        impl Iterator<Item = Result<(ArchiveEntry<'r, 'a>, Utf8PathBuf), ArchiveReadError>>,
+        ArchiveReadError,
+    > {
+        let entries = self.archive.entries().map_err(ArchiveReadError::Io)?;
+        Ok(entries.map(|entry| {
+            let entry = entry.map_err(ArchiveReadError::Io)?;
+
+            // Validation: entry paths must be valid UTF-8.
+            let path = entry_path(&entry)?;
+
+            // Validation: paths start with "target".
+            if !path.starts_with("target") {
+                return Err(ArchiveReadError::NoTargetPrefix(path));
+            }
+
+            // Validation: paths only contain normal components.
+            for component in path.components() {
+                match component {
+                    Utf8Component::Normal(_) => {}
+                    other => {
+                        return Err(ArchiveReadError::InvalidComponent {
+                            path: path.clone(),
+                            component: other.as_str().to_owned(),
+                        });
+                    }
+                }
+            }
+
+            // Validation: checksum matches.
+            let mut header = entry.header().clone();
+            let actual_cksum = header
+                .cksum()
+                .map_err(|err| ArchiveReadError::InvalidChecksum {
+                    path: path.clone(),
+                    payload: Either::Right(err),
+                })?;
+
+            header.set_cksum();
+            let expected_cksum = header
+                .cksum()
+                .expect("checksum that was just set can't be invalid");
+
+            if expected_cksum != actual_cksum {
+                return Err(ArchiveReadError::InvalidChecksum {
+                    path,
+                    payload: Either::Left((expected_cksum, actual_cksum)),
+                });
+            }
+
+            Ok((entry, path))
+        }))
+    }
+}
+
+/// Given an entry, returns its path as a `Utf8Path`.
+fn entry_path(entry: &ArchiveEntry<'_, '_>) -> Result<Utf8PathBuf, ArchiveReadError> {
+    let path_bytes = entry.path_bytes();
+    let path_str = std::str::from_utf8(&path_bytes)
+        .map_err(|_| ArchiveReadError::NonUtf8Path(path_bytes.to_vec()))?;
+    let utf8_path = Utf8Path::new(path_str);
+    Ok(utf8_path.to_owned())
+}
+
+/// Where to extract a nextest archive to.
+#[derive(Clone, Debug)]
+pub enum ExtractDestination {
+    /// Extract the archive to a new temporary directory.
+    TempDir {
+        /// Whether to persist the temporary directory at the end of execution.
+        persist: bool,
+    },
+    /// Extract the archive to a custom destination.
+    Destination {
+        /// The directory to extract to.
+        dir: Utf8PathBuf,
+        /// Whether to overwrite existing contents.
+        overwrite: bool,
+    },
+}
+
+type ArchiveEntry<'r, 'a> = tar::Entry<'r, zstd::Decoder<'static, io::BufReader<&'a mut fs::File>>>;

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -19,6 +19,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     env, fmt,
     io::Cursor,
+    sync::Arc,
 };
 
 #[derive(Copy, Clone, Debug)]
@@ -207,8 +208,9 @@ pub(crate) struct FixtureTargets {
 impl FixtureTargets {
     fn new() -> Self {
         let graph = &*PACKAGE_GRAPH;
-        let binary_list =
-            BinaryList::from_messages(Cursor::new(&*FIXTURE_RAW_CARGO_TEST_OUTPUT), graph).unwrap();
+        let binary_list = Arc::new(
+            BinaryList::from_messages(Cursor::new(&*FIXTURE_RAW_CARGO_TEST_OUTPUT), graph).unwrap(),
+        );
         let rust_build_meta = binary_list.rust_build_meta.clone();
 
         let path_mapper = PathMapper::noop();

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = { version = "1.0.81", features = ["std", "unbounded_depth"] }
 textwrap = { version = "0.15.0", features = ["smawk", "unicode-linebreak", "unicode-width"] }
 
 [build-dependencies]
+cc = { version = "1.0.73", default-features = false, features = ["jobserver", "parallel"] }
 memchr = { version = "2.5.0", features = ["std", "use_std"] }
 proc-macro2 = { version = "1.0.39", features = ["proc-macro"] }
 quote = { version = "1.0.18", features = ["proc-macro"] }
@@ -37,8 +38,14 @@ syn = { version = "1.0.95", features = ["clone-impls", "derive", "extra-traits",
 [target.x86_64-unknown-linux-gnu.dependencies]
 libc = { version = "0.2.124", default-features = false, features = ["extra_traits"] }
 
+[target.x86_64-unknown-linux-gnu.build-dependencies]
+libc = { version = "0.2.124", features = ["extra_traits", "std"] }
+
 [target.x86_64-apple-darwin.dependencies]
 libc = { version = "0.2.124", default-features = false, features = ["extra_traits"] }
+
+[target.x86_64-apple-darwin.build-dependencies]
+libc = { version = "0.2.124", features = ["extra_traits", "std"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
 winapi = { version = "0.3.9", default-features = false, features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "processenv", "processthreadsapi", "profileapi", "shlobj", "std", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winuser"] }


### PR DESCRIPTION
TODO:
- [x] Create archives.
- [x] Output correct file count.
- [x] Extract archives.
- [x] `--archive` and `--extract-to` flags.
- [x] `--binaries-metadata` + `--cargo-metadata` clases with `--archive`.
- [x] `--archive` clashes with Cargo-related options.
- [x] `cargo nextest archive` shouldn't accept reuse-build options.
- [x] Also grab libraries (.so files) from the build output.
- [x] While archiving, always save cargo metadata with deps.

Issue: #229