### PR TITLE
[nextest-runner] expose NEXTEST_BIN_EXE_ environment variables at runtime

### DIFF
--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -318,10 +318,11 @@ impl TestBuildFilter {
             &binary_list.rust_build_meta.target_directory,
         )?;
 
-        let rust_build_meta = binary_list.rust_build_meta.clone();
+        let rust_build_meta = binary_list.rust_build_meta.map_paths(&path_mapper);
         let test_artifacts = RustTestArtifact::from_binary_list(
             graph,
             binary_list,
+            &rust_build_meta,
             &path_mapper,
             self.platform_filter.into(),
         )?;
@@ -331,14 +332,8 @@ impl TestBuildFilter {
             &self.filter,
             filter_exprs,
         );
-        TestList::new(
-            test_artifacts,
-            &rust_build_meta,
-            &path_mapper,
-            &test_filter,
-            runner,
-        )
-        .wrap_err("error building test list")
+        TestList::new(test_artifacts, rust_build_meta, &test_filter, runner)
+            .wrap_err("error building test list")
     }
 
     fn compute_binary_list(

--- a/cargo-nextest/src/tests_integration/fixtures.rs
+++ b/cargo-nextest/src/tests_integration/fixtures.rs
@@ -32,6 +32,11 @@ impl TestInfo {
 pub static EXPECTED_LIST: Lazy<Vec<TestInfo>> = Lazy::new(|| {
     vec![
         TestInfo::new(
+            "cdylib-example",
+            BuildPlatform::Target,
+            vec![("tests::test_multiply_two_cdylib", false)],
+        ),
+        TestInfo::new(
             "cdylib-link",
             BuildPlatform::Target,
             vec![("test_multiply_two", false)],
@@ -249,6 +254,7 @@ pub fn check_run_output(stderr: &[u8], relocated: bool) {
 
     let expected = &[
         (true, "cdylib-link test_multiply_two"),
+        (true, "cdylib-example tests::test_multiply_two_cdylib"),
         (true, "nextest-tests::basic test_cargo_env_vars"),
         (false, "nextest-tests::basic test_failure_error"),
         (false, "nextest-tests::basic test_flaky_mod_2"),
@@ -281,9 +287,9 @@ pub fn check_run_output(stderr: &[u8], relocated: bool) {
     }
 
     let summary_reg = if relocated {
-        Regex::new(r"Summary \[.*\] *18 tests run: 12 passed, 6 failed, 2 skipped").unwrap()
+        Regex::new(r"Summary \[.*\] *19 tests run: 13 passed, 6 failed, 2 skipped").unwrap()
     } else {
-        Regex::new(r"Summary \[.*\] *18 tests run: 13 passed, 5 failed, 2 skipped").unwrap()
+        Regex::new(r"Summary \[.*\] *19 tests run: 14 passed, 5 failed, 2 skipped").unwrap()
     };
     assert!(summary_reg.is_match(&output), "summary didn't match");
 }

--- a/cargo-nextest/src/tests_integration/fixtures.rs
+++ b/cargo-nextest/src/tests_integration/fixtures.rs
@@ -36,11 +36,7 @@ pub static EXPECTED_LIST: Lazy<Vec<TestInfo>> = Lazy::new(|| {
             BuildPlatform::Target,
             vec![("test_multiply_two", false)],
         ),
-        TestInfo::new(
-            "dylib-test::dylib/dylib-test",
-            BuildPlatform::Target,
-            vec![],
-        ),
+        TestInfo::new("dylib-test", BuildPlatform::Target, vec![]),
         TestInfo::new(
             "nextest-tests::basic",
             BuildPlatform::Target,

--- a/cargo-nextest/src/tests_integration/fixtures.rs
+++ b/cargo-nextest/src/tests_integration/fixtures.rs
@@ -48,6 +48,7 @@ pub static EXPECTED_LIST: Lazy<Vec<TestInfo>> = Lazy::new(|| {
             vec![
                 ("test_cargo_env_vars", false),
                 ("test_cwd", false),
+                ("test_execute_bin", false),
                 ("test_failure_assert", false),
                 ("test_failure_error", false),
                 ("test_failure_should_panic", false),
@@ -63,6 +64,11 @@ pub static EXPECTED_LIST: Lazy<Vec<TestInfo>> = Lazy::new(|| {
             "nextest-derive::proc-macro/nextest-derive",
             BuildPlatform::Host,
             vec![("it_works", false)],
+        ),
+        TestInfo::new(
+            "nextest-tests::bench/my-bench",
+            BuildPlatform::Target,
+            vec![("tests::test_execute_bin", false)],
         ),
         TestInfo::new(
             "nextest-tests::bin/nextest-tests",
@@ -144,6 +150,7 @@ pub fn build_tests(p: &TempProject) {
         p.manifest_path().as_str(),
         "list",
         "--workspace",
+        "--all-targets",
         "--message-format",
         "json",
         "--list-type",
@@ -256,6 +263,11 @@ pub fn check_run_output(stderr: &[u8], relocated: bool) {
         (true, "cdylib-link test_multiply_two"),
         (true, "cdylib-example tests::test_multiply_two_cdylib"),
         (true, "nextest-tests::basic test_cargo_env_vars"),
+        (true, "nextest-tests::basic test_execute_bin"),
+        (
+            true,
+            "nextest-tests::bench/my-bench tests::test_execute_bin",
+        ),
         (false, "nextest-tests::basic test_failure_error"),
         (false, "nextest-tests::basic test_flaky_mod_2"),
         (true, "nextest-tests::bin/nextest-tests tests::bin_success"),
@@ -287,9 +299,13 @@ pub fn check_run_output(stderr: &[u8], relocated: bool) {
     }
 
     let summary_reg = if relocated {
-        Regex::new(r"Summary \[.*\] *19 tests run: 13 passed, 6 failed, 2 skipped").unwrap()
+        Regex::new(r"Summary \[.*\] *21 tests run: 15 passed, 6 failed, 2 skipped").unwrap()
     } else {
-        Regex::new(r"Summary \[.*\] *19 tests run: 14 passed, 5 failed, 2 skipped").unwrap()
+        Regex::new(r"Summary \[.*\] *21 tests run: 16 passed, 5 failed, 2 skipped").unwrap()
     };
-    assert!(summary_reg.is_match(&output), "summary didn't match");
+    assert!(
+        summary_reg.is_match(&output),
+        "summary didn't match (actual output: {})",
+        output
+    );
 }

--- a/cargo-nextest/src/tests_integration/mod.rs
+++ b/cargo-nextest/src/tests_integration/mod.rs
@@ -37,6 +37,7 @@ fn test_list_default() {
         p.manifest_path().as_str(),
         "list",
         "--workspace",
+        "--all-targets",
         "--message-format",
         "json",
     ]);
@@ -60,6 +61,7 @@ fn test_list_full() {
         p.manifest_path().as_str(),
         "list",
         "--workspace",
+        "--all-targets",
         "--message-format",
         "json",
         "--list-type",
@@ -93,6 +95,7 @@ fn test_list_binaries_only() {
         p.manifest_path().as_str(),
         "list",
         "--workspace",
+        "--all-targets",
         "--message-format",
         "json",
         "--list-type",
@@ -120,6 +123,7 @@ fn test_target_dir() {
             "nextest",
             "list",
             "--workspace",
+            "--all-targets",
             "--message-format",
             "json",
         ];
@@ -263,6 +267,7 @@ fn test_run() {
         p.manifest_path().as_str(),
         "run",
         "--workspace",
+        "--all-targets",
     ]);
 
     let mut output = OutputWriter::new_test();
@@ -316,7 +321,11 @@ fn test_relocated_run() {
 
     // copy target directory over
     std::fs::create_dir_all(&new_target_path).unwrap();
-    temp_project::copy_dir_all(custom_target_path, &new_target_path, true).unwrap();
+    temp_project::copy_dir_all(custom_target_path, &new_target_path, false).unwrap();
+    // Remove the old target path to ensure that any tests that refer to files within it
+    // fail.
+    std::fs::remove_dir_all(custom_target_path).unwrap();
+
     p2.set_target_dir(new_target_path);
 
     // Use relative paths to the workspace root and target directory to do testing in.

--- a/fixtures/nextest-tests/benches/my-bench.rs
+++ b/fixtures/nextest-tests/benches/my-bench.rs
@@ -1,0 +1,13 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+// TODO: add benchmarks
+
+#[cfg(test)]
+mod tests {
+    /// Test that a binary can be successfully executed.
+    #[test]
+    fn test_execute_bin() {
+        nextest_tests::test_execute_bin_helper();
+    }
+}

--- a/fixtures/nextest-tests/cdylib/cdylib-example/Cargo.toml
+++ b/fixtures/nextest-tests/cdylib/cdylib-example/Cargo.toml
@@ -5,4 +5,3 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
-test = false

--- a/fixtures/nextest-tests/cdylib/cdylib-example/src/lib.rs
+++ b/fixtures/nextest-tests/cdylib/cdylib-example/src/lib.rs
@@ -5,3 +5,13 @@
 pub extern "C" fn multiply_two(a: i32, b: i32) -> i32 {
     a * b
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_multiply_two_cdylib() {
+        assert_eq!(multiply_two(5, 6), 30);
+    }
+}

--- a/fixtures/nextest-tests/src/bin/nextest-tests.rs
+++ b/fixtures/nextest-tests/src/bin/nextest-tests.rs
@@ -1,7 +1,10 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-fn main() {}
+fn main() {
+    println!("The answer is 42");
+    std::process::exit(42);
+}
 
 #[cfg(test)]
 mod tests {

--- a/fixtures/nextest-tests/src/lib.rs
+++ b/fixtures/nextest-tests/src/lib.rs
@@ -3,6 +3,29 @@
 
 #![allow(dead_code)]
 
+use std::path::Path;
+
+/// This method is called by integration tests and benchmarks to ensure that NEXTEST_BIN_EXE
+/// environment variables are properly set.
+pub fn test_execute_bin_helper() {
+    let binary_path = std::env::var("NEXTEST_BIN_EXE_nextest-tests")
+        .expect("NEXTEST_BIN_EXE_nextest-tests should be present");
+    assert!(
+        Path::new(&binary_path).is_absolute(),
+        "binary path {} is absolute",
+        binary_path
+    );
+    let output = std::process::Command::new(&binary_path)
+        .output()
+        .unwrap_or_else(|err| panic!("failed to run binary at {}: {}", binary_path, err));
+    assert_eq!(output.status.code(), Some(42), "exit code matches");
+    assert_eq!(
+        &output.stdout,
+        "The answer is 42\n".as_bytes(),
+        "stdout matches"
+    );
+}
+
 /// This is a doctest.
 ///
 /// ```
@@ -15,6 +38,18 @@ mod tests {
     #[test]
     fn unit_test_success() {
         assert_eq!(2 + 2, 4, "this test should succeed");
+        // Check that CARGO_BIN_EXE is not set.
+        assert_eq!(
+            option_env!("CARGO_BIN_EXE_nextest-tests"),
+            None,
+            "CARGO_BIN_EXE_nextest-tests not set at compile time"
+        );
+
+        let runtime_bin_exe = std::env::var_os("NEXTEST_BIN_EXE_nextest-tests");
+        assert_eq!(
+            runtime_bin_exe, None,
+            "NEXTEST_BIN_EXE_nextest-tests is not set at runtime"
+        )
     }
 
     #[test]

--- a/fixtures/nextest-tests/tests/basic.rs
+++ b/fixtures/nextest-tests/tests/basic.rs
@@ -72,6 +72,12 @@ fn test_ignored_fail() {
     panic!("ignored test that fails");
 }
 
+/// Test that a binary can be successfully executed.
+#[test]
+fn test_execute_bin() {
+    nextest_tests::test_execute_bin_helper();
+}
+
 macro_rules! assert_env {
     ($name: expr) => {
         assert_env!($name, $name);

--- a/nextest-metadata/src/test_list.rs
+++ b/nextest-metadata/src/test_list.rs
@@ -264,8 +264,23 @@ pub struct RustBuildMetaSummary {
     /// Base output directories, relative to the target directory.
     pub base_output_directories: BTreeSet<Utf8PathBuf>,
 
+    /// Information about non-test binaries, keyed by package ID.
+    pub non_test_binaries: BTreeMap<String, BTreeSet<RustNonTestBinarySummary>>,
+
     /// Linked paths, relative to the target directory.
     pub linked_paths: BTreeSet<Utf8PathBuf>,
+}
+
+/// A non-test Rust binary. Used to set the correct environment
+/// variables in reused builds.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct RustNonTestBinarySummary {
+    /// The name of the binary.
+    pub name: String,
+
+    /// The path to the binary, relative to the target directory.
+    pub path: Utf8PathBuf,
 }
 
 /// A serializable suite of tests within a Rust test binary.

--- a/nextest-runner/src/list/rust_build_meta.rs
+++ b/nextest-runner/src/list/rust_build_meta.rs
@@ -6,8 +6,11 @@ use crate::{
     reuse_build::PathMapper,
 };
 use camino::Utf8PathBuf;
-use nextest_metadata::RustBuildMetaSummary;
-use std::{collections::BTreeSet, marker::PhantomData};
+use nextest_metadata::{RustBuildMetaSummary, RustNonTestBinarySummary};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    marker::PhantomData,
+};
 
 /// Rust-related metadata used for builds and test runs.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -18,6 +21,9 @@ pub struct RustBuildMeta<State> {
     /// A list of base output directories, relative to the target directory. These directories
     /// and their "deps" subdirectories are added to the dynamic library path.
     pub base_output_directories: BTreeSet<Utf8PathBuf>,
+
+    /// Information about non-test executables, keyed by package ID.
+    pub non_test_binaries: BTreeMap<String, BTreeSet<RustNonTestBinarySummary>>,
 
     /// A list of linked paths, relative to the target directory. These directories are
     /// added to the dynamic library path.
@@ -32,6 +38,7 @@ impl RustBuildMeta<BinaryListState> {
         Self {
             target_directory: target_directory.into(),
             base_output_directories: BTreeSet::new(),
+            non_test_binaries: BTreeMap::new(),
             linked_paths: BTreeSet::new(),
             state: PhantomData,
         }
@@ -46,6 +53,7 @@ impl RustBuildMeta<BinaryListState> {
                 .to_path_buf(),
             // Since these are relative paths, they don't need to be mapped.
             base_output_directories: self.base_output_directories.clone(),
+            non_test_binaries: self.non_test_binaries.clone(),
             linked_paths: self.linked_paths.clone(),
             state: PhantomData,
         }
@@ -59,6 +67,7 @@ impl RustBuildMeta<TestListState> {
         Self {
             target_directory: Utf8PathBuf::new(),
             base_output_directories: BTreeSet::new(),
+            non_test_binaries: BTreeMap::new(),
             linked_paths: BTreeSet::new(),
             state: PhantomData,
         }
@@ -93,6 +102,7 @@ impl<State> RustBuildMeta<State> {
         Self {
             target_directory: summary.target_directory,
             base_output_directories: summary.base_output_directories,
+            non_test_binaries: summary.non_test_binaries,
             linked_paths: summary.linked_paths,
             state: PhantomData,
         }
@@ -103,6 +113,7 @@ impl<State> RustBuildMeta<State> {
         RustBuildMetaSummary {
             target_directory: self.target_directory.clone(),
             base_output_directories: self.base_output_directories.clone(),
+            non_test_binaries: self.non_test_binaries.clone(),
             linked_paths: self.linked_paths.clone(),
         }
     }

--- a/nextest-runner/src/list/test_list.rs
+++ b/nextest-runner/src/list/test_list.rs
@@ -16,8 +16,8 @@ use guppy::{
     PackageId,
 };
 use nextest_metadata::{
-    BuildPlatform, RustTestBinarySummary, RustTestCaseSummary, RustTestSuiteSummary,
-    TestListSummary,
+    BuildPlatform, RustTestBinaryKind, RustTestBinarySummary, RustTestCaseSummary,
+    RustTestSuiteSummary, TestListSummary,
 };
 use once_cell::sync::OnceCell;
 use owo_colors::OwoColorize;
@@ -47,6 +47,9 @@ pub struct RustTestArtifact<'g> {
 
     /// The unique binary name defined in `Cargo.toml` or inferred by the filename.
     pub binary_name: String,
+
+    /// The kind of Rust test binary this is.
+    pub kind: RustTestBinaryKind,
 
     /// The working directory that this test should be executed in. If None, the current directory
     /// will not be changed.
@@ -97,6 +100,7 @@ impl<'g> RustTestArtifact<'g> {
                 package,
                 binary_path,
                 binary_name: binary.name,
+                kind: binary.kind,
                 cwd,
                 build_platform: binary.build_platform,
             })
@@ -130,6 +134,9 @@ pub struct RustTestSuite<'g> {
 
     /// The unique binary name defined in `Cargo.toml` or inferred by the filename.
     pub binary_name: String,
+
+    /// The kind of Rust test binary this is.
+    pub kind: RustTestBinaryKind,
 
     /// The working directory that this test binary will be executed in. If None, the current directory
     /// will not be changed.
@@ -273,6 +280,7 @@ impl<'g> TestList<'g> {
                     binary: RustTestBinarySummary {
                         binary_name: info.binary_name.clone(),
                         package_id: info.package.id().repr().to_owned(),
+                        kind: info.kind.clone(),
                         binary_path: binary_path.clone(),
                         binary_id: info.binary_id.clone(),
                         build_platform: platform,
@@ -406,6 +414,7 @@ impl<'g> TestList<'g> {
             package,
             binary_path,
             binary_name,
+            kind,
             cwd,
             build_platform: platform,
         } = test_binary;
@@ -416,6 +425,7 @@ impl<'g> TestList<'g> {
                 binary_id,
                 package,
                 binary_name,
+                kind,
                 testcases: tests,
                 cwd,
                 build_platform: platform,
@@ -718,6 +728,7 @@ mod tests {
             package: package_metadata(),
             binary_name: fake_binary_name.clone(),
             binary_id: fake_binary_id.clone(),
+            kind: RustTestBinaryKind::LIB,
             build_platform: BuildPlatform::Target,
         };
         let rust_build_meta = RustBuildMeta::new("/fake");
@@ -755,6 +766,7 @@ mod tests {
                     package: package_metadata(),
                     binary_name: fake_binary_name,
                     binary_id: fake_binary_id,
+                    kind: RustTestBinaryKind::LIB,
                 }
             }
         );
@@ -791,6 +803,7 @@ mod tests {
                   "binary-id": "fake-package::fake-binary",
                   "binary-name": "fake-binary",
                   "package-id": "metadata-helper 0.1.0 (path+file:///Users/fakeuser/local/testcrates/metadata/metadata-helper)",
+                  "kind": "lib",
                   "binary-path": "/fake/binary",
                   "build-platform": "target",
                   "cwd": "/fake/cwd",

--- a/nextest-runner/src/list/test_list.rs
+++ b/nextest-runner/src/list/test_list.rs
@@ -794,6 +794,7 @@ mod tests {
               "rust-build-meta": {
                 "target-directory": "/fake",
                 "base-output-directories": [],
+                "non-test-binaries": {},
                 "linked-paths": []
               },
               "test-count": 4,

--- a/nextest-runner/tests/integration/basic.rs
+++ b/nextest-runner/tests/integration/basic.rs
@@ -99,6 +99,7 @@ fn test_run() -> Result<()> {
     );
 
     let (instance_statuses, run_stats) = execute_collect(&runner);
+    println!("{instance_statuses:#?}");
 
     for (name, expected) in &*EXPECTED_TESTS {
         let test_binary = FIXTURE_TARGETS

--- a/nextest-runner/tests/integration/basic.rs
+++ b/nextest-runner/tests/integration/basic.rs
@@ -99,13 +99,12 @@ fn test_run() -> Result<()> {
     );
 
     let (instance_statuses, run_stats) = execute_collect(&runner);
-    println!("{instance_statuses:#?}");
 
-    for (name, expected) in &*EXPECTED_TESTS {
+    for (binary_id, expected) in &*EXPECTED_TESTS {
         let test_binary = FIXTURE_TARGETS
             .test_artifacts
-            .get(*name)
-            .unwrap_or_else(|| panic!("unexpected test name {}", name));
+            .get(*binary_id)
+            .unwrap_or_else(|| panic!("unexpected binary ID {}", binary_id));
         for fixture in expected {
             let instance_value = instance_statuses
                 .get(&(test_binary.binary_path.as_path(), fixture.name))

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -113,6 +113,9 @@ pub(crate) static EXPECTED_TESTS: Lazy<BTreeMap<&'static str, Vec<TestFixture>>>
                 TestFixture { name: "test_multiply_two", status: FixtureStatus::Pass },
             ],
             "dylib-test" => vec![],
+            "cdylib-example" => vec![
+                TestFixture { name: "tests::test_multiply_two_cdylib", status: FixtureStatus::Pass },
+            ]
         }
     },
 );

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -112,6 +112,7 @@ pub(crate) static EXPECTED_TESTS: Lazy<BTreeMap<&'static str, Vec<TestFixture>>>
             "cdylib-link" => vec![
                 TestFixture { name: "test_multiply_two", status: FixtureStatus::Pass },
             ],
+            "dylib-test" => vec![],
         }
     },
 );


### PR DESCRIPTION
If paths are remapped, the compile-time CARGO_BIN_EXE_ environment
variables are no longer valid. Set these NEXTEST_ replacement variables
instead.