### PR TITLE
[nextest-runner] skip over missing linked paths

### DIFF
--- a/fixtures/nextest-tests/cdylib/cdylib-link/build.rs
+++ b/fixtures/nextest-tests/cdylib/cdylib-link/build.rs
@@ -37,6 +37,7 @@ fn main() {
     println!("cargo:rustc-link-search=native={}", out_dir.display());
 
     // Also output a bogus linked path that doesn't exist on disk.
+    // Some libraries like grpcio-sys 1.1.8 produce them.
     println!(
         "cargo:rustc-link-search=native={}",
         out_dir.parent().unwrap().join("does-not-exist").display()

--- a/fixtures/nextest-tests/cdylib/cdylib-link/build.rs
+++ b/fixtures/nextest-tests/cdylib/cdylib-link/build.rs
@@ -35,6 +35,12 @@ fn main() {
     }
     println!("cargo:rustc-link-lib=dylib=cdylib_example");
     println!("cargo:rustc-link-search=native={}", out_dir.display());
+
+    // Also output a bogus linked path that doesn't exist on disk.
+    println!(
+        "cargo:rustc-link-search=native={}",
+        out_dir.parent().unwrap().join("does-not-exist").display()
+    );
 }
 
 // https://github.com/rust-lang/cargo/blob/5e09899f33744efafb99af7023acfd0a14af1c2f/tests/testsuite/build.rs#L4717-L4727

--- a/nextest-runner/src/reuse_build/archiver.rs
+++ b/nextest-runner/src/reuse_build/archiver.rs
@@ -87,7 +87,7 @@ where
             Ok(file_count)
         })
         .map_err(|err| match err {
-            atomicwrites::Error::Internal(err) => ArchiveCreateError::OutputFileIo(err),
+            atomicwrites::Error::Internal(err) => ArchiveCreateError::OutputArchiveIo(err),
             atomicwrites::Error::User(err) => err,
         })?;
 
@@ -125,13 +125,13 @@ impl<'a, W: Write> Archiver<'a, W> {
         let builder = match format {
             ArchiveFormat::TarZst => {
                 let mut encoder = zstd::Encoder::new(buf_writer, compression_level)
-                    .map_err(ArchiveCreateError::OutputFileIo)?;
+                    .map_err(ArchiveCreateError::OutputArchiveIo)?;
                 encoder
                     .include_checksum(true)
-                    .map_err(ArchiveCreateError::OutputFileIo)?;
+                    .map_err(ArchiveCreateError::OutputArchiveIo)?;
                 encoder
                     .multithread(num_cpus::get() as u32)
-                    .map_err(ArchiveCreateError::OutputFileIo)?;
+                    .map_err(ArchiveCreateError::OutputArchiveIo)?;
                 tar::Builder::new(encoder)
             }
         };
@@ -158,9 +158,9 @@ impl<'a, W: Write> Archiver<'a, W> {
             .to_string(OutputFormat::Serializable(SerializableFormat::JsonPretty))
             .map_err(ArchiveCreateError::CreateBinaryList)?;
 
-        self.add_file(BINARIES_METADATA_FILE_NAME, &binaries_metadata)?;
+        self.append_from_memory(BINARIES_METADATA_FILE_NAME, &binaries_metadata)?;
 
-        self.add_file(CARGO_METADATA_FILE_NAME, self.cargo_metadata)?;
+        self.append_from_memory(CARGO_METADATA_FILE_NAME, self.cargo_metadata)?;
 
         // Write all discovered binaries into the archive.
         let target_dir = &self.binary_list.rust_build_meta.target_directory;
@@ -171,9 +171,8 @@ impl<'a, W: Write> Archiver<'a, W> {
                 .strip_prefix(target_dir.parent().expect("target dir cannot be the root"))
                 .expect("binary paths must be within target directory");
             let rel_path = convert_rel_path_to_forward_slash(rel_path);
-            self.builder
-                .append_path_with_name(&binary.path, &rel_path)
-                .map_err(ArchiveCreateError::OutputFileIo)?;
+
+            self.append_path(&binary.path, &rel_path)?;
             self.file_count += 1;
         }
         for non_test_binary in self
@@ -193,9 +192,7 @@ impl<'a, W: Write> Archiver<'a, W> {
             let rel_path = Utf8Path::new("target").join(&non_test_binary.path);
             let rel_path = convert_rel_path_to_forward_slash(&rel_path);
 
-            self.builder
-                .append_path_with_name(&src_path, &rel_path)
-                .map_err(ArchiveCreateError::OutputFileIo)?;
+            self.append_path(&src_path, &rel_path)?;
             self.file_count += 1;
         }
 
@@ -211,8 +208,7 @@ impl<'a, W: Write> Archiver<'a, W> {
 
             let rel_path = Utf8Path::new("target").join(linked_path);
             let rel_path = convert_rel_path_to_forward_slash(&rel_path);
-            self.append_dir_all(&rel_path, &src_path, true)
-                .map_err(ArchiveCreateError::OutputFileIo)?;
+            self.append_dir_all(&rel_path, &src_path, true)?;
         }
 
         // TODO: add extra files.
@@ -221,12 +217,14 @@ impl<'a, W: Write> Archiver<'a, W> {
         let encoder = self
             .builder
             .into_inner()
-            .map_err(ArchiveCreateError::OutputFileIo)?;
+            .map_err(ArchiveCreateError::OutputArchiveIo)?;
         // Finish writing the zstd stream.
-        let buf_writer = encoder.finish().map_err(ArchiveCreateError::OutputFileIo)?;
+        let buf_writer = encoder
+            .finish()
+            .map_err(ArchiveCreateError::OutputArchiveIo)?;
         let writer = buf_writer
             .into_inner()
-            .map_err(|err| ArchiveCreateError::OutputFileIo(err.into_error()))?;
+            .map_err(|err| ArchiveCreateError::OutputArchiveIo(err.into_error()))?;
 
         Ok((writer, self.file_count))
     }
@@ -235,7 +233,7 @@ impl<'a, W: Write> Archiver<'a, W> {
     // Helper methods
     // ---
 
-    fn add_file(&mut self, name: &str, contents: &str) -> Result<(), ArchiveCreateError> {
+    fn append_from_memory(&mut self, name: &str, contents: &str) -> Result<(), ArchiveCreateError> {
         let mut header = tar::Header::new_gnu();
         header.set_size(contents.len() as u64);
         header.set_mtime(self.unix_timestamp);
@@ -244,42 +242,70 @@ impl<'a, W: Write> Archiver<'a, W> {
 
         self.builder
             .append_data(&mut header, name, io::Cursor::new(contents))
-            .map_err(ArchiveCreateError::OutputFileIo)?;
+            .map_err(ArchiveCreateError::OutputArchiveIo)?;
         self.file_count += 1;
         Ok(())
     }
 
-    // Adapted from tar-rs's source, with tracking for file counts.
+    // Adapted from tar-rs's source, with tracking for file counts and better error messages.
     fn append_dir_all(
         &mut self,
         rel_path: &Utf8Path,
         src_path: &Utf8Path,
         follow: bool,
-    ) -> io::Result<()> {
+    ) -> Result<(), ArchiveCreateError> {
         let mut stack = vec![(src_path.to_path_buf(), true, false)];
 
         while let Some((src, is_dir, is_symlink)) = stack.pop() {
             let dest = rel_path.join(src.strip_prefix(&src_path).unwrap());
             // In case of a symlink pointing to a directory, is_dir is false, but src.is_dir() will return true
             if is_dir || (is_symlink && follow && src.is_dir()) {
-                for entry in src.read_dir_utf8()? {
-                    let entry = entry?;
-                    let file_type = entry.file_type()?;
+                for entry in
+                    src.read_dir_utf8()
+                        .map_err(|error| ArchiveCreateError::InputFileRead {
+                            path: src.clone(),
+                            is_dir: Some(true),
+                            error,
+                        })?
+                {
+                    let entry = entry.map_err(|error| ArchiveCreateError::DirEntryRead {
+                        path: src.clone(),
+                        error,
+                    })?;
+                    let file_name = entry.path();
+                    let file_type =
+                        entry
+                            .file_type()
+                            .map_err(|error| ArchiveCreateError::InputFileRead {
+                                path: file_name.to_owned(),
+                                is_dir: None,
+                                error,
+                            })?;
                     stack.push((
                         entry.path().to_path_buf(),
                         file_type.is_dir(),
                         file_type.is_symlink(),
                     ));
                 }
-                if dest != "" {
-                    self.builder.append_dir(&dest, src)?;
-                }
+                // No need to append the directory entry to the tarball since we don't care about
+                // its metadata.
             } else {
-                self.builder.append_path_with_name(src, &dest)?;
+                self.append_path(&src, &dest)?;
             }
-            self.file_count += 1;
         }
 
+        Ok(())
+    }
+
+    fn append_path(&mut self, src: &Utf8Path, dest: &Utf8Path) -> Result<(), ArchiveCreateError> {
+        self.builder
+            .append_path_with_name(src, dest)
+            .map_err(|error| ArchiveCreateError::InputFileRead {
+                path: src.to_owned(),
+                is_dir: Some(false),
+                error,
+            })?;
+        self.file_count += 1;
         Ok(())
     }
 }


### PR DESCRIPTION
This is a bit annoying: some libraries like grpcio-sys 1.1.8 produce
paths that don't exist. Ignore them.

Closes #247.