### PR TITLE
[nextest-runner] add the ability to print out status lines at the end of a test run

### DIFF
--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -525,6 +525,15 @@ struct TestReporterOpts {
         env = "NEXTEST_STATUS_LEVEL",
     )]
     status_level: Option<StatusLevel>,
+
+    /// Test statuses to output at the end of the run.
+    #[clap(
+        long,
+        possible_values = StatusLevel::variants(),
+        value_name = "LEVEL",
+        env = "NEXTEST_FINAL_STATUS_LEVEL",
+    )]
+    final_status_level: Option<StatusLevel>,
 }
 
 impl TestReporterOpts {
@@ -539,6 +548,9 @@ impl TestReporterOpts {
         }
         if let Some(status_level) = self.status_level {
             builder.set_status_level(status_level);
+        }
+        if let Some(final_status_level) = self.final_status_level {
+            builder.set_final_status_level(final_status_level);
         }
         builder
     }

--- a/nextest-runner/default-config.toml
+++ b/nextest-runner/default-config.toml
@@ -31,7 +31,10 @@ retries = 0
 # Can be overridden through the `--status-level` flag.
 status-level = "pass"
 
-# "failure-output" defines when test failures are output to standard output.
+# Similar to status-level, show these test statuses at the end of the run.
+final-status-level = "none"
+
+# "failure-output" defines when standard output and standard error for failing tests are produced.
 # Accepted values are
 # * "immediate": output failures as soon as they happen
 # * "final": output failures at the end of the test run
@@ -44,8 +47,8 @@ status-level = "pass"
 # Can be overridden through the `--failure-output` option.
 failure-output = "immediate"
 
-# "success-output" controls output on success. This should generally be set to
-# "never".
+# "success-output" controls production of standard output and standard error on success. This should
+# generally be set to "never".
 success-output = "never"
 
 # Cancel the test run on the first failure. For CI runs, consider setting this

--- a/nextest-runner/src/config.rs
+++ b/nextest-runner/src/config.rs
@@ -173,6 +173,13 @@ impl<'cfg> NextestProfile<'cfg> {
             .unwrap_or(self.default_profile.status_level)
     }
 
+    /// Returns the test status level at the end of the run.
+    pub fn final_status_level(&self) -> StatusLevel {
+        self.custom_profile
+            .and_then(|profile| profile.final_status_level)
+            .unwrap_or(self.default_profile.final_status_level)
+    }
+
     /// Returns the failure output config for this profile.
     pub fn failure_output(&self) -> TestOutputDisplay {
         self.custom_profile
@@ -280,6 +287,7 @@ impl NextestProfilesImpl {
 struct DefaultProfileImpl {
     retries: usize,
     status_level: StatusLevel,
+    final_status_level: StatusLevel,
     failure_output: TestOutputDisplay,
     success_output: TestOutputDisplay,
     fail_fast: bool,
@@ -303,6 +311,8 @@ struct CustomProfileImpl {
     retries: Option<usize>,
     #[serde(default)]
     status_level: Option<StatusLevel>,
+    #[serde(default)]
+    final_status_level: Option<StatusLevel>,
     #[serde(default)]
     failure_output: Option<TestOutputDisplay>,
     #[serde(default)]

--- a/nextest-runner/src/reporter.rs
+++ b/nextest-runner/src/reporter.rs
@@ -262,7 +262,6 @@ impl TestReporterBuilder {
 
         let stderr = match output {
             ReporterStderr::Terminal => {
-                // TODO: customize progress bar
                 let progress_bar = ProgressBar::new(test_list.test_count() as u64);
                 // Emulate Cargo's style.
                 let test_count_width = format!("{}", test_list.test_count()).len();

--- a/nextest-runner/src/reporter.rs
+++ b/nextest-runner/src/reporter.rs
@@ -553,7 +553,7 @@ impl<'a> TestReporterImpl<'a> {
                         "only failing tests are retried"
                     );
                     if self.failure_output.is_immediate() {
-                        self.write_run_status(test_instance, run_status, true, &mut writer)?;
+                        self.write_stdout_stderr(test_instance, run_status, true, &mut writer)?;
                     }
 
                     // The final output doesn't show retries.
@@ -620,7 +620,12 @@ impl<'a> TestReporterImpl<'a> {
                             false => self.failure_output,
                         };
                         if test_output_display.is_immediate() {
-                            self.write_run_status(test_instance, last_status, false, &mut writer)?;
+                            self.write_stdout_stderr(
+                                test_instance,
+                                last_status,
+                                false,
+                                &mut writer,
+                            )?;
                         }
                         if test_output_display.is_final() {
                             self.final_outputs
@@ -702,7 +707,7 @@ impl<'a> TestReporterImpl<'a> {
                     && self.cancel_status < Some(CancelReason::Signal)
                 {
                     for (test_instance, run_status) in &*self.final_outputs {
-                        self.write_run_status(test_instance, run_status, false, &mut writer)?;
+                        self.write_stdout_stderr(test_instance, run_status, false, &mut writer)?;
                     }
                 }
             }
@@ -742,7 +747,7 @@ impl<'a> TestReporterImpl<'a> {
         write!(writer, "[>{:>7.3?}s] ", duration.as_secs_f64())
     }
 
-    fn write_run_status(
+    fn write_stdout_stderr(
         &self,
         test_instance: &TestInstance<'a>,
         run_status: &ExecuteStatus,

--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -466,6 +466,7 @@ impl ExecutionStatuses {
 /// A description of test executions obtained from `ExecuteStatuses`.
 ///
 /// This can be used to quickly determine whether a test passed, failed or was flaky.
+#[derive(Copy, Clone, Debug)]
 pub enum ExecutionDescription<'a> {
     /// The test was run once and was successful.
     Success {
@@ -502,8 +503,20 @@ impl<'a> ExecutionDescription<'a> {
     pub fn status_level(&self) -> StatusLevel {
         match self {
             ExecutionDescription::Success { .. } => StatusLevel::Pass,
+            // A flaky test implies that we print out retry information for it.
             ExecutionDescription::Flaky { .. } => StatusLevel::Retry,
             ExecutionDescription::Failure { .. } => StatusLevel::Fail,
+        }
+    }
+
+    /// Returns the last run status.
+    pub fn last_status(&self) -> &'a ExecuteStatus {
+        match self {
+            ExecutionDescription::Success {
+                single_status: last_status,
+            }
+            | ExecutionDescription::Flaky { last_status, .. }
+            | ExecutionDescription::Failure { last_status, .. } => last_status,
         }
     }
 }


### PR DESCRIPTION
This is useful as an intermediate step between printing nothing and full
stdout/stderr.

Closes #255.