### PR TITLE
some improvements to the nextest reporter

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,7 @@
 [profile.ci]
 # Don't fail fast in CI to run the full test suite.
 fail-fast = false
+
+[profile.test-slow]
+# This is a test profile with a quick slow timeout.
+slow-timeout = "1s"

--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -506,8 +506,8 @@ struct TestReporterOpts {
         env = "NEXTEST_FAILURE_OUTPUT",
     )]
     failure_output: Option<TestOutputDisplay>,
-    /// Output stdout and stderr on success
 
+    /// Output stdout and stderr on success
     #[clap(
         long,
         possible_values = TestOutputDisplay::variants(),

--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -19,7 +19,7 @@ use nextest_runner::{
     config::{NextestConfig, NextestProfile},
     list::{BinaryList, OutputFormat, RustTestArtifact, SerializableFormat, TestList},
     partition::PartitionerBuilder,
-    reporter::{StatusLevel, TestOutputDisplay, TestReporterBuilder},
+    reporter::{FinalStatusLevel, StatusLevel, TestOutputDisplay, TestReporterBuilder},
     reuse_build::{archive_to_file, ArchiveReporter, MetadataOrPath, PathMapper, ReuseBuildInfo},
     runner::TestRunnerBuilder,
     signal::SignalHandler,
@@ -530,11 +530,11 @@ struct TestReporterOpts {
     /// Test statuses to output at the end of the run.
     #[clap(
         long,
-        possible_values = StatusLevel::variants(),
+        possible_values = FinalStatusLevel::variants(),
         value_name = "LEVEL",
         env = "NEXTEST_FINAL_STATUS_LEVEL",
     )]
-    final_status_level: Option<StatusLevel>,
+    final_status_level: Option<FinalStatusLevel>,
 }
 
 impl TestReporterOpts {

--- a/nextest-runner/src/config.rs
+++ b/nextest-runner/src/config.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     errors::{ConfigParseError, ProfileNotFound},
-    reporter::{StatusLevel, TestOutputDisplay},
+    reporter::{FinalStatusLevel, StatusLevel, TestOutputDisplay},
 };
 use camino::{Utf8Path, Utf8PathBuf};
 use config::{builder::DefaultState, Config, ConfigBuilder, File, FileFormat};
@@ -174,7 +174,7 @@ impl<'cfg> NextestProfile<'cfg> {
     }
 
     /// Returns the test status level at the end of the run.
-    pub fn final_status_level(&self) -> StatusLevel {
+    pub fn final_status_level(&self) -> FinalStatusLevel {
         self.custom_profile
             .and_then(|profile| profile.final_status_level)
             .unwrap_or(self.default_profile.final_status_level)
@@ -287,7 +287,7 @@ impl NextestProfilesImpl {
 struct DefaultProfileImpl {
     retries: usize,
     status_level: StatusLevel,
-    final_status_level: StatusLevel,
+    final_status_level: FinalStatusLevel,
     failure_output: TestOutputDisplay,
     success_output: TestOutputDisplay,
     fail_fast: bool,
@@ -376,7 +376,7 @@ struct CustomProfileImpl {
     #[serde(default)]
     status_level: Option<StatusLevel>,
     #[serde(default)]
-    final_status_level: Option<StatusLevel>,
+    final_status_level: Option<FinalStatusLevel>,
     #[serde(default)]
     failure_output: Option<TestOutputDisplay>,
     #[serde(default)]

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     helpers::dylib_path_envvar,
-    reporter::{StatusLevel, TestOutputDisplay},
+    reporter::{FinalStatusLevel, StatusLevel, TestOutputDisplay},
     reuse_build::ArchiveFormat,
     target_runner::PlatformRunnerSource,
     test_filter::RunIgnored,
@@ -86,6 +86,24 @@ pub struct StatusLevelParseError {
 }
 
 impl StatusLevelParseError {
+    pub(crate) fn new(input: impl Into<String>) -> Self {
+        Self {
+            input: input.into(),
+        }
+    }
+}
+
+/// Error returned while parsing a [`FinalStatusLevel`] value from a string.
+#[derive(Clone, Debug, Error)]
+#[error(
+    "unrecognized value for final-status-level: {input}\n(known values: {})",
+    FinalStatusLevel::variants().join(", "),
+)]
+pub struct FinalStatusLevelParseError {
+    input: String,
+}
+
+impl FinalStatusLevelParseError {
     pub(crate) fn new(input: impl Into<String>) -> Self {
         Self {
             input: input.into(),

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     helpers::dylib_path_envvar,
-    reporter::{FinalStatusLevel, StatusLevel, TestOutputDisplay},
+    reporter::{StatusLevel, TestOutputDisplay},
     reuse_build::ArchiveFormat,
     target_runner::PlatformRunnerSource,
     test_filter::RunIgnored,
@@ -86,24 +86,6 @@ pub struct StatusLevelParseError {
 }
 
 impl StatusLevelParseError {
-    pub(crate) fn new(input: impl Into<String>) -> Self {
-        Self {
-            input: input.into(),
-        }
-    }
-}
-
-/// Error returned while parsing a [`FinalStatusLevel`] value from a string.
-#[derive(Clone, Debug, Error)]
-#[error(
-    "unrecognized value for final-status-level: {input}\n(known values: {})",
-    FinalStatusLevel::variants().join(", "),
-)]
-pub struct FinalStatusLevelParseError {
-    input: String,
-}
-
-impl FinalStatusLevelParseError {
     pub(crate) fn new(input: impl Into<String>) -> Self {
         Self {
             input: input.into(),

--- a/nextest-runner/src/list/test_list.rs
+++ b/nextest-runner/src/list/test_list.rs
@@ -660,6 +660,12 @@ impl<'a> TestInstance<'a> {
         }
     }
 
+    /// Return a reasonable key for sorting. This is (binary ID, test name).
+    #[inline]
+    pub(crate) fn sort_key(&self) -> (&'a str, &'a str) {
+        (&self.bin_info.binary_id, self.name)
+    }
+
     /// Creates the command expression for this test instance.
     pub(crate) fn make_expression(
         &self,

--- a/nextest-runner/src/reporter.rs
+++ b/nextest-runner/src/reporter.rs
@@ -786,6 +786,10 @@ impl<'a> TestReporterImpl<'a> {
 
                 // Don't print out final outputs if canceled due to Ctrl-C.
                 if self.cancel_status < Some(CancelReason::Signal) {
+                    // Sort the final outputs for a friendlier experience.
+                    self.final_outputs
+                        .sort_by_key(|(test_instance, _)| test_instance.sort_key());
+
                     for (test_instance, run_statuses) in &*self.final_outputs {
                         let last_status = run_statuses.last_status();
                         let test_output_display = match last_status.result.is_success() {

--- a/nextest-runner/src/reporter.rs
+++ b/nextest-runner/src/reporter.rs
@@ -762,7 +762,11 @@ impl<'a> TestReporterImpl<'a> {
                 } else {
                     self.styles.pass
                 };
-                write!(writer, "{:>12} ", "Summary".style(summary_style))?;
+                write!(
+                    writer,
+                    "------------\n{:>12} ",
+                    "Summary".style(summary_style)
+                )?;
 
                 // Next, print the total time taken.
                 // * > means right-align.

--- a/nextest-runner/src/reporter.rs
+++ b/nextest-runner/src/reporter.rs
@@ -9,10 +9,7 @@ mod aggregator;
 
 use crate::{
     config::NextestProfile,
-    errors::{
-        FinalStatusLevelParseError, StatusLevelParseError, TestOutputDisplayParseError,
-        WriteEventError,
-    },
+    errors::{StatusLevelParseError, TestOutputDisplayParseError, WriteEventError},
     helpers::write_test_name,
     list::{TestInstance, TestList},
     reporter::aggregator::EventAggregator,
@@ -200,48 +197,6 @@ pub enum FinalStatusLevel {
 
     /// Currently has the same meaning as [`Pass`](Self::Pass).
     All,
-}
-
-impl FinalStatusLevel {
-    /// Returns string representations of all known variants.
-    pub fn variants() -> &'static [&'static str] {
-        &[
-            // (flaky is the same as retry)
-            "none", "fail", "flaky", "retry", "slow", "skip", "pass", "all",
-        ]
-    }
-}
-
-impl FromStr for FinalStatusLevel {
-    type Err = FinalStatusLevelParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let val = match s {
-            "none" => FinalStatusLevel::None,
-            "fail" => FinalStatusLevel::Fail,
-            "flaky" | "retry" => FinalStatusLevel::Flaky,
-            "slow" => FinalStatusLevel::Slow,
-            "skip" => FinalStatusLevel::Skip,
-            "pass" => FinalStatusLevel::Pass,
-            "all" => FinalStatusLevel::All,
-            other => return Err(FinalStatusLevelParseError::new(other)),
-        };
-        Ok(val)
-    }
-}
-
-impl fmt::Display for FinalStatusLevel {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            FinalStatusLevel::None => write!(f, "none"),
-            FinalStatusLevel::Fail => write!(f, "fail"),
-            FinalStatusLevel::Flaky => write!(f, "flaky"),
-            FinalStatusLevel::Slow => write!(f, "slow"),
-            FinalStatusLevel::Skip => write!(f, "skip"),
-            FinalStatusLevel::Pass => write!(f, "pass"),
-            FinalStatusLevel::All => write!(f, "all"),
-        }
-    }
 }
 
 /// Standard error destination for the reporter.

--- a/nextest-runner/src/stopwatch.rs
+++ b/nextest-runner/src/stopwatch.rs
@@ -26,11 +26,6 @@ impl StopwatchStart {
         }
     }
 
-    #[inline]
-    pub(crate) fn elapsed(&self) -> Duration {
-        self.instant.elapsed()
-    }
-
     pub(crate) fn end(&self) -> StopwatchEnd {
         StopwatchEnd {
             start_time: self.start_time,


### PR DESCRIPTION
* Improve the `final-status-level` option by reordering it slightly (skip is prioritized over pass) and printing out slow and flaky tests clearly.
* produce round numbers for SLOW lines
* add a separator line before the `Summary` line.

Closes #270.