### PR TITLE
[nextest-runner] add detection for signals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,6 +1075,7 @@ dependencies = [
  "atomicwrites",
  "camino",
  "cargo_metadata",
+ "cfg-if",
  "chrono",
  "color-eyre",
  "config",

--- a/cargo-nextest/src/tests_integration/fixtures.rs
+++ b/cargo-nextest/src/tests_integration/fixtures.rs
@@ -90,6 +90,11 @@ pub static EXPECTED_LIST: Lazy<Vec<TestInfo>> = Lazy::new(|| {
             vec![("other_test_success", false)],
         ),
         TestInfo::new(
+            "nextest-tests::segfault",
+            BuildPlatform::Target,
+            vec![("test_segfault", false)],
+        ),
+        TestInfo::new(
             "nextest-tests::bin/other",
             BuildPlatform::Target,
             vec![("tests::other_bin_success", false)],
@@ -245,7 +250,7 @@ fn make_check_result_regex(result: bool, name: &str) -> Regex {
     if result {
         Regex::new(&format!(r"PASS \[.*\] *{}", name)).unwrap()
     } else {
-        Regex::new(&format!(r"FAIL \[.*\] *{}", name)).unwrap()
+        Regex::new(&format!(r"(FAIL|SIGSEGV) \[.*\] *{}", name)).unwrap()
     }
 }
 
@@ -286,6 +291,7 @@ pub fn check_run_output(stderr: &[u8], relocated: bool) {
         ),
         (true, "nextest-tests::other other_test_success"),
         (true, "nextest-tests::basic test_success"),
+        (false, "nextest-tests::segfault test_segfault"),
         (true, "nextest-derive::proc-macro/nextest-derive it_works"),
         (
             true,
@@ -300,9 +306,9 @@ pub fn check_run_output(stderr: &[u8], relocated: bool) {
     }
 
     let summary_reg = if relocated {
-        Regex::new(r"Summary \[.*\] *21 tests run: 15 passed, 6 failed, 3 skipped").unwrap()
+        Regex::new(r"Summary \[.*\] *22 tests run: 15 passed, 7 failed, 3 skipped").unwrap()
     } else {
-        Regex::new(r"Summary \[.*\] *21 tests run: 16 passed, 5 failed, 3 skipped").unwrap()
+        Regex::new(r"Summary \[.*\] *22 tests run: 16 passed, 6 failed, 3 skipped").unwrap()
     };
     assert!(
         summary_reg.is_match(&output),

--- a/fixtures/nextest-tests/tests/segfault.rs
+++ b/fixtures/nextest-tests/tests/segfault.rs
@@ -1,0 +1,9 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#[test]
+fn test_segfault() {
+    println!("going to perform a segfault shortly");
+    let p: *mut i32 = std::ptr::null::<i32>() as *mut i32;
+    unsafe { *p = 42 };
+}

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -15,6 +15,7 @@ aho-corasick = "0.7.18"
 camino = { version = "1.0.9", features = ["serde1"] }
 config = { version = "0.13.1", default-features = false, features = ["toml"] }
 cargo_metadata = "0.14.2"
+cfg-if = "1.0.0"
 chrono = "0.4.19"
 crossbeam-channel = "0.5.4"
 ctrlc = { version = "3.2.2", features = ["termination"] }

--- a/nextest-runner/tests/integration/basic.rs
+++ b/nextest-runner/tests/integration/basic.rs
@@ -297,7 +297,7 @@ fn test_retries() -> Result<()> {
                     let expected_len = match fixture.status {
                         FixtureStatus::Flaky { pass_attempt } => pass_attempt,
                         FixtureStatus::Pass => 1,
-                        FixtureStatus::Fail => retries + 1,
+                        FixtureStatus::Fail | FixtureStatus::Segfault => retries + 1,
                         FixtureStatus::IgnoredPass | FixtureStatus::IgnoredFail => {
                             unreachable!("ignored tests should be skipped")
                         }
@@ -324,9 +324,8 @@ fn test_retries() -> Result<()> {
                                 "correct length for prior statuses"
                             );
                             for prior_status in prior_statuses {
-                                assert_eq!(
-                                    prior_status.result,
-                                    ExecutionResult::Fail,
+                                assert!(
+                                    matches!(prior_status.result, ExecutionResult::Fail { .. }),
                                     "prior status {} should be fail",
                                     prior_status.attempt
                                 );
@@ -344,14 +343,13 @@ fn test_retries() -> Result<()> {
                                 "correct length for retries"
                             );
                             for retry in retries {
-                                assert_eq!(
-                                    retry.result,
-                                    ExecutionResult::Fail,
+                                assert!(
+                                    matches!(retry.result, ExecutionResult::Fail { .. }),
                                     "retry {} should be fail",
                                     retry.attempt
                                 );
                             }
-                            first_status.result == ExecutionResult::Fail
+                            matches!(first_status.result, ExecutionResult::Fail { .. })
                         }
                     }
                 }


### PR DESCRIPTION
Print out these lines as "ABRT SIG N" where N is the signal received.
Also recognize common signals SIGINT and SIGSEGV.

Closes #281.