### PR TITLE
[fixtures] add a #[bench] fixture

### DIFF
--- a/cargo-nextest/src/tests_integration/fixtures.rs
+++ b/cargo-nextest/src/tests_integration/fixtures.rs
@@ -69,7 +69,7 @@ pub static EXPECTED_LIST: Lazy<Vec<TestInfo>> = Lazy::new(|| {
         TestInfo::new(
             "nextest-tests::bench/my-bench",
             BuildPlatform::Target,
-            vec![("tests::test_execute_bin", false)],
+            vec![("bench_add_two", false), ("tests::test_execute_bin", false)],
         ),
         TestInfo::new(
             "nextest-tests::bin/nextest-tests",
@@ -128,6 +128,9 @@ pub(super) fn set_env_vars() {
     // output.
     // TODO: remove this once programmatic run statuses are supported.
     std::env::set_var("CARGO_TERM_COLOR", "never");
+    // This environment variable is required to test the #[bench] fixture. Note that THIS IS FOR
+    // TEST CODE ONLY. NEVER USE THIS IN PRODUCTION.
+    std::env::set_var("RUSTC_BOOTSTRAP", "1");
 }
 
 #[track_caller]
@@ -270,6 +273,7 @@ pub fn check_run_output(stderr: &[u8], relocated: bool) {
         (true, "cdylib-example tests::test_multiply_two_cdylib"),
         (true, "nextest-tests::basic test_cargo_env_vars"),
         (true, "nextest-tests::basic test_execute_bin"),
+        (true, "nextest-tests::bench/my-bench bench_add_two"),
         (
             true,
             "nextest-tests::bench/my-bench tests::test_execute_bin",
@@ -306,9 +310,9 @@ pub fn check_run_output(stderr: &[u8], relocated: bool) {
     }
 
     let summary_reg = if relocated {
-        Regex::new(r"Summary \[.*\] *22 tests run: 15 passed, 7 failed, 3 skipped").unwrap()
+        Regex::new(r"Summary \[.*\] *23 tests run: 16 passed, 7 failed, 3 skipped").unwrap()
     } else {
-        Regex::new(r"Summary \[.*\] *22 tests run: 16 passed, 6 failed, 3 skipped").unwrap()
+        Regex::new(r"Summary \[.*\] *23 tests run: 17 passed, 6 failed, 3 skipped").unwrap()
     };
     assert!(
         summary_reg.is_match(&output),

--- a/fixtures/nextest-tests/benches/my-bench.rs
+++ b/fixtures/nextest-tests/benches/my-bench.rs
@@ -1,7 +1,15 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+#![feature(test)]
+
+extern crate test;
+
 // TODO: add benchmarks
+#[bench]
+fn bench_add_two(b: &mut test::Bencher) {
+    b.iter(|| 2 + 2);
+}
 
 #[cfg(test)]
 mod tests {

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -128,6 +128,7 @@ pub(crate) static EXPECTED_TESTS: Lazy<BTreeMap<&'static str, Vec<TestFixture>>>
             ],
             // Benchmarks
             "nextest-tests::bench/my-bench" => vec![
+                TestFixture { name: "bench_add_two", status: FixtureStatus::Pass },
                 TestFixture { name: "tests::test_execute_bin", status: FixtureStatus::Pass },
             ],
             // Proc-macro tests
@@ -194,7 +195,7 @@ pub(crate) static FIXTURE_RAW_CARGO_TEST_OUTPUT: Lazy<Vec<u8>> =
     Lazy::new(init_fixture_raw_cargo_test_output);
 
 fn init_fixture_raw_cargo_test_output() -> Vec<u8> {
-    // TODO: actually productionize this, probably requires moving x into this repo
+    // This is a simple version of what cargo does.
     let cmd_name = match env::var("CARGO") {
         Ok(v) => v,
         Err(env::VarError::NotPresent) => "cargo".to_owned(),
@@ -210,6 +211,9 @@ fn init_fixture_raw_cargo_test_output() -> Vec<u8> {
         "json-render-diagnostics",
         "--all-targets",
     )
+    // This environment variable is required to test the #[bench] fixture. Note that THIS IS FOR
+    // TEST CODE ONLY. NEVER USE THIS IN PRODUCTION.
+    .env("RUSTC_BOOTSTRAP", "1")
     .dir(workspace_root())
     .stdout_capture();
 


### PR DESCRIPTION
Test out the new capability to test benchmarks, added in #283.

RUSTC_BOOTSTRAP is required to test this out, but we're not using it in
any production code.