### PR TITLE
[cargo-nextest] make all returned errors ExpectedError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "supports-color",
  "supports-unicode",
  "tempfile",
+ "thiserror",
 ]
 
 [[package]]

--- a/cargo-nextest/Cargo.toml
+++ b/cargo-nextest/Cargo.toml
@@ -37,6 +37,7 @@ shell-words = "1.1.0"
 supports-color = "1.3.0"
 supports-unicode = "1.0.2"
 serde_json = "1.0.81"
+thiserror = "1.0.31"
 nextest-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]

--- a/cargo-nextest/src/main.rs
+++ b/cargo-nextest/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use cargo_nextest::{CargoNextestApp, ExpectedError, OutputWriter};
+use cargo_nextest::{CargoNextestApp, OutputWriter};
 use clap::Parser;
 use color_eyre::Result;
 
@@ -12,10 +12,9 @@ fn main() -> Result<()> {
     let opts = CargoNextestApp::parse();
     match opts.exec(&mut OutputWriter::default()) {
         Ok(code) => std::process::exit(code),
-        Err(err) => {
-            let expected_error: ExpectedError = err.downcast()?;
-            expected_error.display_to_stderr();
-            std::process::exit(expected_error.process_exit_code())
+        Err(error) => {
+            error.display_to_stderr();
+            std::process::exit(error.process_exit_code())
         }
     }
 }

--- a/cargo-nextest/src/reuse_build.rs
+++ b/cargo-nextest/src/reuse_build.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::{output::OutputContext, ExpectedError, OutputWriter};
+use crate::{output::OutputContext, ExpectedError, OutputWriter, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::{ArgEnum, Args};
 use guppy::graph::PackageGraph;
@@ -109,7 +109,7 @@ impl ReuseBuildOpts {
         &self,
         output: OutputContext,
         output_writer: &mut OutputWriter,
-    ) -> Result<ReuseBuildInfo, ExpectedError> {
+    ) -> Result<ReuseBuildInfo> {
         if let Some(archive_file) = &self.archive_file {
             let format = self.archive_format.to_archive_format(archive_file)?;
             // Process this archive.
@@ -170,10 +170,7 @@ pub(crate) enum ArchiveFormatOpt {
 }
 
 impl ArchiveFormatOpt {
-    pub(crate) fn to_archive_format(
-        self,
-        archive_file: &Utf8Path,
-    ) -> Result<ArchiveFormat, ExpectedError> {
+    pub(crate) fn to_archive_format(self, archive_file: &Utf8Path) -> Result<ArchiveFormat> {
         match self {
             Self::TarZst => Ok(ArchiveFormat::TarZst),
             Self::Auto => ArchiveFormat::autodetect(archive_file).map_err(|err| {
@@ -196,7 +193,7 @@ pub(crate) fn make_path_mapper(
     info: &ReuseBuildInfo,
     graph: &PackageGraph,
     orig_target_dir: &Utf8Path,
-) -> Result<PathMapper, ExpectedError> {
+) -> Result<PathMapper> {
     PathMapper::new(
         graph.workspace().root(),
         info.workspace_remap(),

--- a/cargo-nextest/src/tests_integration/mod.rs
+++ b/cargo-nextest/src/tests_integration/mod.rs
@@ -16,7 +16,6 @@
 use crate::{dispatch::CargoNextestApp, ExpectedError, OutputWriter};
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::StructOpt;
-use color_eyre::Report;
 use nextest_metadata::{BuildPlatform, TestListSummary};
 
 mod fixtures;
@@ -69,7 +68,7 @@ fn test_list_full() {
     ]);
 
     let mut output = OutputWriter::new_test();
-    args.exec(&mut output).map_err(print_error_chain).unwrap();
+    args.exec(&mut output).map_err(print_error).unwrap();
 
     check_list_full_output(output.stdout().unwrap(), None);
 }
@@ -263,7 +262,7 @@ fn test_run() {
 
     let mut output = OutputWriter::new_test();
     let err = args.exec(&mut output).unwrap_err();
-    assert_eq!("test run failed\n", err.to_string());
+    assert_eq!("test run failed", err.to_string());
 
     check_run_output(output.stderr().unwrap(), false);
 }
@@ -287,7 +286,7 @@ fn test_run_after_build() {
 
     let mut output = OutputWriter::new_test();
     let err = args.exec(&mut output).unwrap_err();
-    assert_eq!("test run failed\n", err.to_string());
+    assert_eq!("test run failed", err.to_string());
 
     check_run_output(output.stderr().unwrap(), false);
 }
@@ -348,7 +347,7 @@ fn test_relocated_run() {
 
     let mut output = OutputWriter::new_test();
     let err = args.exec(&mut output).unwrap_err();
-    assert_eq!("test run failed\n", err.to_string());
+    assert_eq!("test run failed", err.to_string());
 
     check_run_output(output.stderr().unwrap(), true);
 }
@@ -380,7 +379,7 @@ fn test_run_from_archive() {
     ]);
 
     let mut output = OutputWriter::new_test();
-    args.exec(&mut output).map_err(print_error_chain).unwrap();
+    args.exec(&mut output).map_err(print_error).unwrap();
 
     // Remove the old source and target directories to ensure that any tests that refer to files within
     // it fail.
@@ -401,22 +400,13 @@ fn test_run_from_archive() {
 
     let mut output = OutputWriter::new_test();
     let err = args.exec(&mut output).unwrap_err();
-    assert_eq!("test run failed\n", err.to_string());
+    assert_eq!("test run failed", err.to_string());
 
     check_run_output(output.stderr().unwrap(), true);
 }
 
 // Debugging helper to print out the full chain of errors for a report.
-fn print_error_chain(report: Report) -> Report {
-    match report.downcast_ref::<ExpectedError>() {
-        Some(err) => {
-            err.display_to_stderr();
-        }
-        None => {
-            for err in report.chain() {
-                println!("- {}", err);
-            }
-        }
-    };
-    report
+fn print_error(error: ExpectedError) -> ExpectedError {
+    error.display_to_stderr();
+    error
 }

--- a/nextest-metadata/src/exit_codes.rs
+++ b/nextest-metadata/src/exit_codes.rs
@@ -25,6 +25,9 @@ impl NextestExitCode {
     /// Creating a test list produced an error.
     pub const TEST_LIST_CREATION_FAILED: i32 = 104;
 
+    /// Writing data to stdout or stderr produced an error.
+    pub const WRITE_OUTPUT_ERROR: i32 = 110;
+
     /// Downloading an update resulted in an error.
     pub const UPDATE_ERROR: i32 = 90;
 

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -709,6 +709,11 @@ pub enum TargetRunnerError {
     ),
 }
 
+/// An error that occurred while setting up the signal handler.
+#[derive(Debug, Error)]
+#[error(transparent)]
+pub struct SignalHandlerSetupError(#[from] ctrlc::Error);
+
 #[cfg(feature = "self-update")]
 mod self_update_errors {
     use super::*;

--- a/nextest-runner/src/signal.rs
+++ b/nextest-runner/src/signal.rs
@@ -3,6 +3,7 @@
 
 //! Support for handling signals in nextest.
 
+use crate::errors::SignalHandlerSetupError;
 use crossbeam_channel::Receiver;
 
 /// A receiver that generates signals if ctrl-c is pressed.
@@ -19,7 +20,7 @@ impl SignalHandler {
     ///
     /// Errors if a signal handler has already been registered in this process. Only one signal
     /// handler can be registered for a process at any given time.
-    pub fn new() -> Result<Self, ctrlc::Error> {
+    pub fn new() -> Result<Self, SignalHandlerSetupError> {
         let (sender, receiver) = crossbeam_channel::unbounded();
         ctrlc::set_handler(move || {
             let _ = sender.send(SignalEvent::Interrupted);


### PR DESCRIPTION
This means that all non-panicking errors have a well-defined exit code.