### PR TITLE
[nextest-runner] heuristically extract description for JUnit output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,6 +1108,7 @@ dependencies = [
  "proptest-derive",
  "quick-junit",
  "rayon",
+ "regex",
  "self_update",
  "semver",
  "serde",

--- a/cargo-nextest/src/tests_integration/fixtures.rs
+++ b/cargo-nextest/src/tests_integration/fixtures.rs
@@ -56,6 +56,7 @@ pub static EXPECTED_LIST: Lazy<Vec<TestInfo>> = Lazy::new(|| {
                 ("test_flaky_mod_3", false),
                 ("test_ignored", true),
                 ("test_ignored_fail", true),
+                ("test_result_failure", false),
                 ("test_slow_timeout", true),
                 ("test_success", false),
                 ("test_success_should_panic", false),
@@ -285,6 +286,7 @@ pub fn check_run_output(stderr: &[u8], relocated: bool) {
         (true, "nextest-tests::bin/nextest-tests tests::bin_success"),
         (false, "nextest-tests::basic test_failure_should_panic"),
         (true, "nextest-tests::bin/other tests::other_bin_success"),
+        (false, "nextest-tests::basic test_result_failure"),
         (true, "nextest-tests::basic test_success_should_panic"),
         (false, "nextest-tests::basic test_failure_assert"),
         (false, "nextest-tests::basic test_flaky_mod_3"),
@@ -310,9 +312,9 @@ pub fn check_run_output(stderr: &[u8], relocated: bool) {
     }
 
     let summary_reg = if relocated {
-        Regex::new(r"Summary \[.*\] *23 tests run: 16 passed, 7 failed, 3 skipped").unwrap()
+        Regex::new(r"Summary \[.*\] *24 tests run: 16 passed, 8 failed, 3 skipped").unwrap()
     } else {
-        Regex::new(r"Summary \[.*\] *23 tests run: 17 passed, 6 failed, 3 skipped").unwrap()
+        Regex::new(r"Summary \[.*\] *24 tests run: 17 passed, 7 failed, 3 skipped").unwrap()
     };
     assert!(
         summary_reg.is_match(&output),

--- a/fixtures/nextest-tests/.config/nextest.toml
+++ b/fixtures/nextest-tests/.config/nextest.toml
@@ -9,3 +9,9 @@ retries = 2
 
 [profile.with-termination]
 slow-timeout = { period = "1s", terminate-after = 2 }
+
+[profile.with-junit]
+retries = 2
+
+[profile.with-junit.junit]
+path = "junit.xml"

--- a/fixtures/nextest-tests/tests/basic.rs
+++ b/fixtures/nextest-tests/tests/basic.rs
@@ -51,7 +51,7 @@ fn test_success_should_panic() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "this is a panic message")]
 fn test_failure_should_panic() {}
 
 #[test]
@@ -158,4 +158,12 @@ fn test_cargo_env_vars() {
 fn test_slow_timeout() {
     // The timeout for the with-termination profile is set to 2 seconds.
     std::thread::sleep(std::time::Duration::from_secs(4));
+}
+
+#[test]
+fn test_result_failure() -> Result<(), std::io::Error> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        "this is an error",
+    ))
 }

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -35,6 +35,7 @@ once_cell = "1.12.0"
 owo-colors = "3.4.0"
 num_cpus = "1.13.1"
 rayon = "1.5.3"
+regex = "1.5.6"
 semver = "1.0.10"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"

--- a/nextest-runner/src/reporter.rs
+++ b/nextest-runner/src/reporter.rs
@@ -6,6 +6,7 @@
 //! The main structure in this module is [`TestReporter`].
 
 mod aggregator;
+pub use aggregator::heuristic_extract_description;
 
 use crate::{
     config::NextestProfile,

--- a/nextest-runner/src/reporter/aggregator.rs
+++ b/nextest-runner/src/reporter/aggregator.rs
@@ -11,9 +11,12 @@ use crate::{
     runner::{ExecuteStatus, ExecutionDescription, ExecutionResult},
 };
 use camino::Utf8Path;
+use cfg_if::cfg_if;
 use chrono::{DateTime, FixedOffset, Utc};
 use debug_ignore::DebugIgnore;
+use once_cell::sync::Lazy;
 use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestRerun, TestSuite};
+use regex::{Regex, RegexBuilder};
 use std::{borrow::Cow, collections::HashMap, fs::File, time::SystemTime};
 
 #[derive(Clone, Debug)]
@@ -111,18 +114,23 @@ impl<'cfg> MetadataJunit<'cfg> {
 
                 for rerun in reruns {
                     let (kind, ty) = kind_ty(rerun);
+                    let stdout = String::from_utf8_lossy(rerun.stdout());
+                    let stderr = String::from_utf8_lossy(rerun.stderr());
+                    let stack_trace = heuristic_extract_description(rerun.result, &stdout, &stderr);
+
                     let mut test_rerun = TestRerun::new(kind);
+                    if let Some(description) = stack_trace {
+                        test_rerun.set_description(description);
+                    }
                     test_rerun
                         .set_timestamp(to_datetime(rerun.start_time))
                         .set_time(rerun.time_taken)
                         .set_type(ty)
-                        .set_system_out_lossy(rerun.stdout())
-                        .set_system_err_lossy(rerun.stderr());
+                        .set_system_out(stdout)
+                        .set_system_err(stderr);
                     // TODO: also publish time? it won't be standard JUnit (but maybe that's ok?)
                     testcase_status.add_rerun(test_rerun);
                 }
-
-                // TODO: set message/description on testcase_status?
 
                 let mut testcase = TestCase::new(test_instance.name, testcase_status);
                 testcase
@@ -136,7 +144,14 @@ impl<'cfg> MetadataJunit<'cfg> {
                 // https://github.com/allure-framework/allure2/blob/master/plugins/junit-xml-plugin/src/main/java/io/qameta/allure/junitxml/JunitXmlPlugin.java#L192-L196
                 // we may have to update this format to handle that.
                 if !main_status.result.is_success() {
-                    // TODO: use the Arc wrapper, don't clone the system out and system err bytes
+                    let stdout = String::from_utf8_lossy(main_status.stdout());
+                    let stderr = String::from_utf8_lossy(main_status.stderr());
+                    let description =
+                        heuristic_extract_description(main_status.result, &stdout, &stderr);
+                    if let Some(description) = description {
+                        testcase.status.set_description(description);
+                    }
+
                     testcase
                         .set_system_out_lossy(main_status.stdout())
                         .set_system_err_lossy(main_status.stderr());
@@ -203,4 +218,132 @@ fn to_datetime(system_time: SystemTime) -> DateTime<FixedOffset> {
     // Serialize using UTC.
     let datetime = DateTime::<Utc>::from(system_time);
     datetime.into()
+}
+
+// This regex works for the default panic handler for Rust -- other panic handlers may not work,
+// which is why this is heuristic.
+static PANICKED_AT_REGEX_STR: &str = "^thread '([^']+)' panicked at '";
+static PANICKED_AT_REGEX: Lazy<Regex> = Lazy::new(|| {
+    let mut builder = RegexBuilder::new(PANICKED_AT_REGEX_STR);
+    builder.multi_line(true);
+    builder.build().unwrap()
+});
+
+/// Not part of the public API: only used for testing.
+#[doc(hidden)]
+pub fn heuristic_extract_description<'a>(
+    exec_result: ExecutionResult,
+    stdout: &'a str,
+    stderr: &'a str,
+) -> Option<Cow<'a, str>> {
+    // If the test crashed with a signal, use that.
+    if let ExecutionResult::Fail {
+        signal: Some(signal),
+    } = exec_result
+    {
+        // TODO: Windows?
+        cfg_if! {
+            if #[cfg(unix)] {
+                let signal_str = match super::signal_str(signal) {
+                    Some(signal_str) => format!(" ({signal_str})"),
+                    None => String::new()
+                };
+            } else {
+                let signal_str = String::new();
+            }
+        }
+        return Some(format!("Test exited with signal {signal}{signal_str}").into());
+    }
+
+    // Try the heuristic stack trace extraction first as they're the more common kinds of test.
+    if let Some(description) = heuristic_stack_trace(stderr) {
+        return Some(description.into());
+    }
+    heuristic_should_panic(stdout).map(Cow::Borrowed)
+}
+
+fn heuristic_should_panic(stdout: &str) -> Option<&str> {
+    for line in stdout.lines() {
+        if line.contains("note: test did not panic as expected") {
+            return Some(line);
+        }
+    }
+    None
+}
+
+fn heuristic_stack_trace(stderr: &str) -> Option<&str> {
+    let panicked_at_match = PANICKED_AT_REGEX.find(stderr)?;
+    // If the previous line starts with "Error: ", grab it as well -- it contains the error with
+    // result-based test failures.
+    let mut start = panicked_at_match.start();
+    let prefix = stderr[..start].trim_end_matches('\n');
+    if let Some(prev_line_start) = prefix.rfind('\n') {
+        if prefix[prev_line_start..].starts_with("\nError:") {
+            start = prev_line_start + 1;
+        }
+    }
+
+    Some(stderr[start..].trim_end())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_heuristic_extract_description() {
+        let tests: &[(&str, &str)] = &[(
+            "running 1 test
+test test_failure_should_panic - should panic ... FAILED
+
+failures:
+
+---- test_failure_should_panic stdout ----
+note: test did not panic as expected
+
+failures:
+    test_failure_should_panic
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 13 filtered out; finished in 0.00s",
+            "note: test did not panic as expected",
+        )];
+
+        for (input, output) in tests {
+            assert_eq!(heuristic_should_panic(*input), Some(*output));
+        }
+    }
+
+    #[test]
+    fn test_heuristic_stack_trace() {
+        let tests: &[(&str, &str)] = &[
+            (
+                "thread 'main' panicked at 'foo', src/lib.rs:1\n",
+                "thread 'main' panicked at 'foo', src/lib.rs:1",
+            ),
+            (
+                "foobar\n\
+            thread 'main' panicked at 'foo', src/lib.rs:1\n\n",
+                "thread 'main' panicked at 'foo', src/lib.rs:1",
+            ),
+            (
+                r#"
+text: foo
+Error: Custom { kind: InvalidData, error: "this is an error" }
+thread 'test_result_failure' panicked at 'assertion failed: `(left == right)`
+  left: `1`,
+ right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/test/src/lib.rs:186:5
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+            "#,
+                r#"Error: Custom { kind: InvalidData, error: "this is an error" }
+thread 'test_result_failure' panicked at 'assertion failed: `(left == right)`
+  left: `1`,
+ right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/test/src/lib.rs:186:5
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace"#,
+            ),
+        ];
+
+        for (input, output) in tests {
+            assert_eq!(heuristic_stack_trace(*input), Some(*output));
+        }
+    }
 }

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -97,6 +97,7 @@ pub(crate) static EXPECTED_TESTS: Lazy<BTreeMap<&'static str, Vec<TestFixture>>>
                 TestFixture { name: "test_flaky_mod_3", status: FixtureStatus::Flaky { pass_attempt: 3 } },
                 TestFixture { name: "test_ignored", status: FixtureStatus::IgnoredPass },
                 TestFixture { name: "test_ignored_fail", status: FixtureStatus::IgnoredFail },
+                TestFixture { name: "test_result_failure", status: FixtureStatus::Fail },
                 TestFixture { name: "test_slow_timeout", status: FixtureStatus::IgnoredPass },
                 TestFixture { name: "test_success", status: FixtureStatus::Pass },
                 TestFixture { name: "test_success_should_panic", status: FixtureStatus::Pass },


### PR DESCRIPTION
In order:

1. The signal the test failed with, if any.
2. Stack trace from stderr.
3. "note: test did not panic as expected" from stdout.

Closes #311.