### PR TITLE
[nextest-runner] add support for test-threads config option

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,3 +5,6 @@ fail-fast = false
 [profile.test-slow]
 # This is a test profile with a quick slow timeout.
 slow-timeout = "1s"
+
+[profile.serial]
+test-threads = 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,6 +1118,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "shell-words",
  "strip-ansi-escapes",
  "tar",
@@ -1784,6 +1785,15 @@ checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7868ad3b8196a8a0aea99a8220b124278ee5320a55e4fde97794b6f85b1a377"
+dependencies = [
  "serde",
 ]
 

--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -15,7 +15,7 @@ use nextest_filtering::FilteringExpr;
 use nextest_metadata::{BinaryListSummary, BuildPlatform};
 use nextest_runner::{
     cargo_config::{CargoConfigs, TargetTriple},
-    config::{NextestConfig, NextestProfile},
+    config::{NextestConfig, NextestProfile, TestThreads},
     errors::WriteTestListError,
     list::{BinaryList, OutputFormat, RustTestArtifact, SerializableFormat, TestList},
     partition::PartitionerBuilder,
@@ -542,7 +542,7 @@ impl CargoOptions {
 #[derive(Debug, Default, Args)]
 #[clap(next_help_heading = "RUNNER OPTIONS")]
 pub struct TestRunnerOpts {
-    /// Number of tests to run simultaneously [default: logical CPU count]
+    /// Number of tests to run simultaneously [possible values: integer or "num-cpus"]
     #[clap(
         long,
         short = 'j',
@@ -551,7 +551,7 @@ pub struct TestRunnerOpts {
         conflicts_with = "no-capture",
         env = "NEXTEST_TEST_THREADS"
     )]
-    test_threads: Option<usize>,
+    test_threads: Option<TestThreads>,
 
     /// Number of retries for failing tests [default: from profile]
     #[clap(long)]

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -39,6 +39,7 @@ regex = "1.5.6"
 semver = "1.0.10"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
+serde_path_to_error = "0.1.7"
 shell-words = "1.1.0"
 strip-ansi-escapes = "0.1.1"
 tar = "0.4.38"

--- a/nextest-runner/default-config.toml
+++ b/nextest-runner/default-config.toml
@@ -14,6 +14,10 @@ dir = "target/nextest"
 # non-flaky. Can be overridden through the `--retries` option.
 retries = 0
 
+# The number of threads to run tests with. Supported values are either an integer or
+# the string "num-cpus". Can be overridden through the `--test-threads` option.
+test-threads = "num-cpus"
+
 # Show these test statuses in the output.
 #
 # The possible values this can take are:

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -94,6 +94,23 @@ impl StatusLevelParseError {
     }
 }
 
+/// Error returned while parsing a [`TestThreads`](crate::config::TestThreads) value.
+#[derive(Clone, Debug, Error)]
+#[error(
+    "unrecognized value for test-threads: {input}\n(expected either an integer or \"num-cpus\")"
+)]
+pub struct TestThreadsParseError {
+    input: String,
+}
+
+impl TestThreadsParseError {
+    pub(crate) fn new(input: impl Into<String>) -> Self {
+        Self {
+            input: input.into(),
+        }
+    }
+}
+
 /// An error that occurs while parsing a [`RunIgnored`] value from a string.
 #[derive(Clone, Debug, Error)]
 #[error(

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use camino::{FromPathBufError, Utf8Path, Utf8PathBuf};
 use config::ConfigError;
-use itertools::Itertools;
+use itertools::{Either, Itertools};
 use std::{borrow::Cow, env::JoinPathsError, fmt};
 use thiserror::Error;
 
@@ -24,11 +24,14 @@ use thiserror::Error;
 pub struct ConfigParseError {
     config_file: Utf8PathBuf,
     #[source]
-    err: ConfigError,
+    err: Either<ConfigError, serde_path_to_error::Error<ConfigError>>,
 }
 
 impl ConfigParseError {
-    pub(crate) fn new(config_file: impl Into<Utf8PathBuf>, err: ConfigError) -> Self {
+    pub(crate) fn new(
+        config_file: impl Into<Utf8PathBuf>,
+        err: Either<ConfigError, serde_path_to_error::Error<ConfigError>>,
+    ) -> Self {
         Self {
             config_file: config_file.into(),
             err,


### PR DESCRIPTION
Support:
* an integer
* the string `"num-cpus"`

Closes #319.