### PR TITLE
Add metadata for cargo-binstall

### DIFF
--- a/cargo-nextest/Cargo.toml
+++ b/cargo-nextest/Cargo.toml
@@ -52,3 +52,15 @@ self-update = ["nextest-runner/self-update"]
 # Default set of features excluding self-update. This is the recommended set of features for
 # distributor and custom CI builds.
 default-no-update = []
+
+# Metadata for cargo-binstall to get the right artifacts.
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/cargo-nextest-{ version }/{ name }-{ version }-{ target }.tar.gz"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
+# Mac x86_64 and aarch64 use the same universal binary.
+[package.metadata.binstall.overrides.x86_64-apple-darwin]
+pkg-url = "{ repo }/releases/download/cargo-nextest-{ version }/{ name }-{ version }-universal-apple-darwin.tar.gz"
+[package.metadata.binstall.overrides.aarch64-apple-darwin]
+pkg-url = "{ repo }/releases/download/cargo-nextest-{ version }/{ name }-{ version }-universal-apple-darwin.tar.gz"


### PR DESCRIPTION
Supports #31.

Tested local install with target `x86_64-unknown-linux-gnu`. I also verified via dry-run the URLs for a few more targets:
* `x86_64-unknown-linux-gnu` -> https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.23/cargo-nextest-0.9.23-x86_64-unknown-linux-gnu.tar.gz
* `x86_64-apple-darwin` ->  https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.23/cargo-nextest-0.9.23-universal-apple-darwin.tar.gz
* `aarch64-apple-darwin` -> https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.23/cargo-nextest-0.9.23-universal-apple-darwin.tar.gz
* `x86_64-pc-windows-msvc` -> https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.23/cargo-nextest-0.9.23-x86_64-pc-windows-msvc.tar.gz

Credit goes to @sunshowers for https://gist.github.com/sunshowers/0840b338b7e2496615d897d915859dbf