### PR TITLE
[ci] retry integration tests a few times

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -2,6 +2,16 @@
 # Don't fail fast in CI to run the full test suite.
 fail-fast = false
 
+[[profile.ci.overrides]]
+# In CI, and only in CI, some time on 2022-07-10, the integration tests started
+# to be flaky on Windows -- the cdylib-link fixture sometimes exits with code
+# -1073741515 (0xc0000135; STATUS_DLL_NOT_FOUND). This is flaky, so retry these
+# tests a few times.
+#
+# TODO: restrict these tests to Windows.
+filter = '(package(nextest-runner) & binary(integration)) | (package(cargo-nextest) & test(/^tests_integration::/))'
+retries = 9
+
 [profile.test-slow]
 # This is a test profile with a quick slow timeout.
 slow-timeout = "1s"


### PR DESCRIPTION
These tests started being flaky on Windows a couple of days ago -- see
e.g.
https://github.com/nextest-rs/nextest/runs/7312274373?check_suite_focus=true.

The tests appear to work fine in local environments.