### PR TITLE
[nextest-runner] support slow-timeout overrides

### DIFF
--- a/cargo-nextest/src/tests_integration/fixtures.rs
+++ b/cargo-nextest/src/tests_integration/fixtures.rs
@@ -60,6 +60,7 @@ pub static EXPECTED_LIST: Lazy<Vec<TestInfo>> = Lazy::new(|| {
                 ("test_ignored_fail", true),
                 ("test_result_failure", false),
                 ("test_slow_timeout", true),
+                ("test_slow_timeout_2", true),
                 ("test_success", false),
                 ("test_success_should_panic", false),
             ],
@@ -324,9 +325,9 @@ pub fn check_run_output(stderr: &[u8], relocated: bool) {
     }
 
     let summary_reg = if relocated {
-        Regex::new(r"Summary \[.*\] *24 tests run: 16 passed, 8 failed, 3 skipped").unwrap()
+        Regex::new(r"Summary \[.*\] *24 tests run: 16 passed, 8 failed, 4 skipped").unwrap()
     } else {
-        Regex::new(r"Summary \[.*\] *24 tests run: 17 passed, 7 failed, 3 skipped").unwrap()
+        Regex::new(r"Summary \[.*\] *24 tests run: 17 passed, 7 failed, 4 skipped").unwrap()
     };
     assert!(
         summary_reg.is_match(&output),

--- a/fixtures/nextest-tests/.config/nextest.toml
+++ b/fixtures/nextest-tests/.config/nextest.toml
@@ -21,6 +21,11 @@ retries = 4
 [profile.with-termination]
 slow-timeout = { period = "1s", terminate-after = 2 }
 
+[[profile.with-termination.overrides]]
+filter = 'test(=test_slow_timeout_2)'
+# This is set to 1 second
+slow-timeout = { period = "500ms", terminate-after = 2 }
+
 [profile.with-junit]
 retries = 2
 

--- a/fixtures/nextest-tests/tests/basic.rs
+++ b/fixtures/nextest-tests/tests/basic.rs
@@ -161,6 +161,13 @@ fn test_slow_timeout() {
 }
 
 #[test]
+#[ignore]
+fn test_slow_timeout_2() {
+    // There's a per-test override for the with-termination profile for this test: it is set to 1 second.
+    std::thread::sleep(std::time::Duration::from_millis(1500));
+}
+
+#[test]
 fn test_result_failure() -> Result<(), std::io::Error> {
     Err(std::io::Error::new(
         std::io::ErrorKind::InvalidData,

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -103,6 +103,7 @@ pub(crate) static EXPECTED_TESTS: Lazy<BTreeMap<&'static str, Vec<TestFixture>>>
                 TestFixture { name: "test_ignored_fail", status: FixtureStatus::IgnoredFail },
                 TestFixture { name: "test_result_failure", status: FixtureStatus::Fail },
                 TestFixture { name: "test_slow_timeout", status: FixtureStatus::IgnoredPass },
+                TestFixture { name: "test_slow_timeout_2", status: FixtureStatus::IgnoredPass },
                 TestFixture { name: "test_success", status: FixtureStatus::Pass },
                 TestFixture { name: "test_success_should_panic", status: FixtureStatus::Pass },
             ],


### PR DESCRIPTION
Support per-test overrides for `slow-timeout`.