### PR TITLE
detect tests that spawn subprocesses which leak handles

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,6 @@
+[profile.default]
+final-status-level = "slow"
+
 [profile.ci]
 # Don't fail fast in CI to run the full test suite.
 fail-fast = false

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,16 +5,6 @@ final-status-level = "slow"
 # Don't fail fast in CI to run the full test suite.
 fail-fast = false
 
-[[profile.ci.overrides]]
-# In CI, and only in CI, some time on 2022-07-10, the integration tests started
-# to be flaky on Windows -- the cdylib-link fixture sometimes exits with code
-# -1073741515 (0xc0000135; STATUS_DLL_NOT_FOUND). This is flaky, so retry these
-# tests a few times.
-#
-# TODO: restrict these tests to Windows.
-filter = '(package(nextest-runner) & binary(integration)) | (package(cargo-nextest) & test(/^tests_integration::/))'
-retries = 9
-
 [profile.test-slow]
 # This is a test profile with a quick slow timeout.
 slow-timeout = "1s"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,6 +1070,7 @@ dependencies = [
  "aho-corasick",
  "async-scoped",
  "atomicwrites",
+ "bytes",
  "camino",
  "cargo_metadata",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "async-scoped"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1181d2a07303ac3e8df0b3bdaaf648b4ac968d352e61158f5c1897db70d22a09"
+dependencies = [
+ "futures",
+ "pin-project",
+ "slab",
+ "tokio",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,51 +367,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
-dependencies = [
- "autocfg",
- "cfg-if",
- "crossbeam-utils",
- "memoffset",
- "once_cell",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
-dependencies = [
- "cfg-if",
- "once_cell",
-]
-
-[[package]]
 name = "ctor"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,12 +524,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -572,10 +555,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+dependencies = [
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
+]
 
 [[package]]
 name = "futures-sink"
@@ -595,8 +600,11 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -957,15 +965,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "miette"
 version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,6 +1078,7 @@ name = "nextest-runner"
 version = "0.17.0"
 dependencies = [
  "aho-corasick",
+ "async-scoped",
  "atomicwrites",
  "camino",
  "cargo_metadata",
@@ -1086,11 +1086,11 @@ dependencies = [
  "chrono",
  "color-eyre",
  "config",
- "crossbeam-channel",
  "ctrlc",
  "debug-ignore",
  "duct",
  "either",
+ "futures",
  "guppy",
  "home",
  "http",
@@ -1114,7 +1114,6 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "quick-junit",
- "rayon",
  "regex",
  "self_update",
  "semver",
@@ -1128,6 +1127,7 @@ dependencies = [
  "tempfile",
  "test-case",
  "thiserror",
+ "tokio",
  "toml",
  "twox-hash",
  "windows",
@@ -1143,6 +1143,9 @@ dependencies = [
  "clap",
  "console",
  "either",
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
  "indexmap",
  "libc",
  "log",
@@ -1159,6 +1162,7 @@ dependencies = [
  "serde_json",
  "syn 1.0.98",
  "textwrap",
+ "tokio",
  "winapi",
  "windows-sys",
 ]
@@ -1346,6 +1350,26 @@ checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
 dependencies = [
  "fixedbitset",
  "indexmap",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
+dependencies = [
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -1552,30 +1576,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
-dependencies = [
- "autocfg",
- "crossbeam-deque",
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-utils",
- "num_cpus",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1714,12 +1714,6 @@ name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"
@@ -2108,7 +2102,19 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+dependencies = [
+ "proc-macro2 1.0.40",
+ "quote 1.0.20",
+ "syn 1.0.98",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,7 @@ dependencies = [
  "nextest-metadata",
  "nextest-runner",
  "nextest-workspace-hack",
+ "num_cpus",
  "once_cell",
  "owo-colors",
  "pathdiff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,16 +377,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctrlc"
-version = "3.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b37feaa84e6861e00a1f5e5aa8da3ee56d605c9992d33e082786754828e20865"
-dependencies = [
- "nix",
- "winapi",
-]
-
-[[package]]
 name = "debug-ignore"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,7 +1076,6 @@ dependencies = [
  "chrono",
  "color-eyre",
  "config",
- "ctrlc",
  "debug-ignore",
  "duct",
  "either",
@@ -1164,18 +1153,6 @@ dependencies = [
  "textwrap",
  "tokio",
  "winapi",
- "windows-sys",
-]
-
-[[package]]
-name = "nix"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
-dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -1823,6 +1800,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "similar"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2101,6 +2087,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "winapi",

--- a/cargo-nextest/Cargo.toml
+++ b/cargo-nextest/Cargo.toml
@@ -29,6 +29,7 @@ miette = { version = "5.1.1", features = ["fancy"] }
 nextest-filtering = { version = "=0.2.0", path = "../nextest-filtering" }
 nextest-runner = { version = "=0.17.0", path = "../nextest-runner" }
 nextest-metadata = { version = "=0.5.0", path = "../nextest-metadata" }
+num_cpus = "1.13.1"
 once_cell = "1.13.0"
 owo-colors = { version = "3.4.0", features = ["supports-colors"] }
 pathdiff = { version = "0.2.1", features = ["camino"] }

--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -22,7 +22,7 @@ use nextest_runner::{
     reporter::{FinalStatusLevel, StatusLevel, TestOutputDisplay, TestReporterBuilder},
     reuse_build::{archive_to_file, ArchiveReporter, MetadataOrPath, PathMapper, ReuseBuildInfo},
     runner::TestRunnerBuilder,
-    signal::SignalHandler,
+    signal::SignalHandlerKind,
     target_runner::{PlatformRunner, TargetRunner},
     test_filter::{RunIgnored, TestFilterBuilder},
 };
@@ -1031,7 +1031,7 @@ impl App {
             reporter.colorize();
         }
 
-        let handler = SignalHandler::new()?;
+        let handler = SignalHandlerKind::Standard;
         let runner_builder = runner_opts.to_builder(no_capture);
         let mut runner =
             runner_builder.build(&test_list, profile, handler, target_runner.clone())?;

--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -1033,7 +1033,8 @@ impl App {
 
         let handler = SignalHandler::new()?;
         let runner_builder = runner_opts.to_builder(no_capture);
-        let runner = runner_builder.build(&test_list, profile, handler, target_runner.clone());
+        let mut runner =
+            runner_builder.build(&test_list, profile, handler, target_runner.clone())?;
 
         let run_stats = runner.try_execute(|event| {
             // Write and flush the event.

--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -21,7 +21,7 @@ use nextest_runner::{
     partition::PartitionerBuilder,
     reporter::{FinalStatusLevel, StatusLevel, TestOutputDisplay, TestReporterBuilder},
     reuse_build::{archive_to_file, ArchiveReporter, MetadataOrPath, PathMapper, ReuseBuildInfo},
-    runner::TestRunnerBuilder,
+    runner::{configure_handle_inheritance, TestRunnerBuilder},
     signal::SignalHandlerKind,
     target_runner::{PlatformRunner, TargetRunner},
     test_filter::{RunIgnored, TestFilterBuilder},
@@ -1038,6 +1038,7 @@ impl App {
         let mut runner =
             runner_builder.build(&test_list, profile, handler, target_runner.clone())?;
 
+        configure_handle_inheritance(no_capture)?;
         let run_stats = runner.try_execute(|event| {
             // Write and flush the event.
             reporter.report_event(event)

--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -439,6 +439,8 @@ impl TestBuildFilter {
             rust_build_meta,
             &test_filter_builder,
             runner,
+            // TODO: do we need to allow customizing this?
+            num_cpus::get(),
         )
         .map_err(|err| ExpectedError::CreateTestListError { err })
     }

--- a/cargo-nextest/src/errors.rs
+++ b/cargo-nextest/src/errors.rs
@@ -124,6 +124,11 @@ pub enum ExpectedError {
         command: String,
         exit_code: Option<i32>,
     },
+    #[error("building test runner failed")]
+    TestRunnerBuildError {
+        #[from]
+        err: TestRunnerBuildError,
+    },
     #[error("writing test list to output failed")]
     WriteTestListError {
         #[from]
@@ -289,6 +294,7 @@ impl ExpectedError {
             | Self::ArchiveExtractError { .. }
             | Self::PathMapperConstructError { .. }
             | Self::ArgumentJsonParseError { .. }
+            | Self::TestRunnerBuildError { .. }
             | Self::CargoMetadataParseError { .. }
             | Self::TestBinaryArgsParseError { .. }
             | Self::DialoguerError { .. }
@@ -492,6 +498,10 @@ impl ExpectedError {
                 );
 
                 None
+            }
+            Self::TestRunnerBuildError { err } => {
+                log::error!("failed to build test runner");
+                Some(err as &dyn Error)
             }
             Self::WriteTestListError { err } => {
                 log::error!("failed to write test list to output");

--- a/cargo-nextest/src/errors.rs
+++ b/cargo-nextest/src/errors.rs
@@ -139,6 +139,11 @@ pub enum ExpectedError {
         #[from]
         err: WriteEventError,
     },
+    #[error(transparent)]
+    ConfigureHandleInheritanceError {
+        #[from]
+        err: ConfigureHandleInheritanceError,
+    },
     #[error("test run failed")]
     TestRunFailed,
     #[cfg(feature = "self-update")]
@@ -295,6 +300,7 @@ impl ExpectedError {
             | Self::PathMapperConstructError { .. }
             | Self::ArgumentJsonParseError { .. }
             | Self::TestRunnerBuildError { .. }
+            | Self::ConfigureHandleInheritanceError { .. }
             | Self::CargoMetadataParseError { .. }
             | Self::TestBinaryArgsParseError { .. }
             | Self::DialoguerError { .. }
@@ -502,6 +508,10 @@ impl ExpectedError {
             Self::TestRunnerBuildError { err } => {
                 log::error!("failed to build test runner");
                 Some(err as &dyn Error)
+            }
+            Self::ConfigureHandleInheritanceError { err } => {
+                log::error!("{err}");
+                err.source()
             }
             Self::WriteTestListError { err } => {
                 log::error!("failed to write test list to output");

--- a/cargo-nextest/src/tests_integration/fixtures.rs
+++ b/cargo-nextest/src/tests_integration/fixtures.rs
@@ -178,7 +178,6 @@ pub fn build_tests(p: &TempProject) {
     std::fs::write(p.binaries_metadata_path(), output.stdout().unwrap()).unwrap();
 }
 
-#[track_caller]
 pub fn check_list_full_output(stdout: &[u8], platform: Option<BuildPlatform>) {
     let result: TestListSummary = serde_json::from_slice(stdout).unwrap();
 

--- a/cargo-nextest/src/tests_integration/fixtures.rs
+++ b/cargo-nextest/src/tests_integration/fixtures.rs
@@ -61,6 +61,7 @@ pub static EXPECTED_LIST: Lazy<Vec<TestInfo>> = Lazy::new(|| {
                 ("test_result_failure", false),
                 ("test_slow_timeout", true),
                 ("test_slow_timeout_2", true),
+                ("test_subprocess_doesnt_exit", false),
                 ("test_success", false),
                 ("test_success_should_panic", false),
             ],
@@ -324,9 +325,9 @@ pub fn check_run_output(stderr: &[u8], relocated: bool) {
     }
 
     let summary_reg = if relocated {
-        Regex::new(r"Summary \[.*\] *24 tests run: 16 passed, 8 failed, 4 skipped").unwrap()
+        Regex::new(r"Summary \[.*\] *25 tests run: 17 passed, 8 failed, 4 skipped").unwrap()
     } else {
-        Regex::new(r"Summary \[.*\] *24 tests run: 17 passed, 7 failed, 4 skipped").unwrap()
+        Regex::new(r"Summary \[.*\] *25 tests run: 18 passed, 7 failed, 4 skipped").unwrap()
     };
     assert!(
         summary_reg.is_match(&output),

--- a/cargo-nextest/src/tests_integration/fixtures.rs
+++ b/cargo-nextest/src/tests_integration/fixtures.rs
@@ -325,13 +325,15 @@ pub fn check_run_output(stderr: &[u8], relocated: bool) {
     }
 
     let summary_reg = if relocated {
-        Regex::new(r"Summary \[.*\] *25 tests run: 17 passed, 8 failed, 4 skipped").unwrap()
+        Regex::new(r"Summary \[.*\] *25 tests run: 17 passed \(1 leaky\), 8 failed, 4 skipped")
+            .unwrap()
     } else {
-        Regex::new(r"Summary \[.*\] *25 tests run: 18 passed, 7 failed, 4 skipped").unwrap()
+        Regex::new(r"Summary \[.*\] *25 tests run: 18 passed \(1 leaky\), 7 failed, 4 skipped")
+            .unwrap()
     };
     assert!(
         summary_reg.is_match(&output),
-        "summary didn't match (actual output: {})",
+        "summary didn't match (actual output: {}, relocated: {relocated})",
         output
     );
 }

--- a/cargo-nextest/src/tests_integration/fixtures.rs
+++ b/cargo-nextest/src/tests_integration/fixtures.rs
@@ -61,6 +61,7 @@ pub static EXPECTED_LIST: Lazy<Vec<TestInfo>> = Lazy::new(|| {
                 ("test_result_failure", false),
                 ("test_slow_timeout", true),
                 ("test_slow_timeout_2", true),
+                ("test_stdin_closed", false),
                 ("test_subprocess_doesnt_exit", false),
                 ("test_success", false),
                 ("test_success_should_panic", false),
@@ -302,6 +303,7 @@ pub fn check_run_output(stderr: &[u8], relocated: bool) {
         (false, "nextest-tests::basic test_result_failure"),
         (true, "nextest-tests::basic test_success_should_panic"),
         (false, "nextest-tests::basic test_failure_assert"),
+        (true, "nextest-tests::basic test_stdin_closed"),
         (false, "nextest-tests::basic test_flaky_mod_6"),
         (cwd_pass, "nextest-tests::basic test_cwd"),
         (
@@ -325,10 +327,10 @@ pub fn check_run_output(stderr: &[u8], relocated: bool) {
     }
 
     let summary_reg = if relocated {
-        Regex::new(r"Summary \[.*\] *25 tests run: 17 passed \(1 leaky\), 8 failed, 4 skipped")
+        Regex::new(r"Summary \[.*\] *26 tests run: 18 passed \(1 leaky\), 8 failed, 4 skipped")
             .unwrap()
     } else {
-        Regex::new(r"Summary \[.*\] *25 tests run: 18 passed \(1 leaky\), 7 failed, 4 skipped")
+        Regex::new(r"Summary \[.*\] *26 tests run: 19 passed \(1 leaky\), 7 failed, 4 skipped")
             .unwrap()
     };
     assert!(

--- a/fixtures/nextest-tests/tests/basic.rs
+++ b/fixtures/nextest-tests/tests/basic.rs
@@ -1,5 +1,5 @@
 // Copyright (c) The nextest Contributors
-use std::{env, path::Path};
+use std::{env, io::Read, path::Path};
 
 #[test]
 fn test_success() {}
@@ -200,4 +200,16 @@ fn sleep_cmd(secs: usize) -> std::process::Command {
     let mut cmd = std::process::Command::new("sleep");
     cmd.arg(&format!("{secs}"));
     cmd
+}
+
+#[test]
+fn test_stdin_closed() {
+    let mut buf = [0u8; 8];
+    // This should succeed with 0 because it's attached to /dev/null or its Windows equivalent.
+    assert_eq!(
+        0,
+        std::io::stdin()
+            .read(&mut buf)
+            .expect("reading from /dev/null succeeded")
+    );
 }

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -12,16 +12,17 @@ rust-version = "1.59"
 [dependencies]
 atomicwrites = "0.3.1"
 aho-corasick = "0.7.18"
+async-scoped = { version = "0.7.0", features = ["use-tokio"] }
 camino = { version = "1.0.9", features = ["serde1"] }
 config = { version = "0.13.1", default-features = false, features = ["toml"] }
 cargo_metadata = "0.14.2"
 cfg-if = "1.0.0"
 chrono = "0.4.19"
-crossbeam-channel = "0.5.5"
 ctrlc = { version = "3.2.2", features = ["termination"] }
 debug-ignore = "1.0.2"
 duct = "0.13.5"
 either = "1.7.0"
+futures = "0.3.21"
 guppy = "0.14.2"
 # Used to find the cargo root directory, which is needed in case the user has
 # added a config.toml there
@@ -35,7 +36,6 @@ log = "0.4.17"
 once_cell = "1.13.0"
 owo-colors = "3.4.0"
 num_cpus = "1.13.1"
-rayon = "1.5.3"
 regex = "1.6.0"
 semver = "1.0.12"
 serde = { version = "1.0.139", features = ["derive"] }
@@ -49,6 +49,12 @@ target-spec = "1.0.2"
 tempfile = "3.3.0"
 thiserror = "1.0.31"
 # For parsing of .cargo/config.toml files
+tokio = { version = "1.20.0", features = [
+    "macros",
+    "rt",
+    "rt-multi-thread",
+    "sync",
+] }
 toml = "0.5.9"
 twox-hash = { version = "1.6.3", default-features = false }
 zstd = { version = "0.11.2", features = ["zstdmt"] }

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -20,7 +20,6 @@ cargo_metadata = "0.14.2"
 cfg-if = "1.0.0"
 chrono = "0.4.19"
 debug-ignore = "1.0.2"
-duct = "0.13.5"
 either = "1.7.0"
 futures = "0.3.21"
 guppy = "0.14.2"
@@ -86,6 +85,7 @@ windows = { version = "0.38.0", features = ["Win32_Foundation"] }
 
 [dev-dependencies]
 color-eyre = { version = "0.6.2", default-features = false }
+duct = "0.13.5"
 indoc = "1.0.6"
 maplit = "1.0.2"
 pathdiff = { version = "0.2.1", features = ["camino"] }

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.59"
 atomicwrites = "0.3.1"
 aho-corasick = "0.7.18"
 async-scoped = { version = "0.7.0", features = ["use-tokio"] }
+bytes = "1.1.0"
 camino = { version = "1.0.9", features = ["serde1"] }
 config = { version = "0.13.1", default-features = false, features = ["toml"] }
 cargo_metadata = "0.14.2"
@@ -50,10 +51,12 @@ thiserror = "1.0.31"
 # For parsing of .cargo/config.toml files
 tokio = { version = "1.20.0", features = [
     "macros",
+    "process",
     "rt",
     "rt-multi-thread",
     "signal",
     "sync",
+    "time",
 ] }
 toml = "0.5.9"
 twox-hash = { version = "1.6.3", default-features = false }

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -81,7 +81,7 @@ nextest-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 libc = "0.2.126"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.38.0", features = ["Win32_Foundation"] }
+windows = { version = "0.38.0", features = ["Win32_Foundation", "Win32_System_Console"] }
 
 [dev-dependencies]
 color-eyre = { version = "0.6.2", default-features = false }

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -18,7 +18,6 @@ config = { version = "0.13.1", default-features = false, features = ["toml"] }
 cargo_metadata = "0.14.2"
 cfg-if = "1.0.0"
 chrono = "0.4.19"
-ctrlc = { version = "3.2.2", features = ["termination"] }
 debug-ignore = "1.0.2"
 duct = "0.13.5"
 either = "1.7.0"
@@ -53,6 +52,7 @@ tokio = { version = "1.20.0", features = [
     "macros",
     "rt",
     "rt-multi-thread",
+    "signal",
     "sync",
 ] }
 toml = "0.5.9"

--- a/nextest-runner/default-config.toml
+++ b/nextest-runner/default-config.toml
@@ -67,6 +67,13 @@ fail-fast = true
 # Example: slow-timeout = { period = "60s", terminate-after = 2 }
 slow-timeout = { period = "60s" }
 
+# Treat a test as leaky if after the process is shut down, standard output and standard error
+# aren't closed by this time.
+#
+# This usually happens in case of a test that creates a child process and lets it inherit those
+# handles, but doesn't clean the child process up (especially when it fails).
+leak-timeout = "100ms"
+
 [profile.default.junit]
 # Output a JUnit report into the given file inside 'store.dir/<profile-name>'.
 # If unspecified, JUnit is not written out.

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -483,6 +483,17 @@ pub enum WriteTestListError {
     Json(#[source] serde_json::Error),
 }
 
+/// An error occurred while configuring handles.
+///
+/// Only relevant on Windows.
+#[derive(Debug, Error)]
+pub enum ConfigureHandleInheritanceError {
+    /// An error occurred. This can only happen on Windows.
+    #[cfg(windows)]
+    #[error("error configuring handle inheritance")]
+    WindowsError(#[from] windows::core::Error),
+}
+
 /// An error that occurs while building the test runner.
 #[derive(Debug, Error)]
 #[non_exhaustive]

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -420,6 +420,15 @@ pub enum WriteTestListError {
     Json(#[source] serde_json::Error),
 }
 
+/// An error that occurs while building the test runner.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum TestRunnerBuildError {
+    /// An error occurred while creating the Tokio runtime.
+    #[error("error creating Tokio runtime")]
+    TokioRuntimeCreate(#[source] std::io::Error),
+}
+
 /// Represents an unknown archive format.
 ///
 /// Returned by [`ArchiveFormat::autodetect`].

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -427,6 +427,10 @@ pub enum TestRunnerBuildError {
     /// An error occurred while creating the Tokio runtime.
     #[error("error creating Tokio runtime")]
     TokioRuntimeCreate(#[source] std::io::Error),
+
+    /// An error occurred while setting up signals.
+    #[error("error setting up signals")]
+    SignalHandlerSetupError(#[from] SignalHandlerSetupError),
 }
 
 /// Represents an unknown archive format.
@@ -778,8 +782,8 @@ pub enum TargetRunnerError {
 
 /// An error that occurred while setting up the signal handler.
 #[derive(Debug, Error)]
-#[error(transparent)]
-pub struct SignalHandlerSetupError(#[from] ctrlc::Error);
+#[error("error setting up signal handler")]
+pub struct SignalHandlerSetupError(#[from] std::io::Error);
 
 #[cfg(feature = "self-update")]
 mod self_update_errors {

--- a/nextest-runner/src/helpers.rs
+++ b/nextest-runner/src/helpers.rs
@@ -100,6 +100,23 @@ pub(crate) fn convert_rel_path_to_forward_slash(rel_path: &Utf8Path) -> Utf8Path
     rel_path.to_path_buf()
 }
 
+/// On Windows, convert relative paths to use the main separator.
+#[cfg(windows)]
+pub(crate) fn convert_rel_path_to_main_sep(rel_path: &Utf8Path) -> Utf8PathBuf {
+    if !rel_path.is_relative() {
+        panic!(
+            "path for conversion to backslash '{}' is not relative",
+            rel_path
+        );
+    }
+    rel_path.as_str().replace('/', "\\").into()
+}
+
+#[cfg(not(windows))]
+pub(crate) fn convert_rel_path_to_main_sep(rel_path: &Utf8Path) -> Utf8PathBuf {
+    rel_path.to_path_buf()
+}
+
 pub(crate) fn format_duration(duration: Duration) -> String {
     let duration = duration.as_secs_f64();
     if duration > 60.0 {

--- a/nextest-runner/src/list/test_list.rs
+++ b/nextest-runner/src/list/test_list.rs
@@ -10,7 +10,6 @@ use crate::{
     test_filter::TestFilterBuilder,
 };
 use camino::{Utf8Path, Utf8PathBuf};
-use duct::Expression;
 use guppy::{
     graph::{PackageGraph, PackageMetadata},
     PackageId,
@@ -770,7 +769,7 @@ impl<'a> TestInstance<'a> {
         &self,
         test_list: &TestList<'_>,
         target_runner: &TargetRunner,
-    ) -> Expression {
+    ) -> tokio::process::Command {
         let platform_runner = target_runner.for_build_platform(self.bin_info.build_platform);
         // TODO: non-rust tests
 
@@ -790,7 +789,7 @@ impl<'a> TestInstance<'a> {
             args.push("--ignored");
         }
 
-        make_test_expression(
+        make_test_command(
             program,
             args,
             &self.bin_info.cwd,
@@ -840,7 +839,8 @@ pub(crate) fn make_test_expression(
             .collect()
     });
 
-    let mut cmd = duct::cmd(program, args)
+    let mut cmd = duct::cmd(program, args);
+    cmd = cmd
         .dir(cwd)
         // This environment variable is set to indicate that tests are being run under nextest.
         .env("NEXTEST", "1")
@@ -908,6 +908,120 @@ pub(crate) fn make_test_expression(
     // These paths aren't exposed by Cargo at runtime, so use a NEXTEST_BIN_EXE prefix.
     for (name, path) in non_test_binaries {
         cmd = cmd.env(format!("NEXTEST_BIN_EXE_{}", name), &path);
+    }
+
+    cmd
+}
+
+/// Create a duct Expression for a test binary with the given arguments, using the specified [`PackageMetadata`].
+pub(crate) fn make_test_command(
+    program: String,
+    args: impl IntoIterator<Item = impl AsRef<OsStr>>,
+    cwd: &Utf8PathBuf,
+    package: &PackageMetadata<'_>,
+    dylib_path: &OsStr,
+    non_test_binaries: &BTreeSet<(String, Utf8PathBuf)>,
+) -> tokio::process::Command {
+    // This is a workaround for a macOS SIP issue:
+    // https://github.com/nextest-rs/nextest/pull/84
+    //
+    // Basically, if SIP is enabled, macOS removes any environment variables that start with
+    // "LD_" or "DYLD_" when spawning system-protected processes. This unfortunately includes
+    // processes like bash -- this means that if nextest invokes a shell script, paths might
+    // end up getting sanitized.
+    //
+    // This is particularly relevant for target runners, which are often shell scripts.
+    //
+    // To work around this, re-export any variables that begin with LD_ or DYLD_ as "NEXTEST_LD_"
+    // or "NEXTEST_DYLD_". Do this on all platforms for uniformity.
+    //
+    // Nextest never changes these environment variables within its own process, so caching them is
+    // valid.
+    fn is_sip_sanitized(var: &str) -> bool {
+        // Look for variables starting with LD_ or DYLD_.
+        // https://briandfoy.github.io/macos-s-system-integrity-protection-sanitizes-your-environment/
+        var.starts_with("LD_") || var.starts_with("DYLD_")
+    }
+
+    static LD_DYLD_ENV_VARS: Lazy<HashMap<String, OsString>> = Lazy::new(|| {
+        std::env::vars_os()
+            .filter_map(|(k, v)| match k.into_string() {
+                Ok(k) => is_sip_sanitized(&k).then(|| (k, v)),
+                Err(_) => None,
+            })
+            .collect()
+    });
+
+    let mut cmd = tokio::process::Command::new(program);
+
+    cmd.args(args)
+        .current_dir(cwd)
+        // This environment variable is set to indicate that tests are being run under nextest.
+        .env("NEXTEST", "1")
+        // This environment variable is set to indicate that each test is being run in its own process.
+        .env("NEXTEST_EXECUTION_MODE", "process-per-test")
+        // These environment variables are set at runtime by cargo test:
+        // https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
+        .env(
+            "CARGO_MANIFEST_DIR",
+            // CARGO_MANIFEST_DIR is set to the *new* cwd after path mapping.
+            cwd,
+        )
+        .env(
+            "__NEXTEST_ORIGINAL_CARGO_MANIFEST_DIR",
+            // This is a test-only environment variable set to the *old* cwd. Not part of the
+            // public API.
+            package.manifest_path().parent().unwrap(),
+        )
+        .env("CARGO_PKG_VERSION", format!("{}", package.version()))
+        .env(
+            "CARGO_PKG_VERSION_MAJOR",
+            format!("{}", package.version().major),
+        )
+        .env(
+            "CARGO_PKG_VERSION_MINOR",
+            format!("{}", package.version().minor),
+        )
+        .env(
+            "CARGO_PKG_VERSION_PATCH",
+            format!("{}", package.version().patch),
+        )
+        .env(
+            "CARGO_PKG_VERSION_PRE",
+            format!("{}", package.version().pre),
+        )
+        .env("CARGO_PKG_AUTHORS", package.authors().join(":"))
+        .env("CARGO_PKG_NAME", package.name())
+        .env(
+            "CARGO_PKG_DESCRIPTION",
+            package.description().unwrap_or_default(),
+        )
+        .env("CARGO_PKG_HOMEPAGE", package.homepage().unwrap_or_default())
+        .env("CARGO_PKG_LICENSE", package.license().unwrap_or_default())
+        .env(
+            "CARGO_PKG_LICENSE_FILE",
+            package.license_file().unwrap_or_else(|| "".as_ref()),
+        )
+        .env(
+            "CARGO_PKG_REPOSITORY",
+            package.repository().unwrap_or_default(),
+        )
+        .env(dylib_path_envvar(), dylib_path);
+
+    for (k, v) in &*LD_DYLD_ENV_VARS {
+        if k != dylib_path_envvar() {
+            cmd.env("NEXTEST_".to_owned() + k, v);
+        }
+    }
+    // Also add the dylib path envvar under the NEXTEST_ prefix.
+    if is_sip_sanitized(dylib_path_envvar()) {
+        cmd.env("NEXTEST_".to_owned() + dylib_path_envvar(), dylib_path);
+    }
+
+    // Expose paths to non-test binaries at runtime so that relocated paths work.
+    // These paths aren't exposed by Cargo at runtime, so use a NEXTEST_BIN_EXE prefix.
+    for (name, path) in non_test_binaries {
+        cmd.env(format!("NEXTEST_BIN_EXE_{}", name), &path);
     }
 
     cmd

--- a/nextest-runner/src/reporter.rs
+++ b/nextest-runner/src/reporter.rs
@@ -1108,7 +1108,7 @@ fn status_str(result: ExecutionResult) -> Cow<'static, str> {
         #[cfg(unix)]
         ExecutionResult::Fail {
             abort_status: Some(AbortStatus::UnixSignal(sig)),
-        } => match signal_str(sig) {
+        } => match crate::helpers::signal_str(sig) {
             Some(s) => format!("SIG{s}").into(),
             None => format!("ABORT SIG {sig}").into(),
         },
@@ -1133,7 +1133,7 @@ fn short_status_str(result: ExecutionResult) -> Cow<'static, str> {
         #[cfg(unix)]
         ExecutionResult::Fail {
             abort_status: Some(AbortStatus::UnixSignal(sig)),
-        } => match signal_str(sig) {
+        } => match crate::helpers::signal_str(sig) {
             Some(s) => s.into(),
             None => format!("SIG {sig}").into(),
         },
@@ -1149,28 +1149,6 @@ fn short_status_str(result: ExecutionResult) -> Cow<'static, str> {
         ExecutionResult::ExecFail => "XFAIL".into(),
         ExecutionResult::Pass => "PASS".into(),
         ExecutionResult::Timeout => "TMT".into(),
-    }
-}
-
-#[cfg(unix)]
-fn signal_str(signal: i32) -> Option<&'static str> {
-    // These signal numbers are the same on at least Linux, macOS and FreeBSD.
-    match signal {
-        1 => Some("HUP"),
-        2 => Some("INT"),
-        5 => Some("TRAP"),
-        6 => Some("ABRT"),
-        8 => Some("FPE"),
-        9 => Some("KILL"),
-        11 => Some("SEGV"),
-        13 => Some("PIPE"),
-        14 => Some("ALRM"),
-        15 => Some("TERM"),
-        24 => Some("XCPU"),
-        25 => Some("XFSZ"),
-        26 => Some("VTALRM"),
-        27 => Some("PROF"),
-        _ => None,
     }
 }
 

--- a/nextest-runner/src/reporter/aggregator.rs
+++ b/nextest-runner/src/reporter/aggregator.rs
@@ -243,7 +243,7 @@ pub fn heuristic_extract_description<'a>(
         abort_status: Some(AbortStatus::UnixSignal(sig)),
     } = exec_result
     {
-        let signal_str = match super::signal_str(sig) {
+        let signal_str = match crate::helpers::signal_str(sig) {
             Some(signal_str) => format!(" SIG{signal_str}"),
             None => String::new(),
         };

--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -1083,7 +1083,7 @@ impl ExecutionResult {
     }
 }
 
-/// A signal or other abort status for a test.
+/// A regular exit code or Windows NT abort status for a test.
 ///
 /// Returned as part of the [`ExecutionResult::Fail`] variant.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -23,6 +23,7 @@ use std::{
     convert::Infallible,
     marker::PhantomData,
     num::NonZeroUsize,
+    process::Stdio,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -413,6 +414,7 @@ impl<'a> TestRunnerInner<'a> {
 
         // Debug environment variable for testing.
         cmd.env("__NEXTEST_ATTEMPT", format!("{}", attempt));
+        cmd.stdin(Stdio::null());
 
         if !self.no_capture {
             // Capture stdout and stderr.

--- a/nextest-runner/src/signal.rs
+++ b/nextest-runner/src/signal.rs
@@ -4,36 +4,164 @@
 //! Support for handling signals in nextest.
 
 use crate::errors::SignalHandlerSetupError;
-use tokio::sync::mpsc::UnboundedReceiver;
 
-/// A receiver that generates signals if ctrl-c is pressed.
+/// The kind of signal handling to set up for a test run.
 ///
-/// A `SignalHandler` can be passed into
+/// A `SignalHandlerKind` can be passed into
 /// [`TestRunnerBuilder::build`](crate::runner::TestRunnerBuilder::build).
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub enum SignalHandlerKind {
+    /// The standard signal handler. Capture interrupt and termination signals depending on the
+    /// platform.
+    Standard,
+
+    /// A no-op signal handler. Useful for tests.
+    Noop,
+}
+
+impl SignalHandlerKind {
+    pub(crate) fn build(self) -> Result<SignalHandler, SignalHandlerSetupError> {
+        match self {
+            Self::Standard => SignalHandler::new(),
+            Self::Noop => Ok(SignalHandler::noop()),
+        }
+    }
+}
+
+/// The signal handler implementation.
 #[derive(Debug)]
-pub struct SignalHandler {
-    pub(crate) receiver: UnboundedReceiver<SignalEvent>,
+pub(crate) struct SignalHandler {
+    signals: Option<imp::Signals>,
 }
 
 impl SignalHandler {
-    /// Creates a new `SignalReceiver` that handles Ctrl-C errors.
-    ///
-    /// Errors if a signal handler has already been registered in this process. Only one signal
-    /// handler can be registered for a process at any given time.
-    pub fn new() -> Result<Self, SignalHandlerSetupError> {
-        let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
-        // TODO: replace with tokio's signal handling?
-        ctrlc::set_handler(move || {
-            let _ = sender.send(SignalEvent::Interrupted);
-        })?;
-
-        Ok(Self { receiver })
+    /// Creates a new `SignalHandler` that handles Ctrl-C and other signals.
+    #[cfg(any(unix, windows))]
+    pub(crate) fn new() -> Result<Self, SignalHandlerSetupError> {
+        let signals = imp::Signals::new()?;
+        Ok(Self {
+            signals: Some(signals),
+        })
     }
 
     /// Creates a new `SignalReceiver` that does nothing.
-    pub fn noop() -> Self {
-        let (_sender, receiver) = tokio::sync::mpsc::unbounded_channel();
-        Self { receiver }
+    pub(crate) fn noop() -> Self {
+        Self { signals: None }
+    }
+
+    pub(crate) async fn recv(&mut self) -> Option<SignalEvent> {
+        match &mut self.signals {
+            Some(signals) => signals.recv().await,
+            None => None,
+        }
+    }
+}
+
+#[cfg(unix)]
+mod imp {
+    use super::*;
+    use tokio::signal::unix::{signal, Signal, SignalKind};
+
+    /// Signals for SIGINT, SIGTERM and SIGHUP on Unix.
+    #[derive(Debug)]
+    pub(super) struct Signals {
+        sigint: SignalWithDone,
+        sighup: SignalWithDone,
+        sigterm: SignalWithDone,
+    }
+
+    impl Signals {
+        pub(super) fn new() -> std::io::Result<Self> {
+            let sigint = SignalWithDone::new(SignalKind::interrupt())?;
+            let sighup = SignalWithDone::new(SignalKind::hangup())?;
+            let sigterm = SignalWithDone::new(SignalKind::terminate())?;
+
+            Ok(Self {
+                sigint,
+                sighup,
+                sigterm,
+            })
+        }
+
+        pub(super) async fn recv(&mut self) -> Option<SignalEvent> {
+            loop {
+                tokio::select! {
+                    recv = self.sigint.signal.recv(), if !self.sigint.done => {
+                        match recv {
+                            Some(()) => break Some(SignalEvent::Interrupted),
+                            None => self.sigint.done = true,
+                        }
+                    }
+                    recv = self.sighup.signal.recv(), if !self.sighup.done => {
+                        match recv {
+                            Some(()) => break Some(SignalEvent::Interrupted),
+                            None => self.sighup.done = true,
+                        }
+                    }
+                    recv = self.sigterm.signal.recv(), if !self.sigterm.done => {
+                        match recv {
+                            Some(()) => break Some(SignalEvent::Interrupted),
+                            None => self.sigterm.done = true,
+                        }
+                    }
+                    else => {
+                        break None
+                    }
+                }
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct SignalWithDone {
+        signal: Signal,
+        done: bool,
+    }
+
+    impl SignalWithDone {
+        fn new(kind: SignalKind) -> std::io::Result<Self> {
+            let signal = signal(kind)?;
+            Ok(Self {
+                signal,
+                done: false,
+            })
+        }
+    }
+}
+
+#[cfg(windows)]
+mod imp {
+    use super::*;
+    use tokio::signal::windows::{ctrl_c, CtrlC};
+
+    #[derive(Debug)]
+    pub(super) struct Signals {
+        ctrl_c: CtrlC,
+        ctrl_c_done: bool,
+    }
+
+    impl Signals {
+        pub(super) fn new() -> std::io::Result<Self> {
+            let ctrl_c = ctrl_c()?;
+            Ok(Self {
+                ctrl_c,
+                ctrl_c_done: false,
+            })
+        }
+
+        pub(super) async fn recv(&mut self) -> Option<SignalEvent> {
+            if self.ctrl_c_done {
+                return None;
+            }
+
+            match self.ctrl_c.recv().await {
+                Some(()) => Some(SignalEvent::Interrupted),
+                None => {
+                    self.ctrl_c_done = true;
+                    None
+                }
+            }
+        }
     }
 }
 

--- a/nextest-runner/tests/integration/basic.rs
+++ b/nextest-runner/tests/integration/basic.rs
@@ -94,14 +94,18 @@ fn test_run() -> Result<()> {
         .profile(NextestConfig::DEFAULT_PROFILE)
         .expect("default config is valid");
 
-    let runner = TestRunnerBuilder::default().build(
-        &test_list,
-        profile,
-        SignalHandler::noop(),
-        TargetRunner::empty(),
-    );
+    let mut runner = TestRunnerBuilder::default()
+        .build(
+            &test_list,
+            profile,
+            SignalHandler::noop(),
+            TargetRunner::empty(),
+        )
+        .unwrap();
 
-    let (instance_statuses, run_stats) = execute_collect(&runner);
+    let (instance_statuses, run_stats) = execute_collect(&mut runner);
+
+    println!("collected?");
 
     for (binary_id, expected) in &*EXPECTED_TESTS {
         let test_binary = FIXTURE_TARGETS
@@ -184,14 +188,16 @@ fn test_run_ignored() -> Result<()> {
         .profile(NextestConfig::DEFAULT_PROFILE)
         .expect("default config is valid");
 
-    let runner = TestRunnerBuilder::default().build(
-        &test_list,
-        profile,
-        SignalHandler::noop(),
-        TargetRunner::empty(),
-    );
+    let mut runner = TestRunnerBuilder::default()
+        .build(
+            &test_list,
+            profile,
+            SignalHandler::noop(),
+            TargetRunner::empty(),
+        )
+        .unwrap();
 
-    let (instance_statuses, run_stats) = execute_collect(&runner);
+    let (instance_statuses, run_stats) = execute_collect(&mut runner);
 
     for (name, expected) in &*EXPECTED_TESTS {
         let test_binary = FIXTURE_TARGETS
@@ -377,14 +383,16 @@ fn test_retries(retries: Option<usize>) -> Result<()> {
     if let Some(retries) = retries {
         builder.set_retries(retries);
     }
-    let runner = builder.build(
-        &test_list,
-        profile,
-        SignalHandler::noop(),
-        TargetRunner::empty(),
-    );
+    let mut runner = builder
+        .build(
+            &test_list,
+            profile,
+            SignalHandler::noop(),
+            TargetRunner::empty(),
+        )
+        .unwrap();
 
-    let (instance_statuses, run_stats) = execute_collect(&runner);
+    let (instance_statuses, run_stats) = execute_collect(&mut runner);
 
     for (name, expected) in &*EXPECTED_TESTS {
         let test_binary = FIXTURE_TARGETS
@@ -497,14 +505,16 @@ fn test_termination() -> Result<()> {
         .profile("with-termination")
         .expect("with-termination config is valid");
 
-    let runner = TestRunnerBuilder::default().build(
-        &test_list,
-        profile,
-        SignalHandler::noop(),
-        TargetRunner::empty(),
-    );
+    let mut runner = TestRunnerBuilder::default()
+        .build(
+            &test_list,
+            profile,
+            SignalHandler::noop(),
+            TargetRunner::empty(),
+        )
+        .unwrap();
 
-    let (instance_statuses, run_stats) = execute_collect(&runner);
+    let (instance_statuses, run_stats) = execute_collect(&mut runner);
     assert_eq!(run_stats.timed_out, 2, "2 tests timed out");
     for test_name in ["test_slow_timeout", "test_slow_timeout_2"] {
         let (_, instance_value) = instance_statuses

--- a/nextest-runner/tests/integration/basic.rs
+++ b/nextest-runner/tests/integration/basic.rs
@@ -11,7 +11,7 @@ use nextest_runner::{
     list::BinaryList,
     reporter::heuristic_extract_description,
     runner::{ExecutionDescription, ExecutionResult, TestRunnerBuilder},
-    signal::SignalHandler,
+    signal::SignalHandlerKind,
     target_runner::TargetRunner,
     test_filter::{RunIgnored, TestFilterBuilder},
 };
@@ -98,7 +98,7 @@ fn test_run() -> Result<()> {
         .build(
             &test_list,
             profile,
-            SignalHandler::noop(),
+            SignalHandlerKind::Noop,
             TargetRunner::empty(),
         )
         .unwrap();
@@ -192,7 +192,7 @@ fn test_run_ignored() -> Result<()> {
         .build(
             &test_list,
             profile,
-            SignalHandler::noop(),
+            SignalHandlerKind::Noop,
             TargetRunner::empty(),
         )
         .unwrap();
@@ -387,7 +387,7 @@ fn test_retries(retries: Option<usize>) -> Result<()> {
         .build(
             &test_list,
             profile,
-            SignalHandler::noop(),
+            SignalHandlerKind::Noop,
             TargetRunner::empty(),
         )
         .unwrap();
@@ -509,7 +509,7 @@ fn test_termination() -> Result<()> {
         .build(
             &test_list,
             profile,
-            SignalHandler::noop(),
+            SignalHandlerKind::Noop,
             TargetRunner::empty(),
         )
         .unwrap();

--- a/nextest-runner/tests/integration/basic.rs
+++ b/nextest-runner/tests/integration/basic.rs
@@ -105,8 +105,6 @@ fn test_run() -> Result<()> {
 
     let (instance_statuses, run_stats) = execute_collect(&mut runner);
 
-    println!("collected?");
-
     for (binary_id, expected) in &*EXPECTED_TESTS {
         let test_binary = FIXTURE_TARGETS
             .test_artifacts

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -104,6 +104,7 @@ pub(crate) static EXPECTED_TESTS: Lazy<BTreeMap<&'static str, Vec<TestFixture>>>
                 TestFixture { name: "test_result_failure", status: FixtureStatus::Fail },
                 TestFixture { name: "test_slow_timeout", status: FixtureStatus::IgnoredPass },
                 TestFixture { name: "test_slow_timeout_2", status: FixtureStatus::IgnoredPass },
+                TestFixture { name: "test_subprocess_doesnt_exit", status: FixtureStatus::Pass },
                 TestFixture { name: "test_success", status: FixtureStatus::Pass },
                 TestFixture { name: "test_success_should_panic", status: FixtureStatus::Pass },
             ],

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -40,6 +40,7 @@ pub(crate) enum FixtureStatus {
     Pass,
     Fail,
     Flaky { pass_attempt: usize },
+    Leak,
     Segfault,
     IgnoredPass,
     IgnoredFail,
@@ -53,7 +54,10 @@ impl FixtureStatus {
                 if pass_attempt <= total_attempts {
                     ExecutionResult::Pass
                 } else {
-                    ExecutionResult::Fail { abort_status: None }
+                    ExecutionResult::Fail {
+                        abort_status: None,
+                        leaked: false,
+                    }
                 }
             }
             FixtureStatus::Segfault => {
@@ -70,11 +74,16 @@ impl FixtureStatus {
                         let abort_status = None;
                     }
                 }
-                ExecutionResult::Fail { abort_status }
+                ExecutionResult::Fail {
+                    abort_status,
+                    leaked: false,
+                }
             }
-            FixtureStatus::Fail | FixtureStatus::IgnoredFail => {
-                ExecutionResult::Fail { abort_status: None }
-            }
+            FixtureStatus::Fail | FixtureStatus::IgnoredFail => ExecutionResult::Fail {
+                abort_status: None,
+                leaked: false,
+            },
+            FixtureStatus::Leak => ExecutionResult::Leak,
         }
     }
 
@@ -104,7 +113,7 @@ pub(crate) static EXPECTED_TESTS: Lazy<BTreeMap<&'static str, Vec<TestFixture>>>
                 TestFixture { name: "test_result_failure", status: FixtureStatus::Fail },
                 TestFixture { name: "test_slow_timeout", status: FixtureStatus::IgnoredPass },
                 TestFixture { name: "test_slow_timeout_2", status: FixtureStatus::IgnoredPass },
-                TestFixture { name: "test_subprocess_doesnt_exit", status: FixtureStatus::Pass },
+                TestFixture { name: "test_subprocess_doesnt_exit", status: FixtureStatus::Leak },
                 TestFixture { name: "test_success", status: FixtureStatus::Pass },
                 TestFixture { name: "test_success_should_panic", status: FixtureStatus::Pass },
             ],

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -11,7 +11,10 @@ use nextest_runner::{
     list::{BinaryList, RustBuildMeta, RustTestArtifact, TestList, TestListState},
     reporter::TestEvent,
     reuse_build::PathMapper,
-    runner::{AbortStatus, ExecutionResult, ExecutionStatuses, RunStats, TestRunner},
+    runner::{
+        configure_handle_inheritance, AbortStatus, ExecutionResult, ExecutionStatuses, RunStats,
+        TestRunner,
+    },
     target_runner::TargetRunner,
     test_filter::TestFilterBuilder,
 };
@@ -344,6 +347,7 @@ pub(crate) fn execute_collect<'a>(
     RunStats,
 ) {
     let mut instance_statuses = HashMap::new();
+    configure_handle_inheritance(false).expect("configuring handle inheritance on Windows failed");
     let run_stats = runner.execute(|event| {
         let (test_instance, status) = match event {
             TestEvent::TestSkipped {

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -285,6 +285,7 @@ impl FixtureTargets {
             self.rust_build_meta.clone(),
             test_filter,
             target_runner,
+            num_cpus::get(),
         )
         .expect("test list successfully created")
     }

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -116,6 +116,7 @@ pub(crate) static EXPECTED_TESTS: Lazy<BTreeMap<&'static str, Vec<TestFixture>>>
                 TestFixture { name: "test_result_failure", status: FixtureStatus::Fail },
                 TestFixture { name: "test_slow_timeout", status: FixtureStatus::IgnoredPass },
                 TestFixture { name: "test_slow_timeout_2", status: FixtureStatus::IgnoredPass },
+                TestFixture { name: "test_stdin_closed", status: FixtureStatus::Pass },
                 TestFixture { name: "test_subprocess_doesnt_exit", status: FixtureStatus::Leak },
                 TestFixture { name: "test_success", status: FixtureStatus::Pass },
                 TestFixture { name: "test_success_should_panic", status: FixtureStatus::Pass },

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -327,7 +327,7 @@ impl fmt::Debug for InstanceStatus {
 }
 
 pub(crate) fn execute_collect<'a>(
-    runner: &TestRunner<'a>,
+    runner: &mut TestRunner<'a>,
 ) -> (
     HashMap<(&'a Utf8Path, &'a str), InstanceValue<'a>>,
     RunStats,

--- a/nextest-runner/tests/integration/target_runner.rs
+++ b/nextest-runner/tests/integration/target_runner.rs
@@ -256,6 +256,7 @@ fn test_run_with_target_runner() -> Result<()> {
                             if fixture.status == FixtureStatus::Segfault {
                                 expected_status = nextest_runner::runner::ExecutionResult::Fail {
                                     abort_status: None,
+                                    leaked: false,
                                 };
                             }
                         }

--- a/nextest-runner/tests/integration/target_runner.rs
+++ b/nextest-runner/tests/integration/target_runner.rs
@@ -8,7 +8,7 @@ use nextest_runner::{
     cargo_config::{CargoConfigs, TargetTriple},
     config::NextestConfig,
     runner::TestRunnerBuilder,
-    signal::SignalHandler,
+    signal::SignalHandlerKind,
     target_runner::{PlatformRunner, TargetRunner},
     test_filter::{RunIgnored, TestFilterBuilder},
 };
@@ -216,7 +216,7 @@ fn test_run_with_target_runner() -> Result<()> {
 
     let runner = TestRunnerBuilder::default();
     let mut runner = runner
-        .build(&test_list, profile, SignalHandler::noop(), target_runner)
+        .build(&test_list, profile, SignalHandlerKind::Noop, target_runner)
         .unwrap();
 
     let (instance_statuses, run_stats) = execute_collect(&mut runner);

--- a/nextest-runner/tests/integration/target_runner.rs
+++ b/nextest-runner/tests/integration/target_runner.rs
@@ -215,9 +215,11 @@ fn test_run_with_target_runner() -> Result<()> {
         .expect("default config is valid");
 
     let runner = TestRunnerBuilder::default();
-    let runner = runner.build(&test_list, profile, SignalHandler::noop(), target_runner);
+    let mut runner = runner
+        .build(&test_list, profile, SignalHandler::noop(), target_runner)
+        .unwrap();
 
-    let (instance_statuses, run_stats) = execute_collect(&runner);
+    let (instance_statuses, run_stats) = execute_collect(&mut runner);
 
     for (name, expected) in &*EXPECTED_TESTS {
         let test_binary = FIXTURE_TARGETS

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -18,6 +18,8 @@ backtrace = { version = "0.3.66", features = ["gimli-symbolize", "std"] }
 clap = { version = "3.2.12", features = ["atty", "clap_derive", "color", "derive", "env", "once_cell", "std", "strsim", "suggestions", "termcolor"] }
 console = { version = "0.15.0", features = ["ansi-parsing", "regex", "unicode-width"] }
 either = { version = "1.7.0", features = ["use_std"] }
+futures-channel = { version = "0.3.21", features = ["alloc", "futures-sink", "sink", "std"] }
+futures-sink = { version = "0.3.21", default-features = false, features = ["alloc", "std"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 log = { version = "0.4.17", default-features = false, features = ["std"] }
 memchr = { version = "2.5.0", features = ["std", "use_std"] }
@@ -41,18 +43,27 @@ regex-syntax = { version = "0.6.27", features = ["unicode", "unicode-age", "unic
 syn = { version = "1.0.98", features = ["clone-impls", "derive", "extra-traits", "fold", "full", "parsing", "printing", "proc-macro", "quote", "visit-mut"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
+futures-core = { version = "0.3.21", features = ["alloc", "std"] }
+futures-sink = { version = "0.3.21" }
 libc = { version = "0.2.126", features = ["extra_traits", "std"] }
+tokio = { version = "1.20.0", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "rt", "rt-multi-thread", "socket2", "sync", "time", "tokio-macros"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 libc = { version = "0.2.126", features = ["extra_traits", "std"] }
 
 [target.x86_64-apple-darwin.dependencies]
+futures-core = { version = "0.3.21", features = ["alloc", "std"] }
+futures-sink = { version = "0.3.21" }
 libc = { version = "0.2.126", features = ["extra_traits", "std"] }
+tokio = { version = "1.20.0", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "rt", "rt-multi-thread", "socket2", "sync", "time", "tokio-macros"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
 libc = { version = "0.2.126", features = ["extra_traits", "std"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
+futures-core = { version = "0.3.21", features = ["alloc", "std"] }
+futures-sink = { version = "0.3.21" }
+tokio = { version = "1.20.0", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "rt", "rt-multi-thread", "socket2", "sync", "time", "tokio-macros", "winapi"] }
 winapi = { version = "0.3.9", default-features = false, features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "processenv", "processthreadsapi", "profileapi", "shlobj", "std", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winreg", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 windows-sys = { version = "0.36.1", features = ["Win32", "Win32_Foundation", "Win32_Networking", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage", "Win32_Storage_FileSystem", "Win32_System", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_WindowsProgramming"] }
 

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -46,7 +46,7 @@ syn = { version = "1.0.98", features = ["clone-impls", "derive", "extra-traits",
 futures-core = { version = "0.3.21", features = ["alloc", "std"] }
 futures-sink = { version = "0.3.21" }
 libc = { version = "0.2.126", features = ["std"] }
-tokio = { version = "1.20.0", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"] }
+tokio = { version = "1.20.0", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 libc = { version = "0.2.126", features = ["std"] }
@@ -55,7 +55,7 @@ libc = { version = "0.2.126", features = ["std"] }
 futures-core = { version = "0.3.21", features = ["alloc", "std"] }
 futures-sink = { version = "0.3.21" }
 libc = { version = "0.2.126", features = ["std"] }
-tokio = { version = "1.20.0", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"] }
+tokio = { version = "1.20.0", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
 libc = { version = "0.2.126", features = ["std"] }
@@ -63,7 +63,7 @@ libc = { version = "0.2.126", features = ["std"] }
 [target.x86_64-pc-windows-msvc.dependencies]
 futures-core = { version = "0.3.21", features = ["alloc", "std"] }
 futures-sink = { version = "0.3.21" }
-tokio = { version = "1.20.0", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros", "winapi"] }
-winapi = { version = "0.3.9", default-features = false, features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "processenv", "processthreadsapi", "profileapi", "shlobj", "std", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winreg", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
+tokio = { version = "1.20.0", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros", "winapi"] }
+winapi = { version = "0.3.9", default-features = false, features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "processenv", "processthreadsapi", "profileapi", "shlobj", "std", "synchapi", "sysinfoapi", "threadpoollegacyapiset", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winreg", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 
 ### END HAKARI SECTION

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -45,26 +45,25 @@ syn = { version = "1.0.98", features = ["clone-impls", "derive", "extra-traits",
 [target.x86_64-unknown-linux-gnu.dependencies]
 futures-core = { version = "0.3.21", features = ["alloc", "std"] }
 futures-sink = { version = "0.3.21" }
-libc = { version = "0.2.126", features = ["extra_traits", "std"] }
-tokio = { version = "1.20.0", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "rt", "rt-multi-thread", "socket2", "sync", "time", "tokio-macros"] }
+libc = { version = "0.2.126", features = ["std"] }
+tokio = { version = "1.20.0", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
-libc = { version = "0.2.126", features = ["extra_traits", "std"] }
+libc = { version = "0.2.126", features = ["std"] }
 
 [target.x86_64-apple-darwin.dependencies]
 futures-core = { version = "0.3.21", features = ["alloc", "std"] }
 futures-sink = { version = "0.3.21" }
-libc = { version = "0.2.126", features = ["extra_traits", "std"] }
-tokio = { version = "1.20.0", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "rt", "rt-multi-thread", "socket2", "sync", "time", "tokio-macros"] }
+libc = { version = "0.2.126", features = ["std"] }
+tokio = { version = "1.20.0", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
-libc = { version = "0.2.126", features = ["extra_traits", "std"] }
+libc = { version = "0.2.126", features = ["std"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
 futures-core = { version = "0.3.21", features = ["alloc", "std"] }
 futures-sink = { version = "0.3.21" }
-tokio = { version = "1.20.0", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "rt", "rt-multi-thread", "socket2", "sync", "time", "tokio-macros", "winapi"] }
+tokio = { version = "1.20.0", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros", "winapi"] }
 winapi = { version = "0.3.9", default-features = false, features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "processenv", "processthreadsapi", "profileapi", "shlobj", "std", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winreg", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
-windows-sys = { version = "0.36.1", features = ["Win32", "Win32_Foundation", "Win32_Networking", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage", "Win32_Storage_FileSystem", "Win32_System", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_WindowsProgramming"] }
 
 ### END HAKARI SECTION


### PR DESCRIPTION
Switch to tokio for the main runner loop so we get the ability to select across pipe reads and timeouts.

Use this to detect and handle tests which spawn subprocesses that leak handles. We treat them as passing tests for now, though might make leak failures configurable in the future.

Note that we can only detect subprocesses which inherit standard input/output/error. We can't detect subprocesses spawned with piped stdio that outlive the process. That's a far more challenging problem (see duct's [gotchas.md](https://github.com/oconnor663/duct.py/blob/master/gotchas.md#killing-grandchild-processes) for more). However this solves the immediate problem of nextest hanging because of unclosed pipes, and is probably the most common set of issues.

TODO:

- [x] ~Combine env var definitions between duct and tokio::process::Command~ (handled by switching list phase to use duct instead)
- [x] surface leaks in the UI
- [x] add leak to `cargo-nextest::integration` fixture checks
- [x] Close inherited handles on Windows (see https://github.com/rust-lang/rust/issues/54760, workaround listed there should work for us as well)
- [x] make leak timeout configurable

Closes #15.