### PR TITLE
[nextest-runner] add a --tool-config-file option

### DIFF
--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -136,13 +136,48 @@ impl StatusLevelParseError {
     }
 }
 
+/// Error returned while parsing a [`ToolConfigFile`](crate::config::ToolConfigFile) value.
+#[derive(Clone, Debug, Error)]
+pub enum ToolConfigFileParseError {
+    #[error(
+        "tool-config-file has invalid format: {input}\n(hint: tool configs must be in the format <tool-name>:<path>)"
+    )]
+    /// The input was not in the format "tool:path".
+    InvalidFormat {
+        /// The input that failed to parse.
+        input: String,
+    },
+
+    /// The tool name was empty.
+    #[error("tool-config-file has empty tool name: {input}")]
+    EmptyToolName {
+        /// The input that failed to parse.
+        input: String,
+    },
+
+    /// The config file path was empty.
+    #[error("tool-config-file has empty config file path: {input}")]
+    EmptyConfigFile {
+        /// The input that failed to parse.
+        input: String,
+    },
+
+    /// The config file was not an absolute path.
+    #[error("tool-config-file is not an absolute path: {config_file}")]
+    ConfigFileNotAbsolute {
+        /// The file name that wasn't absolute.
+        config_file: Utf8PathBuf,
+    },
+}
+
 /// Error returned while parsing a [`TestThreads`](crate::config::TestThreads) value.
 #[derive(Clone, Debug, Error)]
 #[error(
-    "unrecognized value for test-threads: {input}\n(expected either an integer or \"num-cpus\")"
+    "unrecognized value for test-threads: {input}\n(hint: expected either an integer or \"num-cpus\")"
 )]
 pub struct TestThreadsParseError {
-    input: String,
+    /// The input that failed to parse.
+    pub input: String,
 }
 
 impl TestThreadsParseError {

--- a/nextest-runner/tests/integration/basic.rs
+++ b/nextest-runner/tests/integration/basic.rs
@@ -88,8 +88,7 @@ fn test_run() -> Result<()> {
 
     let test_filter = TestFilterBuilder::any(RunIgnored::Default);
     let test_list = FIXTURE_TARGETS.make_test_list(&test_filter, &TargetRunner::empty());
-    let config = NextestConfig::from_sources(workspace_root(), &*PACKAGE_GRAPH, None)
-        .expect("loaded fixture config");
+    let config = load_config();
     let profile = config
         .profile(NextestConfig::DEFAULT_PROFILE)
         .expect("default config is valid");
@@ -180,8 +179,7 @@ fn test_run_ignored() -> Result<()> {
 
     let test_filter = TestFilterBuilder::any(RunIgnored::IgnoredOnly);
     let test_list = FIXTURE_TARGETS.make_test_list(&test_filter, &TargetRunner::empty());
-    let config = NextestConfig::from_sources(workspace_root(), &*PACKAGE_GRAPH, None)
-        .expect("loaded fixture config");
+    let config = load_config();
     let profile = config
         .profile(NextestConfig::DEFAULT_PROFILE)
         .expect("default config is valid");
@@ -368,8 +366,7 @@ fn test_retries(retries: Option<usize>) -> Result<()> {
 
     let test_filter = TestFilterBuilder::any(RunIgnored::Default);
     let test_list = FIXTURE_TARGETS.make_test_list(&test_filter, &TargetRunner::empty());
-    let config = NextestConfig::from_sources(workspace_root(), &*PACKAGE_GRAPH, None)
-        .expect("loaded fixture config");
+    let config = load_config();
     let profile = config
         .profile("with-retries")
         .expect("with-retries config is valid");
@@ -507,8 +504,7 @@ fn test_termination() -> Result<()> {
     );
 
     let test_list = FIXTURE_TARGETS.make_test_list(&test_filter, &TargetRunner::empty());
-    let config = NextestConfig::from_sources(workspace_root(), &*PACKAGE_GRAPH, None)
-        .expect("loaded fixture config");
+    let config = load_config();
     let profile = config
         .profile("with-termination")
         .expect("with-termination config is valid");

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -8,6 +8,7 @@ use guppy::{graph::PackageGraph, MetadataCommand};
 use maplit::btreemap;
 use nextest_metadata::{FilterMatch, MismatchReason};
 use nextest_runner::{
+    config::NextestConfig,
     list::{BinaryList, RustBuildMeta, RustTestArtifact, TestList, TestListState},
     reporter::TestEvent,
     reuse_build::PathMapper,
@@ -207,6 +208,11 @@ pub(crate) fn workspace_root() -> Utf8PathBuf {
         .parent()
         .unwrap()
         .join("fixtures/nextest-tests")
+}
+
+pub(crate) fn load_config() -> NextestConfig {
+    NextestConfig::from_sources(workspace_root(), &*PACKAGE_GRAPH, None, [])
+        .expect("loaded fixture config")
 }
 
 pub(crate) static PACKAGE_GRAPH: Lazy<PackageGraph> = Lazy::new(|| {

--- a/nextest-runner/tests/integration/target_runner.rs
+++ b/nextest-runner/tests/integration/target_runner.rs
@@ -208,8 +208,7 @@ fn test_run_with_target_runner() -> Result<()> {
 
     let test_list = FIXTURE_TARGETS.make_test_list(&test_filter, &target_runner);
 
-    let config = NextestConfig::from_sources(workspace_root(), &*PACKAGE_GRAPH, None)
-        .expect("loaded fixture config");
+    let config = load_config();
     let profile = config
         .profile(NextestConfig::DEFAULT_PROFILE)
         .expect("default config is valid");


### PR DESCRIPTION
Add an option for tools that integrate with nextest to specify configs
that are lower than .config/nextest.toml in priority, but higher than
the default config.

An example of a tool that would benefit from this is https://github.com/saethlin/miri-tools; see https://github.com/rust-lang/miri/pull/2398#issuecomment-1190903374.