### PR TITLE
[nextest-runner] put each test into a process group on unix

### DIFF
--- a/nextest-runner/src/reporter.rs
+++ b/nextest-runner/src/reporter.rs
@@ -742,6 +742,7 @@ impl<'a> TestReporterImpl<'a> {
                     CancelReason::TestFailure => "test failure",
                     CancelReason::ReportError => "error",
                     CancelReason::Signal => "signal",
+                    CancelReason::Interrupt => "interrupt",
                 };
 
                 writeln!(
@@ -1325,8 +1326,11 @@ pub enum CancelReason {
     /// An error occurred while reporting results.
     ReportError,
 
-    /// A termination signal was received.
+    /// A termination signal (on Unix, SIGTERM or SIGHUP) was received.
     Signal,
+
+    /// An interrupt (on Unix, Ctrl-C) was received.
+    Interrupt,
 }
 
 #[derive(Debug, Default)]

--- a/nextest-runner/src/signal.rs
+++ b/nextest-runner/src/signal.rs
@@ -88,19 +88,19 @@ mod imp {
                 tokio::select! {
                     recv = self.sigint.signal.recv(), if !self.sigint.done => {
                         match recv {
-                            Some(()) => break Some(SignalEvent::Interrupted),
+                            Some(()) => break Some(SignalEvent::Interrupt),
                             None => self.sigint.done = true,
                         }
                     }
                     recv = self.sighup.signal.recv(), if !self.sighup.done => {
                         match recv {
-                            Some(()) => break Some(SignalEvent::Interrupted),
+                            Some(()) => break Some(SignalEvent::Hangup),
                             None => self.sighup.done = true,
                         }
                     }
                     recv = self.sigterm.signal.recv(), if !self.sigterm.done => {
                         match recv {
-                            Some(()) => break Some(SignalEvent::Interrupted),
+                            Some(()) => break Some(SignalEvent::Term),
                             None => self.sigterm.done = true,
                         }
                     }
@@ -155,7 +155,7 @@ mod imp {
             }
 
             match self.ctrl_c.recv().await {
-                Some(()) => Some(SignalEvent::Interrupted),
+                Some(()) => Some(SignalEvent::Interrupt),
                 None => {
                     self.ctrl_c_done = true;
                     None
@@ -166,7 +166,11 @@ mod imp {
 }
 
 // Just a single-valued enum for now, might have more information in the future.
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(crate) enum SignalEvent {
-    Interrupted,
+    #[cfg(unix)]
+    Hangup,
+    #[cfg(unix)]
+    Term,
+    Interrupt,
 }


### PR DESCRIPTION
This allows for a process and all its child processes to be signaled
atomically.

A child process spawned by a test can choose to run in another process
group, but that's quite uncommon.

The one regression with process groups is that if you press Ctrl-C, tests no longer
exit. In the second commit we fix those regressions by forwarding Ctrl-C (and also SIGTERM/SIGHUP) to child process groups.

This should address https://github.com/rust-lang/miri/issues/2421 on Unix. Going to do a similar patch on Windows as well.