### PR TITLE
[nextest-runner] use job objects for process management on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,6 +1121,7 @@ dependencies = [
  "tokio",
  "toml",
  "twox-hash",
+ "win32job",
  "windows",
  "zstd",
 ]
@@ -2408,6 +2409,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
 dependencies = [
  "webpki",
+]
+
+[[package]]
+name = "win32job"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b2a14136f6c8be9146ac6345774ab32cb93e7985319b4a1b42abb663bd64235"
+dependencies = [
+ "thiserror",
+ "winapi",
 ]
 
 [[package]]

--- a/cargo-nextest/src/tests_integration/fixtures.rs
+++ b/cargo-nextest/src/tests_integration/fixtures.rs
@@ -61,6 +61,7 @@ pub static EXPECTED_LIST: Lazy<Vec<TestInfo>> = Lazy::new(|| {
                 ("test_result_failure", false),
                 ("test_slow_timeout", true),
                 ("test_slow_timeout_2", true),
+                ("test_slow_timeout_subprocess", true),
                 ("test_stdin_closed", false),
                 ("test_subprocess_doesnt_exit", false),
                 ("test_success", false),
@@ -327,10 +328,10 @@ pub fn check_run_output(stderr: &[u8], relocated: bool) {
     }
 
     let summary_reg = if relocated {
-        Regex::new(r"Summary \[.*\] *26 tests run: 18 passed \(1 leaky\), 8 failed, 4 skipped")
+        Regex::new(r"Summary \[.*\] *26 tests run: 18 passed \(1 leaky\), 8 failed, 5 skipped")
             .unwrap()
     } else {
-        Regex::new(r"Summary \[.*\] *26 tests run: 19 passed \(1 leaky\), 7 failed, 4 skipped")
+        Regex::new(r"Summary \[.*\] *26 tests run: 19 passed \(1 leaky\), 7 failed, 5 skipped")
             .unwrap()
     };
     assert!(

--- a/fixtures/nextest-tests/tests/basic.rs
+++ b/fixtures/nextest-tests/tests/basic.rs
@@ -167,6 +167,17 @@ fn test_slow_timeout_2() {
     std::thread::sleep(std::time::Duration::from_millis(1500));
 }
 
+#[cfg(any(unix, windows))]
+#[test]
+#[ignore]
+fn test_slow_timeout_subprocess() {
+    // Set a time greater than 5 seconds (that's the maximum amount the with_termination tests
+    // thinks tests should run for). Without job objects on Windows, the test wouldn't return until
+    // the sleep command exits.
+    let mut cmd = sleep_cmd(15);
+    cmd.output().unwrap();
+}
+
 #[test]
 fn test_result_failure() -> Result<(), std::io::Error> {
     Err(std::io::Error::new(

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -85,7 +85,9 @@ libc = "0.2.126"
 windows = { version = "0.39.0", features = [
     "Win32_Foundation",
     "Win32_System_Console",
+    "Win32_System_JobObjects",
 ] }
+win32job = "1.0.1"
 
 [dev-dependencies]
 color-eyre = { version = "0.6.2", default-features = false }

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -117,6 +117,7 @@ pub(crate) static EXPECTED_TESTS: Lazy<BTreeMap<&'static str, Vec<TestFixture>>>
                 TestFixture { name: "test_result_failure", status: FixtureStatus::Fail },
                 TestFixture { name: "test_slow_timeout", status: FixtureStatus::IgnoredPass },
                 TestFixture { name: "test_slow_timeout_2", status: FixtureStatus::IgnoredPass },
+                TestFixture { name: "test_slow_timeout_subprocess", status: FixtureStatus::IgnoredPass },
                 TestFixture { name: "test_stdin_closed", status: FixtureStatus::Pass },
                 TestFixture { name: "test_subprocess_doesnt_exit", status: FixtureStatus::Leak },
                 TestFixture { name: "test_success", status: FixtureStatus::Pass },

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -64,6 +64,6 @@ libc = { version = "0.2.126", features = ["std"] }
 futures-core = { version = "0.3.21", features = ["alloc", "std"] }
 futures-sink = { version = "0.3.21" }
 tokio = { version = "1.20.0", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "once_cell", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros", "winapi"] }
-winapi = { version = "0.3.9", default-features = false, features = ["consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "processenv", "processthreadsapi", "profileapi", "shlobj", "std", "synchapi", "sysinfoapi", "threadpoollegacyapiset", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winreg", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
+winapi = { version = "0.3.9", default-features = false, features = ["basetsd", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "jobapi2", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "processenv", "processthreadsapi", "profileapi", "psapi", "shlobj", "std", "synchapi", "sysinfoapi", "threadpoollegacyapiset", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winreg", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 
 ### END HAKARI SECTION


### PR DESCRIPTION
A job object allows us to atomically kill all child processes within a test.

There are some race conditions involved here, so we ignore errors -- job objects are a best-effort thing for us.