### PR TITLE
Build binaries for Linux aarch64 on CI.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,8 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-18.04
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-18.04
           - target: x86_64-pc-windows-msvc
             os: windows-latest
     runs-on: ${{ matrix.os }}
@@ -112,6 +114,7 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
+          target: ${{ matrix.target }}
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: cargo-nextest
@@ -134,7 +137,8 @@ jobs:
             echo "::set-output name=${{ matrix.target }}-tar::${{ github.ref_name }}-${{ matrix.target }}".tar.gz
           fi
     outputs:
-      linux-tar: ${{ steps.archive-output.outputs.x86_64-unknown-linux-gnu-tar }}
+      x86_64-linux-tar: ${{ steps.archive-output.outputs.x86_64-unknown-linux-gnu-tar }}
+      aarch64-linux-tar: ${{ steps.archive-output.outputs.aarch64-unknown-linux-gnu-tar }}
       windows-tar: ${{ steps.archive-output.outputs.x86_64-pc-windows-msvc-tar }}
       windows-zip: ${{ steps.archive-output.outputs.x86_64-pc-windows-msvc-zip }}
 
@@ -184,7 +188,8 @@ jobs:
           ~/bin/mukti-bin add-release --version ${{ needs.cargo-nextest-release.outputs.version }} \
             --release-url "https://github.com/nextest-rs/nextest/releases/${{ github.ref_name }}" \
             --archive-prefix "https://github.com/nextest-rs/nextest/releases/download/${{ github.ref_name }}" \
-            --archive x86_64-unknown-linux-gnu:tar.gz=${{ needs.build-cargo-nextest-binaries.outputs.linux-tar }} \
+            --archive x86_64-unknown-linux-gnu:tar.gz=${{ needs.build-cargo-nextest-binaries.outputs.x86_64-linux-tar }} \
+            --archive aarch64-unknown-linux-gnu:tar.gz=${{ needs.build-cargo-nextest-binaries.outputs.aarch64-linux-tar }} \
             --archive x86_64-pc-windows-msvc:tar.gz=${{ needs.build-cargo-nextest-binaries.outputs.windows-tar }} \
             --archive x86_64-pc-windows-msvc:zip=${{ needs.build-cargo-nextest-binaries.outputs.windows-zip }} \
             --archive universal-apple-darwin:tar.gz=${{ needs.build-cargo-nextest-binaries-mac.outputs.mac-tar }}
@@ -193,6 +198,7 @@ jobs:
           mkdir out-dir
           ~/bin/mukti-bin generate-netlify out-dir \
             --alias linux=x86_64-unknown-linux-gnu:tar.gz \
+            --alias linux-arm=aarch64-unknown-linux-gnu:tar.gz \
             --alias windows=x86_64-pc-windows-msvc:zip \
             --alias windows-tar=x86_64-pc-windows-msvc:tar.gz \
             --alias mac=universal-apple-darwin:tar.gz \

--- a/site/src/book/release-urls.md
+++ b/site/src/book/release-urls.md
@@ -20,6 +20,7 @@ The `{platform}` identifier is:
 For convenience, the following shortcuts are defined:
 
 * `linux` points to `x86_64-unknown-linux-gnu.tar.gz`
+* `linux-arm` points to `aarch64-unknown-linux-gnu.tar.gz`
 * `mac` points to `universal-apple-darwin.tar.gz`
 * `windows` points to `x86_64-pc-windows-msvc.zip`
 * `windows-tar` points to `x86_64-pc-windows-msvc.tar.gz`


### PR DESCRIPTION
Fixes https://github.com/nextest-rs/nextest/issues/392.

@sunshowers thanks for sharing the link to the playground, it was very helpful. I did experiment with it, and I _think_ this should build the binaries correctly, but I'm not 100% sure.