### PR TITLE
[nextest-runner] parse CLI configs passed in via --config

### DIFF
--- a/cargo-nextest/src/cargo_cli.rs
+++ b/cargo-nextest/src/cargo_cli.rs
@@ -125,9 +125,11 @@ pub(crate) struct CargoOptions {
     #[clap(long, group = "cargo-opts")]
     offline: bool,
 
+    // NOTE: this does not conflict with reuse build opts since we let target.runner be specified
+    // this way
     /// Override a configuration value (unstable)
-    #[clap(long, value_name = "KEY=VALUE", group = "cargo-opts")]
-    config: Vec<String>,
+    #[clap(long, value_name = "KEY=VALUE")]
+    pub(crate) config: Vec<String>,
 
     /// Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
     #[clap(short = 'Z', value_name = "FLAG", group = "cargo-opts")]

--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -914,11 +914,13 @@ impl App {
     fn new(base: BaseApp, build_filter: TestBuildFilter) -> Result<Self> {
         check_experimental_filtering(base.output);
 
+        let cargo_configs = CargoConfigs::new(&base.cargo_opts.config)
+            .map_err(|err| ExpectedError::CargoConfigsConstructError { err })?;
+
         Ok(Self {
             base,
             build_filter,
-            cargo_configs: CargoConfigs::new()
-                .map_err(|err| ExpectedError::CargoConfigsConstructError { err })?,
+            cargo_configs,
             target_triple: OnceCell::new(),
             target_runner: OnceCell::new(),
         })
@@ -1321,6 +1323,7 @@ mod tests {
             "cargo nextest list --archive-file my-archive.tar.zst --extract-to my-path --extract-overwrite",
             "cargo nextest list --archive-file my-archive.tar.zst --persist-extract-tempdir",
             "cargo nextest list --archive-file my-archive.tar.zst --workspace-remap foo",
+            "cargo nextest list --archive-file my-archive.tar.zst --config target.'cfg(all())'.runner=\"my-runner\"",
             // ---
             // Filter expressions
             // ---

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -795,6 +795,17 @@ pub enum CargoConfigsConstructError {
     /// The current directory was invalid UTF-8.
     #[error("current directory is invalid UTF-8")]
     CurrentDirInvalidUtf8(#[source] FromPathBufError),
+
+    /// Parsing a CLI config option failed.
+    #[error("failed to parse --config option `{config_str}` as TOML")]
+    CliConfigParseError {
+        /// The CLI config option.
+        config_str: String,
+
+        /// The error that occurred trying to deserialize the config.
+        #[source]
+        error: toml::de::Error,
+    },
 }
 
 /// An error occurred while looking for Cargo configuration files.

--- a/nextest-runner/tests/integration/target_runner.rs
+++ b/nextest-runner/tests/integration/target_runner.rs
@@ -22,7 +22,12 @@ fn default() -> &'static target_spec::Platform {
 }
 
 fn runner_for_target(triple: Option<&str>) -> Result<TargetRunner> {
-    let configs = CargoConfigs::new_with_isolation(&workspace_root(), &workspace_root()).unwrap();
+    let configs = CargoConfigs::new_with_isolation(
+        Vec::<String>::new(),
+        &workspace_root(),
+        &workspace_root(),
+    )
+    .unwrap();
     let triple = TargetTriple::find(&configs, triple)?;
     Ok(TargetRunner::new(&configs, triple.as_ref())?)
 }
@@ -77,7 +82,9 @@ fn parse_triple(triple: &'static str) -> target_spec::Platform {
 fn parses_cargo_config_exact() {
     let workspace_root = workspace_root();
     let windows = parse_triple("x86_64-pc-windows-gnu");
-    let configs = CargoConfigs::new_with_isolation(&workspace_root, &workspace_root).unwrap();
+    let configs =
+        CargoConfigs::new_with_isolation(Vec::<String>::new(), &workspace_root, &workspace_root)
+            .unwrap();
     let runner = PlatformRunner::find_config(&configs, windows)
         .unwrap()
         .unwrap();
@@ -90,7 +97,9 @@ fn parses_cargo_config_exact() {
 fn disregards_non_matching() {
     let workspace_root = workspace_root();
     let windows = parse_triple("x86_64-unknown-linux-gnu");
-    let configs = CargoConfigs::new_with_isolation(&workspace_root, &workspace_root).unwrap();
+    let configs =
+        CargoConfigs::new_with_isolation(Vec::<String>::new(), &workspace_root, &workspace_root)
+            .unwrap();
     assert!(PlatformRunner::find_config(&configs, windows)
         .unwrap()
         .is_none());
@@ -100,7 +109,9 @@ fn disregards_non_matching() {
 fn parses_cargo_config_cfg() {
     let workspace_root = workspace_root();
     let android = parse_triple("aarch64-linux-android");
-    let configs = CargoConfigs::new_with_isolation(&workspace_root, &workspace_root).unwrap();
+    let configs =
+        CargoConfigs::new_with_isolation(Vec::<String>::new(), &workspace_root, &workspace_root)
+            .unwrap();
     let runner = PlatformRunner::find_config(&configs, android)
         .unwrap()
         .unwrap();

--- a/nextest-runner/tests/integration/target_triple.rs
+++ b/nextest-runner/tests/integration/target_triple.rs
@@ -42,7 +42,12 @@ fn parses_cargo_env() {
 // TODO: tests involving Cargo configs -- ensure the current dir is used for that.
 
 fn target_triple(target_cli_option: Option<&str>) -> Result<Option<TargetTriple>> {
-    let configs = CargoConfigs::new_with_isolation(&workspace_root(), &workspace_root()).unwrap();
+    let configs = CargoConfigs::new_with_isolation(
+        Vec::<String>::new(),
+        &workspace_root(),
+        &workspace_root(),
+    )
+    .unwrap();
     let triple = TargetTriple::find(&configs, target_cli_option)?;
     Ok(triple)
 }


### PR DESCRIPTION
Follow the same rules that Cargo does:
* configs form valid TOML files
* hierarchical config: env vars over CLI options
* configs followed from left to right

Tested against Miri past https://github.com/rust-lang/miri/pull/2428.

Closes #400.

cc @saethlin