### PR TITLE
[nextest-runner] add process-group hack to regain performance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_PROFILE_RELEASE_LTO: true
+          # Temporary hack until Rust 1.64 is stabilized.
+          RUSTC_BOOTSTRAP: 1
+          RUSTFLAGS: --cfg process_group --cfg process_group_bootstrap_hack
       - name: Set archive output variable
         id: archive-output
         shell: bash
@@ -163,6 +166,10 @@ jobs:
         id: build-release
         run: |
           ./scripts/release-mac-build.sh cargo-nextest "${{ github.ref_name }}"
+        env:
+          # Temporary hack until Rust 1.64 is stabilized.
+          RUSTC_BOOTSTRAP: 1
+          RUSTFLAGS: --cfg process_group --cfg process_group_bootstrap_hack
       - uses: svenstaro/upload-release-action@2.2.1
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/nextest-runner/src/lib.rs
+++ b/nextest-runner/src/lib.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 #![warn(missing_docs)]
+// This is a temporary hack for our builds until Rust 1.64 is stabilized.
+#![cfg_attr(process_group_bootstrap_hack, feature(process_set_process_group))]
 
 //! Core functionality for [cargo nextest](https://crates.io/crates/cargo-nextest). For a
 //! higher-level overview, see that documentation.


### PR DESCRIPTION
We're going to remove this hack once Rust 1.64 is stabilized.