### PR TITLE
Implement NEXTEST_RUN_ID env-var to identify runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,6 +1121,7 @@ dependencies = [
  "tokio",
  "toml",
  "twox-hash",
+ "uuid",
  "win32job",
  "windows",
  "zstd",
@@ -2257,6 +2258,15 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+
+[[package]]
+name = "uuid"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "version_check"

--- a/fixtures/nextest-tests/Cargo.lock
+++ b/fixtures/nextest-tests/Cargo.lock
@@ -23,4 +23,11 @@ name = "nextest-tests"
 version = "0.1.0"
 dependencies = [
  "dylib-test",
+ "uuid",
 ]
+
+[[package]]
+name = "uuid"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"

--- a/fixtures/nextest-tests/Cargo.toml
+++ b/fixtures/nextest-tests/Cargo.toml
@@ -32,3 +32,4 @@ members = [
 
 [dependencies]
 dylib-test = { path = "dylib-test" }
+uuid = "1.1.2"

--- a/fixtures/nextest-tests/tests/basic.rs
+++ b/fixtures/nextest-tests/tests/basic.rs
@@ -123,6 +123,11 @@ fn test_cargo_env_vars() {
         Ok("1"),
         "NEXTEST environment variable set to 1"
     );
+    std::env::var("NEXTEST_RUN_ID")
+        .expect("NEXTEST_RUN_ID must be set")
+        .parse::<uuid::Uuid>()
+        .expect("NEXTEST_RUN_ID must be a UUID");
+
     assert_eq!(
         std::env::var("NEXTEST_EXECUTION_MODE").as_deref(),
         Ok("process-per-test"),

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -77,6 +77,7 @@ nextest-filtering = { version = "0.2.0", path = "../nextest-filtering" }
 nextest-metadata = { version = "0.5.0", path = "../nextest-metadata" }
 quick-junit = { version = "0.2.0", path = "../quick-junit" }
 nextest-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+uuid = { version = "1.1.2", features = ["v4"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.126"

--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -34,6 +34,7 @@ use tokio::{
     runtime::Runtime,
     sync::mpsc::UnboundedSender,
 };
+use uuid::Uuid;
 
 /// Test runner options.
 #[derive(Debug, Default)]
@@ -114,6 +115,7 @@ impl TestRunnerBuilder {
                 test_list,
                 target_runner,
                 runtime,
+                run_id: Uuid::new_v4(),
             },
             handler,
         })
@@ -170,6 +172,7 @@ struct TestRunnerInner<'a> {
     test_list: &'a TestList<'a>,
     target_runner: TargetRunner,
     runtime: Runtime,
+    run_id: Uuid,
 }
 
 impl<'a> TestRunnerInner<'a> {
@@ -452,6 +455,7 @@ impl<'a> TestRunnerInner<'a> {
 
         // Debug environment variable for testing.
         cmd.env("__NEXTEST_ATTEMPT", format!("{}", attempt));
+        cmd.env("NEXTEST_RUN_ID", format!("{}", self.run_id));
         cmd.stdin(Stdio::null());
         imp::cmd_pre_exec(&mut cmd);
 


### PR DESCRIPTION
This implements a `NEXTEST_RUN_ID` as proposed in #416.

Refs https://github.com/mitsuhiko/insta/issues/242