### PR TITLE
Add i686-pc-windows-msvc in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,8 @@ jobs:
             os: ubuntu-18.04
           - target: x86_64-pc-windows-msvc
             os: windows-latest
+          - target: i686-pc-windows-msvc
+            os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -135,7 +137,7 @@ jobs:
         id: archive-output
         shell: bash
         run: |
-          if [[ ${{ matrix.target }} == "x86_64-pc-windows-msvc" ]]; then
+          if [[ ${{ matrix.target }} == "x86_64-pc-windows-msvc" || ${{ matrix.target }} == "i686-pc-windows-msvc" ]]; then
             echo "::set-output name=${{ matrix.target }}-tar::${{ github.ref_name }}-${{ matrix.target }}".tar.gz
             echo "::set-output name=${{ matrix.target }}-zip::${{ github.ref_name }}-${{ matrix.target }}".zip
           else
@@ -145,8 +147,10 @@ jobs:
       x86_64-linux-tar: ${{ steps.archive-output.outputs.x86_64-unknown-linux-gnu-tar }}
       x86_64-linux-musl-tar: ${{ steps.archive-output.outputs.x86_64-unknown-linux-musl-tar }}
       aarch64-linux-tar: ${{ steps.archive-output.outputs.aarch64-unknown-linux-gnu-tar }}
-      windows-tar: ${{ steps.archive-output.outputs.x86_64-pc-windows-msvc-tar }}
-      windows-zip: ${{ steps.archive-output.outputs.x86_64-pc-windows-msvc-zip }}
+      x86_64-windows-tar: ${{ steps.archive-output.outputs.x86_64-pc-windows-msvc-tar }}
+      x86_64-windows-zip: ${{ steps.archive-output.outputs.x86_64-pc-windows-msvc-zip }}
+      i686-windows-tar: ${{ steps.archive-output.outputs.i686-pc-windows-msvc-tar }}
+      i686-windows-zip: ${{ steps.archive-output.outputs.i686-pc-windows-msvc-zip }}
 
   build-cargo-nextest-binaries-mac:
     name: Build universal cargo-nextest binary for Mac
@@ -201,8 +205,10 @@ jobs:
             --archive x86_64-unknown-linux-gnu:tar.gz=${{ needs.build-cargo-nextest-binaries.outputs.x86_64-linux-tar }} \
             --archive x86_64-unknown-linux-musl:tar.gz=${{ needs.build-cargo-nextest-binaries.outputs.x86_64-linux-musl-tar }} \
             --archive aarch64-unknown-linux-gnu:tar.gz=${{ needs.build-cargo-nextest-binaries.outputs.aarch64-linux-tar }} \
-            --archive x86_64-pc-windows-msvc:tar.gz=${{ needs.build-cargo-nextest-binaries.outputs.windows-tar }} \
-            --archive x86_64-pc-windows-msvc:zip=${{ needs.build-cargo-nextest-binaries.outputs.windows-zip }} \
+            --archive x86_64-pc-windows-msvc:tar.gz=${{ needs.build-cargo-nextest-binaries.outputs.x86_64-windows-tar }} \
+            --archive x86_64-pc-windows-msvc:zip=${{ needs.build-cargo-nextest-binaries.outputs.x86_64-windows-zip }} \
+            --archive i686-pc-windows-msvc:tar.gz=${{ needs.build-cargo-nextest-binaries.outputs.i686-windows-tar }} \
+            --archive i686-pc-windows-msvc:zip=${{ needs.build-cargo-nextest-binaries.outputs.i686-windows-zip }} \
             --archive universal-apple-darwin:tar.gz=${{ needs.build-cargo-nextest-binaries-mac.outputs.mac-tar }}
       - name: Generate netlify redirects
         run: |
@@ -213,6 +219,8 @@ jobs:
             --alias linux-arm=aarch64-unknown-linux-gnu:tar.gz \
             --alias windows=x86_64-pc-windows-msvc:zip \
             --alias windows-tar=x86_64-pc-windows-msvc:tar.gz \
+            --alias windows-x86=i686-pc-windows-msvc:zip \
+            --alias windows-x86-tar=i686-pc-windows-msvc:tar.gz \
             --alias mac=universal-apple-darwin:tar.gz \
       - name: Update releases.json on main branch
         run: |

--- a/site/src/book/pre-built-binaries.md
+++ b/site/src/book/pre-built-binaries.md
@@ -3,6 +3,7 @@
 The quickest way to get going with nextest is to download a pre-built binary for your platform. The latest nextest release is available at:
 * [**get.nexte.st/latest/linux**](https://get.nexte.st/latest/linux) for Linux x86_64, including Windows Subsystem for Linux (WSL)
 * [**get.nexte.st/latest/linux-arm**](https://get.nexte.st/latest/linux-arm) for Linux aarch64
+* [**get.nexte.st/latest/linux-musl**](https://get.nexte.st/latest/linux-musl) for Linux with musl libc
 * [**get.nexte.st/latest/mac**](https://get.nexte.st/latest/mac) for macOS, both x86_64 and Apple Silicon
 * [**get.nexte.st/latest/windows**](https://get.nexte.st/latest/windows) for Windows x86_64
 

--- a/site/src/book/pre-built-binaries.md
+++ b/site/src/book/pre-built-binaries.md
@@ -6,6 +6,7 @@ The quickest way to get going with nextest is to download a pre-built binary for
 * [**get.nexte.st/latest/linux-musl**](https://get.nexte.st/latest/linux-musl) for Linux with musl libc
 * [**get.nexte.st/latest/mac**](https://get.nexte.st/latest/mac) for macOS, both x86_64 and Apple Silicon
 * [**get.nexte.st/latest/windows**](https://get.nexte.st/latest/windows) for Windows x86_64
+* [**get.nexte.st/latest/windows-x86**](https://get.nexte.st/latest/windows-x86) for Windows i686
 
 These archives contain a single binary called `cargo-nextest` (`cargo-nextest.exe` on Windows). Add this binary to a location on your PATH.
 

--- a/site/src/book/release-urls.md
+++ b/site/src/book/release-urls.md
@@ -18,6 +18,8 @@ The `{platform}` identifier is:
 * `universal-apple-darwin.tar.gz` for x86_64 and arm64 macOS (tar.gz)
 * `x86_64-pc-windows-msvc.zip` for x86_64 Windows (zip)
 * `x86_64-pc-windows-msvc.tar.gz` for x86_64 Windows (tar.gz)
+* `i686-pc-windows-msvc.zip` for i686 Windows (zip)
+* `i686-pc-windows-msvc.tar.gz` for i686 Windows (tar.gz)
 
 For convenience, the following shortcuts are defined:
 
@@ -27,6 +29,8 @@ For convenience, the following shortcuts are defined:
 * `mac` points to `universal-apple-darwin.tar.gz`
 * `windows` points to `x86_64-pc-windows-msvc.zip`
 * `windows-tar` points to `x86_64-pc-windows-msvc.tar.gz`
+* `windows-x86` points to `i686-pc-windows-msvc.zip`
+* `windows-x86-tar` points to `i686-pc-windows-msvc.tar.gz`
 
 Also, each release's canonical GitHub Releases URL is available at **`https://get.nexte.st/{version}/release`**. For example, the latest GitHub release is avaiable at [get.nexte.st/latest/release](https://get.nexte.st/latest/release).
 


### PR DESCRIPTION
Closes #419

- Site: Add latest pre-built link for `x86_64-unknown-linux-musl`
- Release: Add pre-build for `i686-pc-windows-msvc`
- Site: Add info and links for pre-built for `i686-pc-windows-msvc`