### PR TITLE
fix(runner): cancel retry if cancel signal is received

### DIFF
--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -291,7 +291,9 @@ impl<'a> TestRunnerInner<'a> {
                                     // The test succeeded.
                                     run_statuses.push(run_status);
                                     break;
-                                } else if attempt < total_attempts {
+                                } else if attempt < total_attempts
+                                    && !canceled_ref.load(Ordering::Acquire)
+                                {
                                     // Retry this test: send a retry event, then retry the loop.
                                     let _ = this_run_sender.send(InternalTestEvent::Retry {
                                         test_instance,


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

Currently, a test will still be retried even if nextest receives a cancel signal. This PR fixes this behavior by not retrying after cancelled. To reproduce this issue, press Ctrl+C immediately after `cargo nextest run` with the following config and test crate:

nextest.toml:

```toml
[profile.default]
retries = 5
slow-timeout = { period = "5s" }
status-level = "all"
final-status-level = "slow"
```

lib.rs:

```rust
#[cfg(test)]
mod tests {
    #[test]
    fn test_timeout() {
        println!("test");
        std::thread::sleep(std::time::Duration::from_secs(10));
        println!("test");
    }    
}
```