### PR TITLE
[nextest-runner] support changes to CLI config options added in Rust 1.63

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,6 +341,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "config"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,7 +1159,7 @@ dependencies = [
  "test-case",
  "thiserror",
  "tokio",
- "toml",
+ "toml_edit",
  "twox-hash",
  "uuid",
  "win32job",
@@ -2182,6 +2192,18 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
+dependencies = [
+ "combine",
+ "indexmap",
+ "itertools",
  "serde",
 ]
 

--- a/cargo-nextest/src/cargo_cli.rs
+++ b/cargo-nextest/src/cargo_cli.rs
@@ -127,7 +127,7 @@ pub(crate) struct CargoOptions {
 
     // NOTE: this does not conflict with reuse build opts since we let target.runner be specified
     // this way
-    /// Override a configuration value (unstable)
+    /// Override a configuration value
     #[clap(long, value_name = "KEY=VALUE")]
     pub(crate) config: Vec<String>,
 

--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -924,8 +924,7 @@ impl App {
     fn new(base: BaseApp, build_filter: TestBuildFilter) -> Result<Self> {
         check_experimental_filtering(base.output);
 
-        let cargo_configs = CargoConfigs::new(&base.cargo_opts.config)
-            .map_err(|err| ExpectedError::CargoConfigsConstructError { err })?;
+        let cargo_configs = CargoConfigs::new(&base.cargo_opts.config)?;
 
         Ok(Self {
             base,

--- a/cargo-nextest/src/errors.rs
+++ b/cargo-nextest/src/errors.rs
@@ -49,10 +49,10 @@ pub enum ExpectedError {
         #[source]
         err: std::io::Error,
     },
-    #[error("cargo configs construction error")]
-    CargoConfigsConstructError {
+    #[error("cargo config error")]
+    CargoConfigError {
         #[from]
-        err: CargoConfigsConstructError,
+        err: CargoConfigError,
     },
     #[error("config parse error")]
     ConfigParseError {
@@ -292,7 +292,7 @@ impl ExpectedError {
             Self::ProfileNotFound { .. }
             | Self::StoreDirCreateError { .. }
             | Self::RootManifestNotFound { .. }
-            | Self::CargoConfigsConstructError { .. }
+            | Self::CargoConfigError { .. }
             | Self::ConfigParseError { .. }
             | Self::ArgumentFileReadError { .. }
             | Self::UnknownArchiveFormat { .. }
@@ -376,7 +376,7 @@ impl ExpectedError {
                 );
                 Some(err as &dyn Error)
             }
-            Self::CargoConfigsConstructError { err } => {
+            Self::CargoConfigError { err } => {
                 log::error!("{}", err);
                 err.source()
             }

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -58,7 +58,7 @@ tokio = { version = "1.20.1", features = [
     "sync",
     "time",
 ] }
-toml = "0.5.9"
+toml_edit = { version = "0.14.4", features = ["easy"] }
 twox-hash = { version = "1.6.3", default-features = false }
 zstd = { version = "0.11.2", features = ["zstdmt"] }
 

--- a/nextest-runner/src/cargo_config.rs
+++ b/nextest-runner/src/cargo_config.rs
@@ -221,7 +221,7 @@ fn parse_cli_configs(
         .map(|config_str| {
             // Each cargo config is expected to be a valid TOML file.
             let config_str = config_str.as_ref();
-            let config = toml::from_str(config_str).map_err(|error| {
+            let config = toml_edit::easy::from_str(config_str).map_err(|error| {
                 CargoConfigsConstructError::CliConfigParseError {
                     config_str: config_str.to_owned(),
                     error,
@@ -310,12 +310,13 @@ fn discover_impl(
                     error,
                 }
             })?;
-            let config: CargoConfig = toml::from_str(&config_contents).map_err(|error| {
-                CargoConfigSearchError::ConfigParseError {
-                    path: path.clone(),
-                    error,
-                }
-            })?;
+            let config: CargoConfig =
+                toml_edit::easy::from_str(&config_contents).map_err(|error| {
+                    CargoConfigSearchError::ConfigParseError {
+                        path: path.clone(),
+                        error,
+                    }
+                })?;
             Ok((CargoConfigSource::File(path), config))
         })
         .collect::<Result<Vec<_>, CargoConfigSearchError>>()?;

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -804,7 +804,7 @@ pub enum CargoConfigsConstructError {
 
         /// The error that occurred trying to deserialize the config.
         #[source]
-        error: toml::de::Error,
+        error: toml_edit::easy::de::Error,
     },
 }
 
@@ -850,7 +850,7 @@ pub enum CargoConfigSearchError {
 
         /// The error that occurred trying to deserialize the config file
         #[source]
-        error: toml::de::Error,
+        error: toml_edit::easy::de::Error,
     },
 }
 

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -787,7 +787,7 @@ pub enum WriteEventError {
 /// instance.
 #[derive(Debug, Error)]
 #[non_exhaustive]
-pub enum CargoConfigsConstructError {
+pub enum CargoConfigError {
     /// Failed to retrieve the current directory.
     #[error("failed to retrieve current directory")]
     GetCurrentDir(#[source] std::io::Error),
@@ -830,39 +830,7 @@ pub enum CargoConfigsConstructError {
         #[source]
         reason: InvalidCargoCliConfigReason,
     },
-}
 
-/// The reason an invalid CLI config failed.
-///
-/// Part of [`CargoConfigsConstructError::InvalidCliConfig`].
-#[derive(Copy, Clone, Debug, Error, Eq, PartialEq)]
-#[non_exhaustive]
-pub enum InvalidCargoCliConfigReason {
-    /// The argument is not a TOML dotted key expression.
-    #[error("was not a TOML dotted key expression (such as `build.jobs = 2`)")]
-    NotDottedKv,
-
-    /// The argument includes non-whitespace decoration.
-    #[error("includes non-whitespace decoration")]
-    IncludesNonWhitespaceDecoration,
-
-    /// The argument sets a value to an inline table.
-    #[error("sets a value to an inline table, which is not accepted")]
-    SetsValueToInlineTable,
-
-    /// The argument sets a value to an array of tables.
-    #[error("sets a value to an array of tables, which is not accepted")]
-    SetsValueToArrayOfTables,
-
-    /// The argument doesn't provide a value.
-    #[error("doesn't provide a value")]
-    DoesntProvideValue,
-}
-
-/// An error occurred while looking for Cargo configuration files.
-#[derive(Debug, Error)]
-#[non_exhaustive]
-pub enum CargoConfigSearchError {
     /// A non-UTF-8 path was encountered.
     #[error("non-UTF-8 path encountered")]
     NonUtf8Path(#[source] FromPathBufError),
@@ -905,6 +873,33 @@ pub enum CargoConfigSearchError {
     },
 }
 
+/// The reason an invalid CLI config failed.
+///
+/// Part of [`CargoConfigError::InvalidCliConfig`].
+#[derive(Copy, Clone, Debug, Error, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum InvalidCargoCliConfigReason {
+    /// The argument is not a TOML dotted key expression.
+    #[error("was not a TOML dotted key expression (such as `build.jobs = 2`)")]
+    NotDottedKv,
+
+    /// The argument includes non-whitespace decoration.
+    #[error("includes non-whitespace decoration")]
+    IncludesNonWhitespaceDecoration,
+
+    /// The argument sets a value to an inline table.
+    #[error("sets a value to an inline table, which is not accepted")]
+    SetsValueToInlineTable,
+
+    /// The argument sets a value to an array of tables.
+    #[error("sets a value to an array of tables, which is not accepted")]
+    SetsValueToArrayOfTables,
+
+    /// The argument doesn't provide a value.
+    #[error("doesn't provide a value")]
+    DoesntProvideValue,
+}
+
 /// An error occurred while determining the cross-compiling target triple.
 #[derive(Debug, Error)]
 pub enum TargetTripleError {
@@ -920,7 +915,7 @@ pub enum TargetTripleError {
     CargoConfigSearchError(
         #[from]
         #[source]
-        CargoConfigSearchError,
+        CargoConfigError,
     ),
 }
 
@@ -963,7 +958,7 @@ pub enum TargetRunnerError {
     CargoConfigSearchError(
         #[from]
         #[source]
-        CargoConfigSearchError,
+        CargoConfigError,
     ),
 }
 


### PR DESCRIPTION
Rust 1.63 stabilizes `--config` with a few changes: https://github.com/rust-lang/cargo/pull/10755

Mirror those changes into nextest.