### PR TITLE
fix: respect test runner during build reuse

### DIFF
--- a/nextest-metadata/src/test_list.rs
+++ b/nextest-metadata/src/test_list.rs
@@ -271,6 +271,9 @@ pub struct RustBuildMetaSummary {
 
     /// Linked paths, relative to the target directory.
     pub linked_paths: BTreeSet<Utf8PathBuf>,
+
+    /// The target triple used while compiling the Rust artifacts
+    pub target_triple: String,
 }
 
 /// A non-test Rust binary. Used to set the correct environment

--- a/nextest-runner/src/cargo_config.rs
+++ b/nextest-runner/src/cargo_config.rs
@@ -165,7 +165,7 @@ impl fmt::Display for TargetTripleSource {
                 write!(f, "`build.target` within `{path}`")
             }
             Self::Metadata => {
-                write!(f, "--binaries-metadata option")
+                write!(f, "--archive-file or --binaries-metadata option")
             }
         }
     }

--- a/nextest-runner/src/list/test_list.rs
+++ b/nextest-runner/src/list/test_list.rs
@@ -958,7 +958,11 @@ pub(crate) fn make_test_command(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{list::SerializableFormat, test_filter::RunIgnored};
+    use crate::{
+        cargo_config::{TargetTriple, TargetTripleSource},
+        list::SerializableFormat,
+        test_filter::RunIgnored,
+    };
     use guppy::CargoMetadata;
     use indoc::indoc;
     use maplit::btreemap;
@@ -1017,7 +1021,12 @@ mod tests {
             build_platform: BuildPlatform::Host,
         };
 
-        let rust_build_meta = RustBuildMeta::new("/fake").map_paths(&PathMapper::noop());
+        let fake_triple = TargetTriple {
+            triple: "fake-triple".to_owned(),
+            source: TargetTripleSource::CliOption,
+        };
+        let rust_build_meta =
+            RustBuildMeta::new("/fake", Some(fake_triple)).map_paths(&PathMapper::noop());
         let test_list = TestList::new_with_outputs(
             [
                 (test_binary, &non_ignored_output, &ignored_output),
@@ -1114,7 +1123,8 @@ mod tests {
                 "target-directory": "/fake",
                 "base-output-directories": [],
                 "non-test-binaries": {},
-                "linked-paths": []
+                "linked-paths": [],
+                "target-triple": "fake-triple"
               },
               "test-count": 6,
               "rust-suites": {

--- a/nextest-runner/tests/integration/basic.rs
+++ b/nextest-runner/tests/integration/basic.rs
@@ -25,7 +25,7 @@ fn test_list_binaries() -> Result<()> {
 
     let graph = &*PACKAGE_GRAPH;
     let binary_list =
-        BinaryList::from_messages(Cursor::new(&*FIXTURE_RAW_CARGO_TEST_OUTPUT), graph)?;
+        BinaryList::from_messages(Cursor::new(&*FIXTURE_RAW_CARGO_TEST_OUTPUT), graph, None)?;
 
     for (id, name, platform_is_target) in &EXPECTED_BINARY_LIST {
         let bin = binary_list

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -269,7 +269,8 @@ impl FixtureTargets {
     fn new() -> Self {
         let graph = &*PACKAGE_GRAPH;
         let binary_list = Arc::new(
-            BinaryList::from_messages(Cursor::new(&*FIXTURE_RAW_CARGO_TEST_OUTPUT), graph).unwrap(),
+            BinaryList::from_messages(Cursor::new(&*FIXTURE_RAW_CARGO_TEST_OUTPUT), graph, None)
+                .unwrap(),
         );
         let rust_build_meta = binary_list.rust_build_meta.clone();
 


### PR DESCRIPTION
Fixes #468 

Previously `CARGO_TARGET_<target>_RUNNER` would be ignored if a build was
loaded from an archive file with --archive, because no/the incorrect target-triple was
detected in that case.

This patch changes the runner detection to account for those cases.
The target triple is now stored in the `BuildMetadata`.
If cargo is invoked the triple will be detected with the usual mechanism while
the `BuildMetadata` is generated.
During build-reuse the target triple is loaded from the `BuildMetadataSummary`.

If the target was not manually set, the host target-triple will be used
during serialization. This ensures correct behaviour in cases where
runner has a different default toolchain.

I have tested this locally with a docker container with cross compilation for windows and running with wine. I am not sure if this needs any tests. The changes are quite simple and testing this would probably be quite involved (because you need a working target runner that works for something that is not host).

I think change logs need to be adjusted but I am not sure how exactly this is handled for this project so I held off on that for now.