### PR TITLE
[WIP] [nextest-runner] add rudimentary support for handling SIGTSTP and SIGCONT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,6 +1248,7 @@ dependencies = [
  "once_cell",
  "owo-colors",
  "pathdiff",
+ "pin-project-lite",
  "pretty_assertions",
  "proptest",
  "proptest-derive",

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -38,6 +38,7 @@ rand = "0.8.5"
 miette = "5.4.1"
 once_cell = "1.16.0"
 owo-colors = "3.5.0"
+pin-project-lite = "0.2.9"
 regex = "1.7.0"
 semver = "1.0.14"
 serde = { version = "1.0.147", features = ["derive"] }

--- a/nextest-runner/src/helpers.rs
+++ b/nextest-runner/src/helpers.rs
@@ -184,3 +184,17 @@ pub(crate) fn display_nt_status(nt_status: windows::Win32::Foundation::NTSTATUS)
         io::Error::from_raw_os_error(win32_code as i32)
     );
 }
+
+// From https://twitter.com/8051Enthusiast/status/1571909110009921538
+extern "C" {
+    fn __nextest_external_symbol_that_does_not_exist();
+}
+
+#[inline]
+#[allow(dead_code)]
+pub(crate) fn statically_unreachable() -> ! {
+    unsafe {
+        __nextest_external_symbol_that_does_not_exist();
+    }
+    unreachable!("linker symbol above cannot be resolved")
+}

--- a/nextest-runner/src/lib.rs
+++ b/nextest-runner/src/lib.rs
@@ -21,9 +21,9 @@ pub mod reporter;
 pub mod reuse_build;
 pub mod runner;
 pub mod signal;
-mod stopwatch;
 pub mod target_runner;
 mod test_command;
 pub mod test_filter;
+mod time;
 #[cfg(feature = "self-update")]
 pub mod update;

--- a/nextest-runner/src/reporter.rs
+++ b/nextest-runner/src/reporter.rs
@@ -769,7 +769,24 @@ impl<'a> TestReporterImpl<'a> {
                     running.style(self.styles.count)
                 )?;
             }
-
+            TestEvent::RunPaused { running } => {
+                writeln!(
+                    writer,
+                    "{:>12} {} running tests due to {}",
+                    "Pausing".style(self.styles.pass),
+                    running.style(self.styles.count),
+                    "signal".style(self.styles.count),
+                )?;
+            }
+            TestEvent::RunContinued { running } => {
+                writeln!(
+                    writer,
+                    "{:>12} {} running tests due to {}",
+                    "Continuing".style(self.styles.pass),
+                    running.style(self.styles.count),
+                    "signal".style(self.styles.count),
+                )?;
+            }
             TestEvent::RunFinished {
                 start_time: _start_time,
                 elapsed,
@@ -1349,6 +1366,18 @@ pub enum TestEvent<'a> {
 
         /// The reason this run was canceled.
         reason: CancelReason,
+    },
+
+    /// A SIGTSTP event was received and the run was paused.
+    RunPaused {
+        /// The number of tests currently running.
+        running: usize,
+    },
+
+    /// A SIGCONT event was received and the run is being continued.
+    RunContinued {
+        /// The number of tests that will be started up again.
+        running: usize,
     },
 
     /// The test run finished.

--- a/nextest-runner/src/reporter/aggregator.rs
+++ b/nextest-runner/src/reporter/aggregator.rs
@@ -61,7 +61,9 @@ impl<'cfg> MetadataJunit<'cfg> {
 
     pub(crate) fn write_event(&mut self, event: TestEvent<'cfg>) -> Result<(), WriteEventError> {
         match event {
-            TestEvent::RunStarted { .. } => {}
+            TestEvent::RunStarted { .. }
+            | TestEvent::RunPaused { .. }
+            | TestEvent::RunContinued { .. } => {}
             TestEvent::TestStarted { .. } => {}
             TestEvent::TestSlow { .. } => {}
             TestEvent::TestAttemptFailedWillRetry { .. } | TestEvent::TestRetryStarted { .. } => {

--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -13,8 +13,8 @@ use crate::{
     list::{TestExecuteContext, TestInstance, TestList},
     reporter::{CancelReason, FinalStatusLevel, StatusLevel, TestEvent},
     signal::{SignalEvent, SignalHandler, SignalHandlerKind},
-    stopwatch::{StopwatchEnd, StopwatchStart},
     target_runner::TargetRunner,
+    time::{StopwatchEnd, StopwatchStart},
 };
 use async_scoped::TokioScope;
 use buffer_unordered_weighted::StreamExt;
@@ -547,7 +547,7 @@ impl<'a> TestRunnerInner<'a> {
         forward_receiver: &mut tokio::sync::broadcast::Receiver<SignalForwardEvent>,
         delay_before_start: Duration,
     ) -> InternalExecuteStatus {
-        let stopwatch = StopwatchStart::now();
+        let stopwatch = crate::time::stopwatch();
 
         match self
             .run_test_inner(
@@ -1147,7 +1147,7 @@ where
         Self {
             callback,
             run_id,
-            stopwatch: StopwatchStart::now(),
+            stopwatch: crate::time::stopwatch(),
             run_stats: RunStats {
                 initial_run_count,
                 ..RunStats::default()

--- a/nextest-runner/src/time/mod.rs
+++ b/nextest-runner/src/time/mod.rs
@@ -1,0 +1,6 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+mod stopwatch;
+
+pub(crate) use stopwatch::*;

--- a/nextest-runner/src/time/mod.rs
+++ b/nextest-runner/src/time/mod.rs
@@ -1,6 +1,10 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+#![cfg_attr(not(unix), allow(dead_code))]
+
+mod pausable_sleep;
 mod stopwatch;
 
+pub(crate) use pausable_sleep::*;
 pub(crate) use stopwatch::*;

--- a/nextest-runner/src/time/pausable_sleep.rs
+++ b/nextest-runner/src/time/pausable_sleep.rs
@@ -1,0 +1,99 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use pin_project_lite::pin_project;
+use std::{future::Future, pin::Pin, task::Poll, time::Duration};
+use tokio::time::{Instant, Sleep};
+
+pub(crate) fn pausable_sleep(duration: Duration) -> PausableSleep {
+    PausableSleep::new(duration)
+}
+
+pin_project! {
+    /// A wrapper around `tokio::time::Sleep` that can also be paused, resumed and reset.
+    #[derive(Debug)]
+    pub(crate) struct PausableSleep {
+        #[pin]
+        sleep: Sleep,
+        duration: Duration,
+        pause_state: SleepPauseState,
+    }
+}
+
+impl PausableSleep {
+    fn new(duration: Duration) -> Self {
+        Self {
+            sleep: tokio::time::sleep(duration),
+            duration,
+            pause_state: SleepPauseState::Running,
+        }
+    }
+
+    pub(crate) fn is_paused(&self) -> bool {
+        matches!(self.pause_state, SleepPauseState::Paused { .. })
+    }
+
+    pub(crate) fn pause(self: Pin<&mut Self>) {
+        let this = self.project();
+        match &*this.pause_state {
+            SleepPauseState::Running => {
+                // Figure out how long there is until the deadline.
+                let deadline = this.sleep.deadline();
+                this.sleep.reset(far_future());
+                // This will return 0 if the deadline has passed. That's fine because we'll just
+                // reset the timer back to 0 in resume, which will behave correctly.
+                let remaining = deadline.duration_since(Instant::now());
+                *this.pause_state = SleepPauseState::Paused { remaining };
+            }
+            SleepPauseState::Paused { remaining } => {
+                panic!("illegal state transition: pause() called while sleep was paused (remaining = {remaining:?})");
+            }
+        }
+    }
+
+    pub(crate) fn resume(self: Pin<&mut Self>) {
+        let this = self.project();
+        match &*this.pause_state {
+            SleepPauseState::Paused { remaining } => {
+                this.sleep.reset(Instant::now() + *remaining);
+                *this.pause_state = SleepPauseState::Running;
+            }
+            SleepPauseState::Running => {
+                panic!("illegal state transition: resume() called while sleep was running");
+            }
+        }
+    }
+
+    /// Resets the inner sleep to now + the original duration.
+    pub(crate) fn reset_original_duration(self: Pin<&mut Self>) {
+        let this = self.project();
+        this.sleep.reset(Instant::now() + *this.duration);
+    }
+}
+
+impl Future for PausableSleep {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        match &this.pause_state {
+            SleepPauseState::Running => this.sleep.poll(cx),
+            SleepPauseState::Paused { .. } => Poll::Pending,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum SleepPauseState {
+    Running,
+    Paused { remaining: Duration },
+}
+
+// Cribbed from tokio.
+fn far_future() -> Instant {
+    // Roughly 30 years from now.
+    // API does not provide a way to obtain max `Instant`
+    // or convert specific date in the future to instant.
+    // 1000 years overflows on macOS, 100 years overflows on FreeBSD.
+    Instant::now() + Duration::from_secs(86400 * 365 * 30)
+}

--- a/nextest-runner/src/time/stopwatch.rs
+++ b/nextest-runner/src/time/stopwatch.rs
@@ -9,6 +9,10 @@
 
 use std::time::{Duration, Instant, SystemTime};
 
+pub(crate) fn stopwatch() -> StopwatchStart {
+    StopwatchStart::new()
+}
+
 /// The start state of a stopwatch.
 #[derive(Clone, Debug)]
 pub(crate) struct StopwatchStart {
@@ -17,7 +21,7 @@ pub(crate) struct StopwatchStart {
 }
 
 impl StopwatchStart {
-    pub(crate) fn now() -> Self {
+    fn new() -> Self {
         Self {
             // These two syscalls will happen imperceptibly close to each other, which is good
             // enough for our purposes.


### PR DESCRIPTION
Some interesting issues we've faced while developing this:

## Race in posix_spawn

Sometimes nextest just hangs if Ctrl-Z comes in at the wrong time. This is due to a fundamental race in posix_spawn: https://sourceware.org/pipermail/libc-help/2022-August/006263.html

To solve this issue, we use a double-spawn approach (with `NEXTEST_EXPERIMENTAL_DOUBLE_SPAWN=1` set in the environment and with Rust beta, currently):

1. Block SIGTSTP before calling posix_spawn.
2. Rather than spawning the test process directly, spawn `cargo-nextest __double-spawn <test-binary and args>`.
3. In the child process, unblock SIGTSTP before execing the child process.

## Pausing timers

We need a way to pause all our timers when we're pausing, then resume them afterwards. To do this, introduce a `PausableTimer` with `pause()` and `resume()` methods.