### PR TITLE
Optimization: Collect output in parallel in `TestRunner::run_test_inner`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,6 +1157,7 @@ dependencies = [
  "test-case",
  "thiserror",
  "tokio",
+ "tokio-util",
  "toml_edit",
  "twox-hash",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1144,6 +1144,7 @@ dependencies = [
  "proptest-derive",
  "quick-junit",
  "regex",
+ "scopeguard",
  "self_update",
  "semver",
  "serde",
@@ -1746,6 +1747,12 @@ name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -59,6 +59,7 @@ tokio = { version = "1.21.1", features = [
     "sync",
     "time",
 ] }
+tokio-util = "0.7.4"
 toml_edit = { version = "0.14.4", features = ["easy"] }
 twox-hash = { version = "1.6.3", default-features = false }
 zstd = { version = "0.11.2", features = ["zstdmt"] }

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -37,6 +37,7 @@ once_cell = "1.15.0"
 owo-colors = "3.5.0"
 num_cpus = "1.13.1"
 regex = "1.6.0"
+scopeguard = "1.1.0"
 semver = "1.0.14"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"

--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -1220,6 +1220,9 @@ impl ReadTask {
     }
 
     /// This method is cancel safe.
+    ///
+    /// Once this method returns, you must not call this method
+    /// or [`Self::wait_for_res`].
     async fn wait_for_err(&mut self) -> std::io::Error {
         // wait is cancel safe
         if let Err(err) = self.wait().await {

--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -1241,17 +1241,11 @@ impl ReadTask {
     /// this function would return an empty `Bytes` on the first call.
     ///
     /// Otherwise, this function would return `Poll::Pending` forever.
-    async fn wait_for_res(&mut self) -> std::io::Result<Bytes> {
+    async fn wait_for_res(mut self) -> std::io::Result<Bytes> {
         // This method is cancel safe
         self.wait().await?;
 
-        if let Some(bytes) = self.bytes.take() {
-            Ok(bytes)
-        } else {
-            // Trivally cancel safe as it has no state and always returns
-            // Poll::Pending.
-            pending().await
-        }
+        Ok(self.bytes.take().unwrap())
     }
 }
 

--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -35,7 +35,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 use tokio::{
-    io::{AsyncRead, AsyncReadExt, BufReader},
+    io::{AsyncRead, AsyncReadExt},
     process::Child,
     runtime::Runtime,
     sync::mpsc::UnboundedSender,

--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -504,8 +504,8 @@ impl<'a> TestRunnerInner<'a> {
 
         let mut timeout_hit = 0;
 
-        let child_stdout = child.stdout.take().map(BufReader::new);
-        let child_stderr = child.stderr.take().map(BufReader::new);
+        let child_stdout = child.stdout.take();
+        let child_stderr = child.stderr.take();
 
         let mut stdout = Bytes::from_static(b"");
         let mut stderr = Bytes::from_static(b"");

--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -1162,6 +1162,9 @@ impl ReadTask {
 
             let mut buffer = bytes::BytesMut::with_capacity(4096);
 
+            let cancelled_fut = token.cancelled();
+            tokio::pin!(cancelled_fut);
+
             loop {
                 tokio::select! {
                     res = reader.read_buf(&mut buffer) => {
@@ -1170,7 +1173,7 @@ impl ReadTask {
                             break;
                         }
                     }
-                    () = token.cancelled() => {
+                    () = &mut cancelled_fut => {
                         cancelled.store(true, Ordering::Relaxed);
                         break;
                     }

--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -1167,15 +1167,17 @@ impl ReadTask {
 
             loop {
                 tokio::select! {
+                    biased;
+
+                    () = &mut cancelled_fut => {
+                        cancelled.store(true, Ordering::Relaxed);
+                        break;
+                    }
                     res = reader.read_buf(&mut buffer) => {
                         let bytes_read = res?;
                         if bytes_read == 0 {
                             break;
                         }
-                    }
-                    () = &mut cancelled_fut => {
-                        cancelled.store(true, Ordering::Relaxed);
-                        break;
                     }
                 }
                 buffer.reserve(4096);


### PR DESCRIPTION
* Add new dep tokio-util v0.7.4 to nextest-runner
* Add new dep scopeguard v1.1.0 to nextest-runner
* Create new type `ReadTask` for spawning the read tasks and handles the cancellation.
* Do not wrap `child_std{out, err}` in `BufReader`  since we read the output into a
  `BytesMut` that is at least 4096 large, having an internal buffer here won't help and
   would only incur additional copies.

This moves collection of output to a separate tokio task instead of doing it in the `tokio::select!` loop, which can be the bottleneck since `tokio::select!` is quite complex.

This also simplify the implementation by replacing the second `tokio::select!` loop with a spawned job.

All of the `*_done` boolean flags is also removed.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>