### PR TITLE
Optimization: Rm use of `BufReader` and lazily allocate space for `BytesMut` in `TestRunner::run_test_inner`

### DIFF
--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -522,18 +522,20 @@ impl<'a> TestRunnerInner<'a> {
             // Set up futures for reading from stdout and stderr.
             let stdout_fut = async {
                 if let Some(mut child_stdout) = child_stdout {
-                    read_all_to_bytes(&mut stdout, &mut child_stdout).await?;
+                    read_all_to_bytes(&mut stdout, &mut child_stdout).await
+                } else {
+                    Ok(())
                 }
-                Ok::<_, std::io::Error>(())
             };
             tokio::pin!(stdout_fut);
             let mut stdout_done = false;
 
             let stderr_fut = async {
                 if let Some(mut child_stderr) = child_stderr {
-                    read_all_to_bytes(&mut stderr, &mut child_stderr).await?;
+                    read_all_to_bytes(&mut stderr, &mut child_stderr).await
+                } else {
+                    Ok(())
                 }
-                Ok::<_, std::io::Error>(())
             };
             tokio::pin!(stderr_fut);
             let mut stderr_done = false;

--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -28,12 +28,7 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
     time::{Duration, SystemTime},
 };
-use tokio::{
-    io::{AsyncReadExt, BufReader},
-    process::Child,
-    runtime::Runtime,
-    sync::mpsc::UnboundedSender,
-};
+use tokio::{io::AsyncReadExt, process::Child, runtime::Runtime, sync::mpsc::UnboundedSender};
 use uuid::Uuid;
 
 /// Test runner options.
@@ -498,8 +493,8 @@ impl<'a> TestRunnerInner<'a> {
 
         let child_stdout = child.stdout.take();
         let child_stderr = child.stderr.take();
-        let mut stdout = bytes::BytesMut::with_capacity(4096);
-        let mut stderr = bytes::BytesMut::with_capacity(4096);
+        let mut stdout = bytes::BytesMut::new();
+        let mut stderr = bytes::BytesMut::new();
 
         let (res, leaked) = {
             // Set up futures for reading from stdout and stderr.

--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -496,8 +496,8 @@ impl<'a> TestRunnerInner<'a> {
 
         let mut timeout_hit = 0;
 
-        let child_stdout = child.stdout.take().map(BufReader::new);
-        let child_stderr = child.stderr.take().map(BufReader::new);
+        let child_stdout = child.stdout.take();
+        let child_stderr = child.stderr.take();
         let mut stdout = bytes::BytesMut::with_capacity(4096);
         let mut stderr = bytes::BytesMut::with_capacity(4096);
 


### PR DESCRIPTION
Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>