### PR TITLE
[nextest-runner] before terminating, replace last SLOW message with TERMINATING

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -9,6 +9,10 @@ fail-fast = false
 # This is a test profile with a quick slow timeout.
 slow-timeout = "1s"
 
+[profile.test-slow-with-timeout]
+slow-timeout = { period = "1s", terminate-after = 2 }
+retries = 2
+
 [profile.serial]
 test-threads = 1
 

--- a/nextest-runner/tests/integration/basic.rs
+++ b/nextest-runner/tests/integration/basic.rs
@@ -462,7 +462,7 @@ fn test_retries(retries: Option<RetryPolicy>) -> Result<()> {
                                 assert!(
                                     matches!(prior_status.result, ExecutionResult::Fail { .. }),
                                     "prior status {} should be fail",
-                                    prior_status.attempt
+                                    prior_status.retry_data.attempt
                                 );
                             }
                             last_status.result == ExecutionResult::Pass
@@ -484,7 +484,7 @@ fn test_retries(retries: Option<RetryPolicy>) -> Result<()> {
                                         ExecutionResult::Fail { .. } | ExecutionResult::Leak
                                     ),
                                     "retry {} should be fail or leak",
-                                    retry.attempt
+                                    retry.retry_data.attempt
                                 );
                             }
                             matches!(

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -336,8 +336,8 @@ impl fmt::Debug for InstanceStatus {
                     write!(
                         f,
                         "({}/{}) {:?}\n---STDOUT---\n{}\n\n---STDERR---\n{}\n\n",
-                        run_status.attempt,
-                        run_status.total_attempts,
+                        run_status.retry_data.attempt,
+                        run_status.retry_data.total_attempts,
                         run_status.result,
                         String::from_utf8_lossy(&run_status.stdout),
                         String::from_utf8_lossy(&run_status.stderr)

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,7 @@
+allow-branch = ["main"]
+sign-tag = true
+consolidate-commits = true
+pre-release-commit-message = "[meta] prepare releases"
+tag-message = "{{crate_name}} version {{version}}"
+tag-name = "{{prefix}}{{version}}"
+dev-version = false


### PR DESCRIPTION
Flagged in #571.