### PR TITLE
add support for restricting overrides to particular platforms

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,6 +5,12 @@ final-status-level = "slow"
 # Don't fail fast in CI to run the full test suite.
 fail-fast = false
 
+[[profile.ci.overrides]]
+# These tests are a bit flaky on Mac GHA CI runners due to resource exhaustion.
+platform = 'cfg(target_os = "macos")'
+filter = 'package(nextest-runner) and binary(integration)'
+retries = { count = 3, backoff = "fixed", delay = "1s" }
+
 [profile.test-slow]
 # This is a test profile with a quick slow timeout.
 slow-timeout = "1s"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.135"
+version = "0.2.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+checksum = "55edcf6c0bb319052dea84732cf99db461780fd5e8d3eb46ab6ff312ab31f197"
 
 [[package]]
 name = "link-cplusplus"
@@ -1211,6 +1211,7 @@ dependencies = [
  "libc",
  "log",
  "maplit",
+ "miette",
  "mukti-metadata",
  "nextest-filtering",
  "nextest-metadata",
@@ -1234,6 +1235,7 @@ dependencies = [
  "strip-ansi-escapes",
  "tar",
  "target-spec",
+ "target-spec-miette",
  "tempfile",
  "test-case",
  "thiserror",
@@ -2095,14 +2097,25 @@ checksum = "c02424087780c9b71cc96799eaeddff35af2bc513278cda5c99fc1f5d026d3c1"
 
 [[package]]
 name = "target-spec"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46b1748adaf6a95d3fa8cdf590403e789c5e172dcd9dc4b8c199c7f4be7fc11e"
+checksum = "eb961bf20f35d75a2e8e182c56c7f69890520c957334df265a6c9e37ba7674ae"
 dependencies = [
  "cfg-expr",
  "guppy-workspace-hack",
  "serde",
  "target-lexicon",
+]
+
+[[package]]
+name = "target-spec-miette"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05f99f2cd9ad6c8431ab04c9040e0da05b9ef2f05ca4a48c63939e285ee3cad"
+dependencies = [
+ "guppy-workspace-hack",
+ "miette",
+ "target-spec",
 ]
 
 [[package]]

--- a/nextest-metadata/Cargo.toml
+++ b/nextest-metadata/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.62"
 camino = { version = "1.1.1", features = ["serde1"] }
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.87"
-target-spec = { version = "1.2.0", features = ["summaries"] }
+target-spec = { version = "1.2.1", features = ["summaries"] }
 nextest-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -34,6 +34,7 @@ is_ci = "1.1.1"
 itertools = "0.10.5"
 log = "0.4.17"
 rand = "0.8.5"
+miette = "5.3.0"
 once_cell = "1.15.0"
 owo-colors = "3.5.0"
 num_cpus = "1.13.1"
@@ -46,7 +47,8 @@ shell-words = "1.1.0"
 strip-ansi-escapes = "0.1.1"
 tar = "0.4.38"
 # For cfg expression evaluation for [target.'cfg()'] expressions
-target-spec = { version = "1.2.0", features = ["summaries"] }
+target-spec = { version = "1.2.1", features = ["summaries"] }
+target-spec-miette = "0.1.0"
 tempfile = "3.3.0"
 thiserror = "1.0.37"
 # For parsing of .cargo/config.toml files

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -102,6 +102,9 @@ pub struct ConfigParseOverrideError {
 impl ConfigParseOverrideError {
     /// Returns [`miette::Report`]s for each error recorded by self.
     pub fn reports(&self) -> impl Iterator<Item = miette::Report> + '_ {
+        let not_specified_report = self.not_specified.then(|| {
+            miette::Report::msg("at least one of `platform` and `filter` should be specified")
+        });
         let platform_parse_report = self.platform_parse_error.as_ref().map(|error| {
             // TODO: replace with Report::new_boxed once https://github.com/zkat/miette/pull/214
             // is fixed.
@@ -117,7 +120,10 @@ impl ConfigParseOverrideError {
                         .with_source_code(parse_errors.input.to_owned())
                 })
             });
-        platform_parse_report.into_iter().chain(parse_reports)
+        not_specified_report
+            .into_iter()
+            .chain(platform_parse_report)
+            .chain(parse_reports)
     }
 }
 

--- a/nextest-runner/src/lib.rs
+++ b/nextest-runner/src/lib.rs
@@ -46,6 +46,7 @@ pub mod errors;
 mod helpers;
 pub mod list;
 pub mod partition;
+pub mod platform;
 pub mod reporter;
 pub mod reuse_build;
 pub mod runner;

--- a/nextest-runner/src/list/rust_build_meta.rs
+++ b/nextest-runner/src/list/rust_build_meta.rs
@@ -3,9 +3,10 @@
 
 use crate::{
     cargo_config::TargetTriple,
-    errors::RustBuildMetaParseError,
+    errors::{RustBuildMetaParseError, UnknownHostPlatform},
     helpers::convert_rel_path_to_main_sep,
     list::{BinaryListState, TestListState},
+    platform::BuildPlatforms,
     reuse_build::PathMapper,
 };
 use camino::Utf8PathBuf;
@@ -123,6 +124,11 @@ impl RustBuildMeta<TestListState> {
 }
 
 impl<State> RustBuildMeta<State> {
+    /// Returns the build platforms.
+    pub fn build_platforms(&self) -> Result<BuildPlatforms, UnknownHostPlatform> {
+        BuildPlatforms::new(self.target_triple.clone())
+    }
+
     /// Creates a `RustBuildMeta` from a serializable summary.
     pub fn from_summary(summary: RustBuildMetaSummary) -> Result<Self, RustBuildMetaParseError> {
         let target_triple = if !summary.target_platforms.is_empty() {

--- a/nextest-runner/src/platform.rs
+++ b/nextest-runner/src/platform.rs
@@ -3,9 +3,8 @@
 
 //! Platform-related data structures.
 
+use crate::{cargo_config::TargetTriple, errors::UnknownHostPlatform};
 pub use target_spec::Platform;
-
-use crate::cargo_config::TargetTriple;
 
 /// A representation of host and target platforms.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -23,8 +22,16 @@ pub struct BuildPlatforms {
 impl BuildPlatforms {
     /// Creates a new `BuildPlatform`.
     ///
-    /// The host platform should typically be set to `Platform::current()`.
-    pub fn new(host: Platform, target: Option<TargetTriple>) -> Self {
+    /// Returns an error if the host platform could not be determined.
+    pub fn new(target: Option<TargetTriple>) -> Result<Self, UnknownHostPlatform> {
+        let host = Platform::current().map_err(|error| UnknownHostPlatform { error })?;
+        Ok(Self { host, target })
+    }
+
+    /// Creates a new `BuildPlatform` where the host is specified.
+    ///
+    /// This is intended for testing situations. Most users should call [`Self::new`] instead.
+    pub fn new_with_host(host: Platform, target: Option<TargetTriple>) -> Self {
         Self { host, target }
     }
 }

--- a/nextest-runner/src/reporter.rs
+++ b/nextest-runner/src/reporter.rs
@@ -1416,7 +1416,7 @@ impl Styles {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::NextestConfig;
+    use crate::{config::NextestConfig, platform::BuildPlatforms};
 
     #[test]
     fn no_capture_settings() {
@@ -1430,10 +1430,15 @@ mod tests {
         let test_list = TestList::empty();
         let config = NextestConfig::default_config("/fake/dir");
         let profile = config.profile(NextestConfig::DEFAULT_PROFILE).unwrap();
+        let build_platforms = BuildPlatforms::new(None).unwrap();
 
         let mut buf: Vec<u8> = Vec::new();
         let output = ReporterStderr::Buffer(&mut buf);
-        let reporter = builder.build(&test_list, &profile, output);
+        let reporter = builder.build(
+            &test_list,
+            &profile.apply_build_platforms(&build_platforms),
+            output,
+        );
         assert!(reporter.inner.no_capture, "no_capture is true");
         assert_eq!(
             reporter.inner.failure_output,

--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -1625,7 +1625,7 @@ enum TerminateMode {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::NextestConfig;
+    use crate::{config::NextestConfig, platform::BuildPlatforms};
 
     #[test]
     fn no_capture_settings() {
@@ -1637,9 +1637,15 @@ mod tests {
         let test_list = TestList::empty();
         let config = NextestConfig::default_config("/fake/dir");
         let profile = config.profile(NextestConfig::DEFAULT_PROFILE).unwrap();
+        let build_platforms = BuildPlatforms::new(None).unwrap();
         let handler_kind = SignalHandlerKind::Noop;
         let runner = builder
-            .build(&test_list, profile, handler_kind, TargetRunner::empty())
+            .build(
+                &test_list,
+                profile.apply_build_platforms(&build_platforms),
+                handler_kind,
+                TargetRunner::empty(),
+            )
             .unwrap();
         assert!(runner.inner.no_capture, "no_capture is true");
         assert_eq!(runner.inner.test_threads, 1, "tests run serially");

--- a/nextest-runner/tests/integration/basic.rs
+++ b/nextest-runner/tests/integration/basic.rs
@@ -9,6 +9,7 @@ use nextest_metadata::{BuildPlatform, FilterMatch, MismatchReason};
 use nextest_runner::{
     config::{NextestConfig, RetryPolicy},
     list::BinaryList,
+    platform::BuildPlatforms,
     reporter::heuristic_extract_description,
     runner::{ExecutionDescription, ExecutionResult, TestRunnerBuilder},
     signal::SignalHandlerKind,
@@ -92,11 +93,12 @@ fn test_run() -> Result<()> {
     let profile = config
         .profile(NextestConfig::DEFAULT_PROFILE)
         .expect("default config is valid");
+    let build_platforms = BuildPlatforms::new(None).unwrap();
 
     let mut runner = TestRunnerBuilder::default()
         .build(
             &test_list,
-            profile,
+            profile.apply_build_platforms(&build_platforms),
             SignalHandlerKind::Noop,
             TargetRunner::empty(),
         )
@@ -190,11 +192,12 @@ fn test_run_ignored() -> Result<()> {
     let profile = config
         .profile(NextestConfig::DEFAULT_PROFILE)
         .expect("default config is valid");
+    let build_platforms = BuildPlatforms::new(None).unwrap();
 
     let mut runner = TestRunnerBuilder::default()
         .build(
             &test_list,
-            profile,
+            profile.apply_build_platforms(&build_platforms),
             SignalHandlerKind::Noop,
             TargetRunner::empty(),
         )
@@ -381,6 +384,8 @@ fn test_retries(retries: Option<RetryPolicy>) -> Result<()> {
     let profile = config
         .profile("with-retries")
         .expect("with-retries config is valid");
+    let build_platforms = BuildPlatforms::new(None).unwrap();
+    let profile = profile.apply_build_platforms(&build_platforms);
 
     let profile_retries = profile.retries();
     assert_eq!(
@@ -525,6 +530,8 @@ fn test_termination() -> Result<()> {
     let profile = config
         .profile("with-termination")
         .expect("with-termination config is valid");
+    let build_platforms = BuildPlatforms::new(None).unwrap();
+    let profile = profile.apply_build_platforms(&build_platforms);
 
     let mut runner = TestRunnerBuilder::default()
         .build(

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -29,7 +29,7 @@ nom-tracable = { version = "0.8.0", features = ["trace"] }
 num-traits = { version = "0.2.15", default-features = false, features = ["std"] }
 owo-colors = { version = "3.5.0", default-features = false, features = ["supports-color", "supports-colors"] }
 serde_json = { version = "1.0.87", features = ["std", "unbounded_depth"] }
-target-spec = { version = "1.2.0", default-features = false, features = ["serde", "summaries"] }
+target-spec = { version = "1.2.1", default-features = false, features = ["serde", "summaries"] }
 uuid = { version = "1.2.1", features = ["getrandom", "rng", "std", "v4"] }
 
 [build-dependencies]
@@ -44,26 +44,26 @@ syn = { version = "1.0.103", features = ["clone-impls", "derive", "extra-traits"
 futures-core = { version = "0.3.25", features = ["alloc", "std"] }
 futures-sink = { version = "0.3.25" }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
-libc = { version = "0.2.135", features = ["std"] }
+libc = { version = "0.2.136", features = ["std"] }
 once_cell = { version = "1.15.0", features = ["alloc", "race", "std"] }
 tokio = { version = "1.21.2", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 getrandom = { version = "0.2.8", default-features = false, features = ["std"] }
-libc = { version = "0.2.135", features = ["std"] }
+libc = { version = "0.2.136", features = ["std"] }
 once_cell = { version = "1.15.0", features = ["alloc", "race", "std"] }
 
 [target.x86_64-apple-darwin.dependencies]
 futures-core = { version = "0.3.25", features = ["alloc", "std"] }
 futures-sink = { version = "0.3.25" }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
-libc = { version = "0.2.135", features = ["std"] }
+libc = { version = "0.2.136", features = ["std"] }
 once_cell = { version = "1.15.0", features = ["alloc", "race", "std"] }
 tokio = { version = "1.21.2", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
 getrandom = { version = "0.2.8", default-features = false, features = ["std"] }
-libc = { version = "0.2.135", features = ["std"] }
+libc = { version = "0.2.136", features = ["std"] }
 once_cell = { version = "1.15.0", features = ["alloc", "race", "std"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]


### PR DESCRIPTION
Use target-spec with the new target-spec-miette crate for producing errors.