### PR TITLE
[nextest-runner] shutdown Tokio runtime aggressively

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,7 @@
 [alias]
 xfmt = "fmt -- --config imports_granularity=Crate"
 local-nt = "run --package cargo-nextest -- nextest"
+
+[build]
+# Required for tokio_console support
+rustflags = ["--cfg", "tokio_unstable"]

--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -22,3 +22,7 @@ platforms = [
 
 # Write out exact versions rather than a semver range. (Defaults to false.)
 exact-versions = true
+
+[traversal-excludes]
+# This is not part of the default build and is rarely needed.
+third-party = [{ name = "console-subscriber" }]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,6 +1,13 @@
 [profile.default]
 final-status-level = "slow"
 
+[[profile.default.overrides]]
+# test_subprocess_doesnt_exit runs a sleep command for 360 seconds. If integration tests take longer
+# than 180 seconds, it likely means that nextest is stuck waiting for the sleep command to exit.
+# This is a bug.
+filter = 'package(integration-tests)'
+slow-timeout = { period = "60s", terminate-after = 3 }
+
 [profile.ci]
 # Don't fail fast in CI to run the full test suite.
 fail-fast = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,8 @@ jobs:
         run: cargo build --package cargo-nextest
       - name: Build all targets
         run: cargo build --all-targets
+      - name: Build all targets with all features
+        run: cargo build --all-targets --all-features
       - name: Doctests
         run: cargo test --doc
       - name: Test with locally built nextest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +68,27 @@ dependencies = [
  "pin-project",
  "slab",
  "tokio",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -101,6 +128,51 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "axum"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acee9fd5073ab6b045a275b3e709c163dd36c90685219cb21804a147b58dba43"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e5939e02c56fecd5c017c37df4238c0a839fa76b7f97acdd7efb804fd181cc"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "backtrace"
@@ -397,6 +469,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "console-api"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57ff02e8ad8e06ab9731d5dc72dc23bef9200778eae1a89d555d8c42e5d4a86"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a3a81dfaf6b66bce5d159eddae701e3a002f194d378cbf7be5f053c281d9be"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures",
+ "hdrhistogram",
+ "humantime",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +515,25 @@ name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "422f23e724af1240ec469ea1e834d87a4b59ce2efe2c6a96256b0c47e2fd86aa"
 dependencies = [
  "cfg-if",
 ]
@@ -784,6 +911,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
+dependencies = [
+ "base64",
+ "byteorder",
+ "flate2",
+ "nom 7.1.1",
+ "num-traits",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,6 +968,12 @@ dependencies = [
  "http",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
 
 [[package]]
 name = "httparse"
@@ -892,6 +1038,18 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -1091,6 +1249,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchit"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,6 +1396,7 @@ dependencies = [
  "chrono",
  "color-eyre",
  "config",
+ "console-subscriber",
  "debug-ignore",
  "duct",
  "dunce",
@@ -1629,6 +1803,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0841812012b2d4a6145fae9a6af1534873c32aa67fff26bd09f8fa42c83f95a"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "164ae68b6587001ca506d3bf7f1000bfa248d0e1217b618108fba4ec1d0cc306"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747761bc3dc48f9a34553bf65605cf6cb6288ba219f3450b4275dbd81539551a"
+dependencies = [
+ "bytes",
+ "prost",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,6 +1970,9 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
 
 [[package]]
 name = "regex-syntax"
@@ -1985,6 +2195,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared_child"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2138,6 +2357,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+
+[[package]]
 name = "tar"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2264,6 +2489,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2305,7 +2539,18 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "winapi",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2328,6 +2573,17 @@ dependencies = [
  "rustls",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2376,6 +2632,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b9af819e54b8f33d453655bef9b9acc171568fb49523078d0cc4e7484200ec"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project",
+ "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c530c8675c1dbf98facee631536fa116b5fb6382d7dd6dc1b118d970eafe3ba"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2388,8 +2721,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.103",
 ]
 
 [[package]]
@@ -2399,6 +2745,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+dependencies = [
+ "matchers",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
 ]
 
 [[package]]
@@ -2497,6 +2869,12 @@ checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -60,9 +60,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-scoped"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1181d2a07303ac3e8df0b3bdaaf648b4ac968d352e61158f5c1897db70d22a09"
+checksum = "0e7a6a57c8aeb40da1ec037f5d455836852f7a57e69e1b1ad3d8f38ac1d6cadf"
 dependencies = [
  "futures",
  "pin-project",
@@ -263,9 +263,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "camino"
@@ -318,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406c859255d568f4f742b3146d51851f3bfd49f734a2c289d9107c4395ee0062"
+checksum = "982a0cf6a99c350d7246035613882e376d58cebe571785abc5da4f648d53ac0a"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -332,9 +332,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.76"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
+checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
 dependencies = [
  "jobserver",
 ]
@@ -1100,9 +1100,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -2164,9 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
  "itoa",
  "ryu",
@@ -2525,9 +2525,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2863,9 +2863,9 @@ checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
 
 [[package]]
 name = "uuid"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
+checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 dependencies = [
  "getrandom",
 ]

--- a/cargo-nextest/Cargo.toml
+++ b/cargo-nextest/Cargo.toml
@@ -36,7 +36,7 @@ semver = "1.0.14"
 shell-words = "1.1.0"
 supports-color = "1.3.1"
 supports-unicode = "1.0.2"
-serde_json = "1.0.87"
+serde_json = "1.0.89"
 thiserror = "1.0.37"
 nextest-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 

--- a/cargo-nextest/Cargo.toml
+++ b/cargo-nextest/Cargo.toml
@@ -42,6 +42,7 @@ nextest-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [features]
 default = ["default-no-update", "self-update"]
+experimental-tokio-console = ["nextest-runner/experimental-tokio-console"]
 # Perform self-updates (enabled by default)
 self-update = ["nextest-runner/self-update"]
 # Default set of features excluding self-update. This is the recommended set of features for

--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -57,6 +57,9 @@ pub struct CargoNextestApp {
 impl CargoNextestApp {
     /// Executes the app.
     pub fn exec(self, output_writer: &mut OutputWriter) -> Result<i32> {
+        #[cfg(feature = "experimental-tokio-console")]
+        nextest_runner::console::init();
+
         match self.subcommand {
             NextestSubcommand::Nextest(app) => app.exec(output_writer),
             #[cfg(unix)]

--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -1199,7 +1199,7 @@ impl App {
             }
         };
 
-        let mut runner = runner_builder.build(
+        let runner = runner_builder.build(
             &test_list,
             profile,
             handler,

--- a/fixtures/nextest-tests/tests/basic.rs
+++ b/fixtures/nextest-tests/tests/basic.rs
@@ -282,9 +282,12 @@ fn test_result_failure() -> Result<(), std::io::Error> {
 #[cfg(any(unix, windows))]
 #[test]
 fn test_subprocess_doesnt_exit() {
-    // Note: setting a high value here can cause large delays with the GitHub Actions runner on
-    // Windows.
+    // Note: this is synchronized with a per-test override in the main nextest repo. TODO: This
+    // should actually be 360, but needs to wait until cargo-nextest 0.9.44 is out (because the test
+    // runner itself hangs, and CI is tested against the latest release as well.)
     let mut cmd = sleep_cmd(5);
+    // Try setting stdout to a piped process -- this will cause the runner to hang, unless
+    cmd.stdout(std::process::Stdio::piped());
     cmd.spawn().unwrap();
 }
 

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -24,4 +24,4 @@ nextest-metadata = { version = "=0.7.0", path = "../nextest-metadata" }
 once_cell = "1.16.0"
 tempfile = "3.3.0"
 regex = "1.7.0"
-serde_json = "1.0.87"
+serde_json = "1.0.89"

--- a/nextest-metadata/Cargo.toml
+++ b/nextest-metadata/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.62"
 [dependencies]
 camino = { version = "1.1.1", features = ["serde1"] }
 serde = { version = "1.0.147", features = ["derive"] }
-serde_json = "1.0.87"
+serde_json = "1.0.89"
 target-spec = { version = "1.2.2", features = ["summaries"] }
 nextest-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -84,6 +84,7 @@ nextest-metadata = { version = "0.7.0", path = "../nextest-metadata" }
 quick-junit = { version = "0.3.0", path = "../quick-junit" }
 uuid = { version = "1.2.1", features = ["v4"] }
 nextest-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+console-subscriber = { version = "0.1.8", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.137"
@@ -117,3 +118,4 @@ path = "test-helpers/passthrough.rs"
 
 [features]
 self-update = ["self_update", "mukti-metadata"]
+experimental-tokio-console = ["console-subscriber", "tokio/tracing"]

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -11,13 +11,13 @@ rust-version = "1.62"
 
 [dependencies]
 atomicwrites = "0.3.1"
-aho-corasick = "0.7.19"
-async-scoped = { version = "0.7.0", features = ["use-tokio"] }
+aho-corasick = "0.7.20"
+async-scoped = { version = "0.7.1", features = ["use-tokio"] }
 buffer-unordered-weighted = "0.1.2"
-bytes = "1.2.1"
+bytes = "1.3.0"
 camino = { version = "1.1.1", features = ["serde1"] }
 config = { version = "0.13.2", default-features = false, features = ["toml"] }
-cargo_metadata = "0.15.1"
+cargo_metadata = "0.15.2"
 cfg-if = "1.0.0"
 chrono = "0.4.23"
 debug-ignore = "1.0.3"
@@ -43,7 +43,7 @@ regex = "1.7.0"
 semver = "1.0.14"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_ignored = "0.1.5"
-serde_json = "1.0.87"
+serde_json = "1.0.89"
 serde_path_to_error = "0.1.8"
 shell-words = "1.1.0"
 strip-ansi-escapes = "0.1.1"
@@ -54,7 +54,7 @@ target-spec-miette = "0.1.0"
 tempfile = "3.3.0"
 thiserror = "1.0.37"
 # For parsing of .cargo/config.toml files
-tokio = { version = "1.21.2", features = [
+tokio = { version = "1.22.0", features = [
     "io-util",
     "macros",
     "process",
@@ -82,7 +82,7 @@ self_update = { version = "0.32.0", optional = true, default-features = false, f
 nextest-filtering = { version = "0.2.1", path = "../nextest-filtering" }
 nextest-metadata = { version = "0.7.0", path = "../nextest-metadata" }
 quick-junit = { version = "0.3.0", path = "../quick-junit" }
-uuid = { version = "1.2.1", features = ["v4"] }
+uuid = { version = "1.2.2", features = ["v4"] }
 nextest-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 console-subscriber = { version = "0.1.8", optional = true }
 

--- a/nextest-runner/src/console.rs
+++ b/nextest-runner/src/console.rs
@@ -1,0 +1,11 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Experimental support for creating a Tokio console.
+//!
+//! This is currently not shipped with release builds but is available as a debugging tool.
+
+/// Initializes the Tokio console subscriber.
+pub fn init() {
+    console_subscriber::init();
+}

--- a/nextest-runner/src/lib.rs
+++ b/nextest-runner/src/lib.rs
@@ -11,6 +11,8 @@
 
 pub mod cargo_config;
 pub mod config;
+#[cfg(feature = "experimental-tokio-console")]
+pub mod console;
 pub mod double_spawn;
 pub mod errors;
 mod helpers;

--- a/nextest-runner/src/list/test_list.rs
+++ b/nextest-runner/src/list/test_list.rs
@@ -234,6 +234,11 @@ impl<'g> TestList<'g> {
         let fut = stream.buffer_unordered(list_threads).try_collect();
 
         let rust_suites: BTreeMap<_, _> = runtime.block_on(fut)?;
+
+        // Ensure that the runtime doesn't stay hanging even if a custom test framework misbehaves
+        // (can be an issue on Windows).
+        runtime.shutdown_background();
+
         let test_count = rust_suites
             .values()
             .map(|suite| suite.status.test_count())

--- a/nextest-runner/tests/integration/basic.rs
+++ b/nextest-runner/tests/integration/basic.rs
@@ -96,7 +96,7 @@ fn test_run() -> Result<()> {
         .expect("default config is valid");
     let build_platforms = BuildPlatforms::new(None).unwrap();
 
-    let mut runner = TestRunnerBuilder::default()
+    let runner = TestRunnerBuilder::default()
         .build(
             &test_list,
             profile.apply_build_platforms(&build_platforms),
@@ -106,7 +106,7 @@ fn test_run() -> Result<()> {
         )
         .unwrap();
 
-    let (instance_statuses, run_stats) = execute_collect(&mut runner);
+    let (instance_statuses, run_stats) = execute_collect(runner);
 
     for (binary_id, expected) in &*EXPECTED_TESTS {
         let test_binary = FIXTURE_TARGETS
@@ -197,7 +197,7 @@ fn test_run_ignored() -> Result<()> {
         .expect("default config is valid");
     let build_platforms = BuildPlatforms::new(None).unwrap();
 
-    let mut runner = TestRunnerBuilder::default()
+    let runner = TestRunnerBuilder::default()
         .build(
             &test_list,
             profile.apply_build_platforms(&build_platforms),
@@ -207,7 +207,7 @@ fn test_run_ignored() -> Result<()> {
         )
         .unwrap();
 
-    let (instance_statuses, run_stats) = execute_collect(&mut runner);
+    let (instance_statuses, run_stats) = execute_collect(runner);
 
     for (name, expected) in &*EXPECTED_TESTS {
         let test_binary = FIXTURE_TARGETS
@@ -402,7 +402,7 @@ fn test_retries(retries: Option<RetryPolicy>) -> Result<()> {
     if let Some(retries) = retries {
         builder.set_retries(retries);
     }
-    let mut runner = builder
+    let runner = builder
         .build(
             &test_list,
             profile,
@@ -412,7 +412,7 @@ fn test_retries(retries: Option<RetryPolicy>) -> Result<()> {
         )
         .unwrap();
 
-    let (instance_statuses, run_stats) = execute_collect(&mut runner);
+    let (instance_statuses, run_stats) = execute_collect(runner);
 
     for (name, expected) in &*EXPECTED_TESTS {
         let test_binary = FIXTURE_TARGETS
@@ -538,7 +538,7 @@ fn test_termination() -> Result<()> {
     let build_platforms = BuildPlatforms::new(None).unwrap();
     let profile = profile.apply_build_platforms(&build_platforms);
 
-    let mut runner = TestRunnerBuilder::default()
+    let runner = TestRunnerBuilder::default()
         .build(
             &test_list,
             profile,
@@ -548,7 +548,7 @@ fn test_termination() -> Result<()> {
         )
         .unwrap();
 
-    let (instance_statuses, run_stats) = execute_collect(&mut runner);
+    let (instance_statuses, run_stats) = execute_collect(runner);
     assert_eq!(run_stats.timed_out, 3, "3 tests timed out");
     for test_name in [
         "test_slow_timeout",

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -406,10 +406,10 @@ impl fmt::Debug for InstanceStatus {
     }
 }
 
-pub(crate) fn execute_collect<'a>(
-    runner: &mut TestRunner<'a>,
+pub(crate) fn execute_collect(
+    runner: TestRunner<'_>,
 ) -> (
-    HashMap<(&'a Utf8Path, &'a str), InstanceValue<'a>>,
+    HashMap<(&'_ Utf8Path, &'_ str), InstanceValue<'_>>,
     RunStats,
 ) {
     let mut instance_statuses = HashMap::new();

--- a/nextest-runner/tests/integration/target_runner.rs
+++ b/nextest-runner/tests/integration/target_runner.rs
@@ -203,7 +203,7 @@ fn test_run_with_target_runner() -> Result<()> {
         .apply_build_platforms(&build_platforms);
 
     let runner = TestRunnerBuilder::default();
-    let mut runner = runner
+    let runner = runner
         .build(
             &test_list,
             profile,
@@ -213,7 +213,7 @@ fn test_run_with_target_runner() -> Result<()> {
         )
         .unwrap();
 
-    let (instance_statuses, run_stats) = execute_collect(&mut runner);
+    let (instance_statuses, run_stats) = execute_collect(runner);
 
     for (name, expected) in &*EXPECTED_TESTS {
         let test_binary = FIXTURE_TARGETS

--- a/quick-junit/Cargo.toml
+++ b/quick-junit/Cargo.toml
@@ -13,10 +13,10 @@ rust-version = "1.62"
 
 [dependencies]
 chrono = "0.4.23"
-indexmap = "1.9.1"
+indexmap = "1.9.2"
 quick-xml = "0.26.0"
 thiserror = "1.0.37"
-uuid = "1.2.1"
+uuid = "1.2.2"
 nextest-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 
 [dev-dependencies]

--- a/scripts/cargo-release-publish.sh
+++ b/scripts/cargo-release-publish.sh
@@ -9,10 +9,8 @@ set -xe -o pipefail
 git checkout -B to-release
 
 # --execute: actually does the release
-# --no-verify: doesn't build before releasing (this is because the cargo publish process might pull
-# in new versions of dependencies, which might have regressions)
 # --no-confirm: don't ask for confirmation, since this is a non-interactive script
-cargo release publish --publish --execute --no-verify --no-confirm --workspace "$@"
+cargo release publish --publish --execute --no-confirm --workspace "$@"
 
 git checkout -
 git branch -D to-release

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -29,13 +29,13 @@ nom-tracable = { version = "0.8.0", features = ["trace"] }
 num-traits = { version = "0.2.15", default-features = false, features = ["std"] }
 owo-colors = { version = "3.5.0", default-features = false, features = ["supports-color", "supports-colors"] }
 serde = { version = "1.0.147", features = ["alloc", "derive", "serde_derive", "std"] }
-serde_json = { version = "1.0.87", features = ["std", "unbounded_depth"] }
+serde_json = { version = "1.0.89", features = ["std", "unbounded_depth"] }
 target-spec = { version = "1.2.2", default-features = false, features = ["serde", "summaries"] }
-tokio = { version = "1.21.2", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "num_cpus", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "time", "tokio-macros", "tracing"] }
-uuid = { version = "1.2.1", features = ["getrandom", "rng", "std", "v4"] }
+tokio = { version = "1.22.0", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "num_cpus", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "time", "tokio-macros", "tracing"] }
+uuid = { version = "1.2.2", features = ["getrandom", "rng", "std", "v4"] }
 
 [build-dependencies]
-cc = { version = "1.0.76", default-features = false, features = ["jobserver", "parallel"] }
+cc = { version = "1.0.77", default-features = false, features = ["jobserver", "parallel"] }
 hashbrown = { version = "0.12.3", features = ["ahash", "inline-more", "raw"] }
 memchr = { version = "2.5.0", features = ["std", "use_std"] }
 proc-macro2 = { version = "1.0.47", features = ["proc-macro"] }
@@ -45,10 +45,10 @@ syn = { version = "1.0.103", features = ["clone-impls", "derive", "extra-traits"
 [target.x86_64-unknown-linux-gnu.dependencies]
 futures-core = { version = "0.3.25", features = ["alloc", "std"] }
 futures-sink = { version = "0.3.25" }
-indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
+indexmap = { version = "1.9.2", default-features = false, features = ["std"] }
 libc = { version = "0.2.137", features = ["extra_traits", "std"] }
 once_cell = { version = "1.16.0", features = ["alloc", "race", "std"] }
-tokio = { version = "1.21.2", default-features = false, features = ["net", "socket2"] }
+tokio = { version = "1.22.0", default-features = false, features = ["net", "socket2"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 getrandom = { version = "0.2.8", default-features = false, features = ["std"] }
@@ -58,10 +58,10 @@ once_cell = { version = "1.16.0", features = ["alloc", "race", "std"] }
 [target.x86_64-apple-darwin.dependencies]
 futures-core = { version = "0.3.25", features = ["alloc", "std"] }
 futures-sink = { version = "0.3.25" }
-indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
+indexmap = { version = "1.9.2", default-features = false, features = ["std"] }
 libc = { version = "0.2.137", features = ["extra_traits", "std"] }
 once_cell = { version = "1.16.0", features = ["alloc", "race", "std"] }
-tokio = { version = "1.21.2", default-features = false, features = ["net", "socket2"] }
+tokio = { version = "1.22.0", default-features = false, features = ["net", "socket2"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
 getrandom = { version = "0.2.8", default-features = false, features = ["std"] }
@@ -71,9 +71,9 @@ once_cell = { version = "1.16.0", features = ["alloc", "race", "std"] }
 [target.x86_64-pc-windows-msvc.dependencies]
 futures-core = { version = "0.3.25", features = ["alloc", "std"] }
 futures-sink = { version = "0.3.25" }
-indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
+indexmap = { version = "1.9.2", default-features = false, features = ["std"] }
 once_cell = { version = "1.16.0", features = ["alloc", "race", "std"] }
-tokio = { version = "1.21.2", default-features = false, features = ["net", "socket2", "winapi"] }
+tokio = { version = "1.22.0", default-features = false, features = ["net", "socket2", "winapi"] }
 winapi = { version = "0.3.9", default-features = false, features = ["accctrl", "aclapi", "activation", "basetsd", "combaseapi", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "jobapi2", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "objbase", "processenv", "processthreadsapi", "profileapi", "psapi", "roapi", "shlobj", "std", "synchapi", "sysinfoapi", "threadpoollegacyapiset", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winreg", "winstring", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 
 [target.x86_64-pc-windows-msvc.build-dependencies]

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -31,6 +31,7 @@ owo-colors = { version = "3.5.0", default-features = false, features = ["support
 serde = { version = "1.0.147", features = ["alloc", "derive", "serde_derive", "std"] }
 serde_json = { version = "1.0.87", features = ["std", "unbounded_depth"] }
 target-spec = { version = "1.2.2", default-features = false, features = ["serde", "summaries"] }
+tokio = { version = "1.21.2", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "num_cpus", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "time", "tokio-macros", "tracing"] }
 uuid = { version = "1.2.1", features = ["getrandom", "rng", "std", "v4"] }
 
 [build-dependencies]
@@ -47,7 +48,7 @@ futures-sink = { version = "0.3.25" }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 libc = { version = "0.2.137", features = ["extra_traits", "std"] }
 once_cell = { version = "1.16.0", features = ["alloc", "race", "std"] }
-tokio = { version = "1.21.2", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"] }
+tokio = { version = "1.21.2", default-features = false, features = ["net", "socket2"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 getrandom = { version = "0.2.8", default-features = false, features = ["std"] }
@@ -60,7 +61,7 @@ futures-sink = { version = "0.3.25" }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 libc = { version = "0.2.137", features = ["extra_traits", "std"] }
 once_cell = { version = "1.16.0", features = ["alloc", "race", "std"] }
-tokio = { version = "1.21.2", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"] }
+tokio = { version = "1.21.2", default-features = false, features = ["net", "socket2"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
 getrandom = { version = "0.2.8", default-features = false, features = ["std"] }
@@ -72,7 +73,7 @@ futures-core = { version = "0.3.25", features = ["alloc", "std"] }
 futures-sink = { version = "0.3.25" }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 once_cell = { version = "1.16.0", features = ["alloc", "race", "std"] }
-tokio = { version = "1.21.2", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "net", "num_cpus", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros", "winapi"] }
+tokio = { version = "1.21.2", default-features = false, features = ["net", "socket2", "winapi"] }
 winapi = { version = "0.3.9", default-features = false, features = ["accctrl", "aclapi", "activation", "basetsd", "combaseapi", "consoleapi", "errhandlingapi", "fileapi", "handleapi", "impl-debug", "impl-default", "jobapi2", "minwinbase", "minwindef", "namedpipeapi", "ntdef", "ntsecapi", "objbase", "processenv", "processthreadsapi", "profileapi", "psapi", "roapi", "shlobj", "std", "synchapi", "sysinfoapi", "threadpoollegacyapiset", "timezoneapi", "winbase", "wincon", "winerror", "winnt", "winreg", "winstring", "winuser", "ws2ipdef", "ws2tcpip", "wtypesbase"] }
 
 [target.x86_64-pc-windows-msvc.build-dependencies]


### PR DESCRIPTION
On Windows, spawned processes can leave the Tokio runtime hanging.
Ensure that the runtime is shut down immediately rather than waiting for
it to exit -- it is better for nextest to leak resources than to hang.

Fixes https://github.com/nextest-rs/nextest/issues/656.