### PR TITLE
[fixtures] update sleep timeout to 360 seconds

### DIFF
--- a/fixtures/nextest-tests/tests/basic.rs
+++ b/fixtures/nextest-tests/tests/basic.rs
@@ -282,10 +282,8 @@ fn test_result_failure() -> Result<(), std::io::Error> {
 #[cfg(any(unix, windows))]
 #[test]
 fn test_subprocess_doesnt_exit() {
-    // Note: this is synchronized with a per-test override in the main nextest repo. TODO: This
-    // should actually be 360, but needs to wait until cargo-nextest 0.9.44 is out (because the test
-    // runner itself hangs, and CI is tested against the latest release as well.)
-    let mut cmd = sleep_cmd(5);
+    // Note: this is synchronized with a per-test override in the main nextest repo.
+    let mut cmd = sleep_cmd(360);
     // Try setting stdout to a piped process -- this will cause the runner to hang, unless
     cmd.stdout(std::process::Stdio::piped());
     cmd.spawn().unwrap();


### PR DESCRIPTION
This is now fixed in the released version of nextest.