### PR TITLE
Fix typos

### DIFF
--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -1469,7 +1469,7 @@ mod tests {
             // ---
             // Test binary arguments
             // ---
-            "cargo nextest run -- --a an arbitary arg",
+            "cargo nextest run -- --a an arbitrary arg",
             // Test negative test threads
             "cargo nextest run --jobs -3",
             "cargo nextest run --jobs 3",

--- a/integration-tests/tests/integration/main.rs
+++ b/integration-tests/tests/integration/main.rs
@@ -121,7 +121,7 @@ fn test_target_dir() {
         );
     };
 
-    // Absolute target direcctory
+    // Absolute target directory
     {
         let abs_target_dir = p.workspace_root().join("test-target-dir-abs");
         run_check(

--- a/nextest-filtering/tests/match.rs
+++ b/nextest-filtering/tests/match.rs
@@ -712,7 +712,7 @@ fn test_binary_query() {
         }),
         Some(true)
     );
-    // platform = host shold match the second predicate.
+    // platform = host should match the second predicate.
     assert_eq!(
         expr.matches_binary(&BinaryQuery {
             package_id: &pid_b,
@@ -722,7 +722,7 @@ fn test_binary_query() {
         }),
         Some(true)
     );
-    // kind = bench shold match the third predicate.
+    // kind = bench should match the third predicate.
     assert_eq!(
         expr.matches_binary(&BinaryQuery {
             package_id: &pid_a,

--- a/nextest-metadata/CHANGELOG.md
+++ b/nextest-metadata/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- A new exit code, `DOUBLE_SPAWN_ERROR`, indicates that an error was encountered wile attempting to double-spawn a test process.
+- A new exit code, `DOUBLE_SPAWN_ERROR`, indicates that an error was encountered while attempting to double-spawn a test process.
 
 ### Changed
 

--- a/nextest-runner/src/cargo_config/target_triple.rs
+++ b/nextest-runner/src/cargo_config/target_triple.rs
@@ -172,7 +172,7 @@ pub enum TargetTripleSource {
         source: CargoConfigSource,
     },
 
-    /// The platform runner was defined trough a metadata file provided using the --archive-file or
+    /// The platform runner was defined through a metadata file provided using the --archive-file or
     /// the `--binaries-metadata` CLI option
     Metadata,
 }

--- a/quick-junit/src/errors.rs
+++ b/quick-junit/src/errors.rs
@@ -3,7 +3,7 @@
 
 use thiserror::Error;
 
-/// An error that occurrs while serializing a [`Report`](crate::Report).
+/// An error that occurs while serializing a [`Report`](crate::Report).
 ///
 /// Returned by [`Report::serialize`](crate::Report::serialize) and
 /// [`Report::to_string`](crate::Report::to_string).

--- a/site/src/book/release-urls.md
+++ b/site/src/book/release-urls.md
@@ -36,7 +36,7 @@ For convenience, the following shortcuts are defined:
 * `freebsd` points to `x86_64-unknown-freebsd.tar.gz`
 * `illumos` points to `x86_64-unknown-illumos.tar.gz`
 
-Also, each release's canonical GitHub Releases URL is available at **`https://get.nexte.st/{version}/release`**. For example, the latest GitHub release is avaiable at [get.nexte.st/latest/release](https://get.nexte.st/latest/release).
+Also, each release's canonical GitHub Releases URL is available at **`https://get.nexte.st/{version}/release`**. For example, the latest GitHub release is available at [get.nexte.st/latest/release](https://get.nexte.st/latest/release).
 
 ### Examples
 


### PR DESCRIPTION
Found via `codespell -S target -L crate,iterm`