### PR TITLE
[nextest-runner] add support for test groups

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,6 +7,7 @@ final-status-level = "slow"
 # This is a bug.
 filter = 'package(integration-tests)'
 slow-timeout = { period = "60s", terminate-after = 3 }
+test-group = "my-group"
 
 [profile.ci]
 # Don't fail fast in CI to run the full test suite.
@@ -32,3 +33,7 @@ test-threads = 1
 [[profile.serial.overrides]]
 filter = 'test(foo)'
 retries = 3
+
+# Added for testing.
+[test-groups.my-group]
+max-threads = 4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,16 +229,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "buffer-unordered-weighted"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f2f39994c555ca870429ffed32206c4c963b891f939d23ad933686d0a42eb5"
-dependencies = [
- "futures-util",
- "pin-project-lite",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,6 +734,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "future-queue"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a947f004b7f2a4cbb416cfc812060a0f63c0b95f6711150ec86d38054ef2a"
+dependencies = [
+ "fnv",
+ "futures-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1440,7 +1441,6 @@ dependencies = [
  "aho-corasick",
  "async-scoped",
  "atomicwrites",
- "buffer-unordered-weighted",
  "bytes",
  "camino",
  "cargo_metadata",
@@ -1453,6 +1453,7 @@ dependencies = [
  "duct",
  "dunce",
  "either",
+ "future-queue",
  "futures",
  "guppy",
  "home",
@@ -1489,6 +1490,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "shell-words",
+ "smol_str",
  "strip-ansi-escapes",
  "tar",
  "target-spec",
@@ -2352,6 +2354,15 @@ name = "smawk"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+
+[[package]]
+name = "smol_str"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7475118a28b7e3a2e157ce0131ba8c5526ea96e90ee601d9f6bb2e286a35ab44"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.64"
 atomicwrites = "0.3.1"
 aho-corasick = "0.7.20"
 async-scoped = { version = "0.7.1", features = ["use-tokio"] }
-buffer-unordered-weighted = "0.1.2"
+future-queue = "0.2.2"
 bytes = "1.3.0"
 camino = { version = "1.1.1", features = ["serde1"] }
 config = { version = "0.13.3", default-features = false, features = ["toml"] }
@@ -48,6 +48,7 @@ serde_ignored = "0.1.6"
 serde_json = "1.0.91"
 serde_path_to_error = "0.1.9"
 shell-words = "1.1.0"
+smol_str = { version = "0.1.23", features = ["serde"] }
 strip-ansi-escapes = "0.1.1"
 tar = "0.4.38"
 # For cfg expression evaluation for [target.'cfg()'] expressions


### PR DESCRIPTION
Test groups allow for mutual exclusion or other concurrency limits among sets of tests. This is useful to emulate tests that must be run in a single-threaded fashion.