### PR TITLE
[nextest-runner] restrict group names to valid identifiers

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
-xfmt = "fmt -- --config imports_granularity=Crate"
+xfmt = "fmt -- --config imports_granularity=Crate --config group_imports=One"
 local-nt = "run --package cargo-nextest -- nextest"
 
 [build]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1501,6 +1501,8 @@ dependencies = [
  "tokio",
  "toml_edit",
  "twox-hash",
+ "unicode-ident",
+ "unicode-normalization",
  "uuid",
  "win32job",
  "windows",

--- a/nextest-filtering/src/parsing.rs
+++ b/nextest-filtering/src/parsing.rs
@@ -13,8 +13,6 @@
 //!     - return an error/none variant of the expected result type
 //!     - push an error in the parsing state (in span.extra)
 
-use std::{cell::RefCell, fmt};
-
 use guppy::graph::cargo::BuildPlatform;
 use miette::SourceSpan;
 use nom::{
@@ -27,11 +25,11 @@ use nom::{
     Slice,
 };
 use nom_tracable::tracable_parser;
+use std::{cell::RefCell, fmt};
 
 mod unicode_string;
-pub(crate) use unicode_string::DisplayParsedString;
-
 use crate::{errors::*, NameMatcher};
+pub(crate) use unicode_string::DisplayParsedString;
 
 pub(crate) type Span<'a> = nom_locate::LocatedSpan<&'a str, State<'a>>;
 type IResult<'a, T> = nom::IResult<Span<'a>, T>;
@@ -649,9 +647,8 @@ pub(crate) fn parse(input: Span) -> Result<ParsedExpr, nom::Err<nom::error::Erro
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
-
     use super::*;
+    use std::cell::RefCell;
 
     #[track_caller]
     fn parse_regex(input: &str) -> NameMatcher {

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -3,8 +3,7 @@
 
 // Adapted from https://github.com/Geal/nom/blob/294ffb3d9e0ade2c3b7ddfff52484b6d643dcce1/examples/string.rs
 
-use std::fmt;
-
+use super::{IResult, Span};
 use nom::{
     branch::alt,
     bytes::streaming::{is_not, take_while_m_n},
@@ -15,8 +14,7 @@ use nom::{
     Slice,
 };
 use nom_tracable::tracable_parser;
-
-use super::{IResult, Span};
+use std::fmt;
 
 fn run_str_parser<'a, T, I>(mut inner: I) -> impl FnMut(Span<'a>) -> IResult<'a, T>
 where

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -88,6 +88,8 @@ quick-junit = { version = "0.3.2", path = "../quick-junit" }
 uuid = { version = "1.2.2", features = ["v4"] }
 nextest-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 console-subscriber = { version = "0.1.8", optional = true }
+unicode-ident = "1.0.6"
+unicode-normalization = "0.1.22"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.139"

--- a/nextest-runner/src/cargo_config/env.rs
+++ b/nextest-runner/src/cargo_config/env.rs
@@ -275,11 +275,10 @@ mod imp {
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::OsStr;
-
     use super::*;
     use crate::cargo_config::{test_helpers::setup_temp_dir, CargoConfigs};
     use camino::Utf8PathBuf;
+    use std::ffi::OsStr;
 
     #[test]
     fn test_env_var_precedence() {

--- a/nextest-runner/src/config.rs
+++ b/nextest-runner/src/config.rs
@@ -4,8 +4,6 @@
 //! Configuration support for nextest.
 
 mod identifier;
-pub use identifier::*;
-
 use crate::{
     errors::{
         provided_by_tool, ConfigParseError, ConfigParseErrorKind, ConfigParseOverrideError,
@@ -18,6 +16,7 @@ use crate::{
 use camino::{Utf8Path, Utf8PathBuf};
 use config::{builder::DefaultState, Config, ConfigBuilder, File, FileFormat, FileSourceFile};
 use guppy::graph::{cargo::BuildPlatform, PackageGraph};
+pub use identifier::*;
 use nextest_filtering::{FilteringExpr, TestQuery};
 use once_cell::sync::Lazy;
 use serde::{de::IntoDeserializer, Deserialize};
@@ -1565,9 +1564,8 @@ struct JunitImpl {
 
 #[cfg(test)]
 mod tests {
-    use crate::cargo_config::{TargetTriple, TargetTripleSource};
-
     use super::*;
+    use crate::cargo_config::{TargetTriple, TargetTripleSource};
     use config::ConfigError;
     use guppy::{graph::cargo::BuildPlatform, MetadataCommand};
     use indoc::indoc;

--- a/nextest-runner/src/config/identifier.rs
+++ b/nextest-runner/src/config/identifier.rs
@@ -1,12 +1,10 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use std::fmt;
-
-use smol_str::SmolStr;
-use unicode_normalization::{is_nfc_quick, IsNormalized, UnicodeNormalization};
-
 use crate::errors::InvalidIdentifier;
+use smol_str::SmolStr;
+use std::fmt;
+use unicode_normalization::{is_nfc_quick, IsNormalized, UnicodeNormalization};
 
 /// An identifier used in configuration.
 ///

--- a/nextest-runner/src/config/identifier.rs
+++ b/nextest-runner/src/config/identifier.rs
@@ -1,0 +1,227 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::fmt;
+
+use smol_str::SmolStr;
+use unicode_normalization::{is_nfc_quick, IsNormalized, UnicodeNormalization};
+
+use crate::errors::InvalidIdentifier;
+
+/// An identifier used in configuration.
+///
+/// The identifier goes through some basic validation:
+/// * conversion to NFC
+/// * ensuring that it is of the form (XID_Start)(XID_Continue | -)*
+///
+/// Identifiers can also be tool identifiers, which are of the form "@tool:tool-name:identifier".
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ConfigIdentifier(SmolStr);
+
+impl ConfigIdentifier {
+    /// Validates and creates a new identifier.
+    pub fn new(identifier: SmolStr) -> Result<Self, InvalidIdentifier> {
+        let identifier = if is_nfc_quick(identifier.chars()) == IsNormalized::Yes {
+            identifier
+        } else {
+            identifier.nfc().collect::<SmolStr>()
+        };
+
+        if identifier.is_empty() {
+            return Err(InvalidIdentifier::Empty);
+        }
+
+        // Tool identifiers are of the form "@tool:identifier:identifier".
+
+        if let Some(suffix) = identifier.strip_prefix("@tool:") {
+            // TODO: finish this
+            let mut parts = suffix.splitn(2, ':');
+            let tool_name = parts
+                .next()
+                .expect("at least one identifier should be returned.");
+            let tool_identifier = match parts.next() {
+                Some(tool_identifier) => tool_identifier,
+                None => return Err(InvalidIdentifier::ToolIdentifierInvalidFormat(identifier)),
+            };
+
+            for x in [tool_name, tool_identifier] {
+                Self::is_valid_unicode(x).map_err(|error| match error {
+                    InvalidIdentifierKind::Empty => {
+                        InvalidIdentifier::ToolComponentEmpty(identifier.clone())
+                    }
+                    InvalidIdentifierKind::InvalidXid => {
+                        InvalidIdentifier::ToolIdentifierInvalidXid(identifier.clone())
+                    }
+                })?;
+            }
+        } else {
+            // This should be a regular identifier.
+            Self::is_valid_unicode(&identifier).map_err(|error| match error {
+                InvalidIdentifierKind::Empty => InvalidIdentifier::Empty,
+                InvalidIdentifierKind::InvalidXid => {
+                    InvalidIdentifier::InvalidXid(identifier.clone())
+                }
+            })?;
+        }
+
+        Ok(Self(identifier))
+    }
+
+    /// Returns true if this is a tool identifier.
+    pub fn is_tool_identifier(&self) -> bool {
+        self.0.starts_with("@tool:")
+    }
+
+    /// Returns the tool name and identifier, if this is a tool identifier.
+    pub fn tool_components(&self) -> Option<(&str, &str)> {
+        self.0.strip_prefix("@tool:").map(|suffix| {
+            let mut parts = suffix.splitn(2, ':');
+            let tool_name = parts
+                .next()
+                .expect("identifier was checked to have 2 components above");
+            let tool_identifier = parts
+                .next()
+                .expect("identifier was checked to have 2 components above");
+            (tool_name, tool_identifier)
+        })
+    }
+
+    /// Returns the identifier as a string slice.
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    fn is_valid_unicode(identifier: &str) -> Result<(), InvalidIdentifierKind> {
+        if identifier.is_empty() {
+            return Err(InvalidIdentifierKind::Empty);
+        }
+
+        let mut first = true;
+        for ch in identifier.chars() {
+            if first {
+                if !unicode_ident::is_xid_start(ch) {
+                    return Err(InvalidIdentifierKind::InvalidXid);
+                }
+                first = false;
+            } else if !(ch == '-' || unicode_ident::is_xid_continue(ch)) {
+                return Err(InvalidIdentifierKind::InvalidXid);
+            }
+        }
+        Ok(())
+    }
+}
+
+impl fmt::Display for ConfigIdentifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ConfigIdentifier {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let identifier = SmolStr::deserialize(deserializer)?;
+        ConfigIdentifier::new(identifier).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum InvalidIdentifierKind {
+    Empty,
+    InvalidXid,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Deserialize, Debug, PartialEq, Eq)]
+    struct TestDeserialize {
+        identifier: ConfigIdentifier,
+    }
+
+    fn make_json(identifier: &str) -> String {
+        format!(r#"{{ "identifier": "{}" }}"#, identifier)
+    }
+
+    #[test]
+    fn test_valid() {
+        let valid_inputs = ["foo", "foo-bar", "Δabc"];
+
+        for &input in &valid_inputs {
+            let identifier = ConfigIdentifier::new(input.into()).unwrap();
+            assert_eq!(identifier.as_str(), input);
+            assert!(!identifier.is_tool_identifier());
+
+            serde_json::from_str::<TestDeserialize>(&make_json(input)).unwrap();
+        }
+
+        let valid_tool_inputs = ["@tool:foo:bar", "@tool:Δabc_def-ghi:foo-bar"];
+
+        for &input in &valid_tool_inputs {
+            let identifier = ConfigIdentifier::new(input.into()).unwrap();
+            assert_eq!(identifier.as_str(), input);
+            assert!(identifier.is_tool_identifier());
+
+            serde_json::from_str::<TestDeserialize>(&make_json(input)).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_invalid() {
+        let identifier = ConfigIdentifier::new("".into());
+        assert_eq!(identifier.unwrap_err(), InvalidIdentifier::Empty);
+
+        let invalid_xid = ["foo bar", "_", "-foo", "_foo", "@foo", "@tool"];
+
+        for &input in &invalid_xid {
+            let identifier = ConfigIdentifier::new(input.into());
+            assert_eq!(
+                identifier.unwrap_err(),
+                InvalidIdentifier::InvalidXid(input.into())
+            );
+
+            serde_json::from_str::<TestDeserialize>(&make_json(input)).unwrap_err();
+        }
+
+        let tool_component_empty = ["@tool::", "@tool:foo:", "@tool::foo"];
+
+        for &input in &tool_component_empty {
+            let identifier = ConfigIdentifier::new(input.into());
+            assert_eq!(
+                identifier.unwrap_err(),
+                InvalidIdentifier::ToolComponentEmpty(input.into())
+            );
+
+            serde_json::from_str::<TestDeserialize>(&make_json(input)).unwrap_err();
+        }
+
+        let tool_identifier_invalid_format = ["@tool:", "@tool:foo"];
+
+        for &input in &tool_identifier_invalid_format {
+            let identifier = ConfigIdentifier::new(input.into());
+            assert_eq!(
+                identifier.unwrap_err(),
+                InvalidIdentifier::ToolIdentifierInvalidFormat(input.into())
+            );
+
+            serde_json::from_str::<TestDeserialize>(&make_json(input)).unwrap_err();
+        }
+
+        let tool_identifier_invalid_xid = ["@tool:_foo:bar", "@tool:foo:#bar", "@tool:foo:bar:baz"];
+
+        for &input in &tool_identifier_invalid_xid {
+            let identifier = ConfigIdentifier::new(input.into());
+            assert_eq!(
+                identifier.unwrap_err(),
+                InvalidIdentifier::ToolIdentifierInvalidXid(input.into())
+            );
+
+            serde_json::from_str::<TestDeserialize>(&make_json(input)).unwrap_err();
+        }
+    }
+}

--- a/nextest-runner/src/double_spawn.rs
+++ b/nextest-runner/src/double_spawn.rs
@@ -100,9 +100,8 @@ pub fn double_spawn_child_init() {
 
 #[cfg(unix)]
 mod imp {
-    use nix::sys::signal::{SigSet, Signal};
-
     use super::*;
+    use nix::sys::signal::{SigSet, Signal};
     use std::path::PathBuf;
 
     #[derive(Clone, Debug)]

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -15,6 +15,7 @@ use camino::{FromPathBufError, Utf8Path, Utf8PathBuf};
 use config::ConfigError;
 use itertools::Itertools;
 use nextest_filtering::errors::FilterExpressionParseErrors;
+use smol_str::SmolStr;
 use std::{borrow::Cow, collections::BTreeSet, env::JoinPathsError, fmt, process::ExitStatus};
 use target_spec_miette::IntoMietteDiagnostic;
 use thiserror::Error;
@@ -181,6 +182,35 @@ impl ProfileNotFound {
         }
     }
 }
+
+/// An identifier is invalid.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub enum InvalidIdentifier {
+    /// The identifier is empty.
+    #[error("identifier is empty")]
+    Empty,
+
+    /// The identifier is not in the correct Unicode format.
+    #[error("invalid identifier `{0}`")]
+    InvalidXid(SmolStr),
+
+    /// This tool identifier doesn't match the expected pattern.
+    #[error("tool identifier not of the form \"@tool:tool-name:identifier\": `{0}`")]
+    ToolIdentifierInvalidFormat(SmolStr),
+
+    /// One of the components of this tool identifier is empty.
+    #[error("tool identifier has empty component: `{0}`")]
+    ToolComponentEmpty(SmolStr),
+
+    /// The tool identifier is not in the correct Unicode format.
+    #[error("invalid tool identifier `{0}`")]
+    ToolIdentifierInvalidXid(SmolStr),
+}
+
+/// The name of a test group is invalid (not a valid identifier).
+#[derive(Clone, Debug, Error)]
+#[error("invalid custom test group name: {0}")]
+pub struct InvalidCustomTestGroupName(pub InvalidIdentifier);
 
 /// Error returned while parsing a [`ToolConfigFile`](crate::config::ToolConfigFile) value.
 #[derive(Clone, Debug, Error)]

--- a/nextest-runner/src/reporter.rs
+++ b/nextest-runner/src/reporter.rs
@@ -6,9 +6,6 @@
 //! The main structure in this module is [`TestReporter`].
 
 mod aggregator;
-pub use aggregator::heuristic_extract_description;
-use uuid::Uuid;
-
 use crate::{
     config::NextestProfile,
     errors::WriteEventError,
@@ -20,6 +17,7 @@ use crate::{
         RetryData, RunStats,
     },
 };
+pub use aggregator::heuristic_extract_description;
 use debug_ignore::DebugIgnore;
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use nextest_metadata::MismatchReason;
@@ -33,6 +31,7 @@ use std::{
     io::{BufWriter, Write},
     time::{Duration, SystemTime},
 };
+use uuid::Uuid;
 
 /// When to display test output in the reporter.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Deserialize)]

--- a/nextest-runner/src/reuse_build/archive_reporter.rs
+++ b/nextest-runner/src/reuse_build/archive_reporter.rs
@@ -1,14 +1,13 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use crate::helpers::format_duration;
 use camino::Utf8Path;
 use owo_colors::{OwoColorize, Style};
 use std::{
     io::{self, Write},
     time::Duration,
 };
-
-use crate::helpers::format_duration;
 
 #[derive(Debug)]
 /// Reporter for archive operations.


### PR DESCRIPTION
See doc comment to `ConfigIdentifier` for more.

We'll eventually want to restrict profile names to these as well, but maybe some other day.