### PR TITLE
[nextest-runner] add a way to show configuration for test groups

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -36,4 +36,7 @@ retries = 3
 
 # Added for testing.
 [test-groups.my-group]
-max-threads = 4
+max-threads = 8
+
+[test-groups.unused-group]
+max-threads = 8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,6 +1149,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da2d6f23ffea9d7e76c53eee25dfb67bcd8fde7f1198b0855350698c9f07c780"
 
 [[package]]
+name = "insta"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48b08a091dfe5b09a6a9688c468fdd5b4396e92ce09e2eb932f0884b02788a4"
+dependencies = [
+ "lazy_static",
+ "linked-hash-map",
+ "similar",
+ "yaml-rust",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1167,6 +1179,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "enable-ansi-support",
+ "insta",
  "nextest-metadata",
  "nextest-workspace-hack",
  "once_cell",
@@ -1276,6 +1289,12 @@ checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1461,6 +1480,7 @@ dependencies = [
  "http",
  "humantime-serde",
  "indent_write",
+ "indexmap",
  "indicatif",
  "indoc",
  "is_ci",
@@ -1538,6 +1558,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "similar",
  "syn 1.0.107",
  "target-spec",
  "tokio",
@@ -3302,6 +3323,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,6 +1430,7 @@ dependencies = [
  "nextest-workspace-hack",
  "serde",
  "serde_json",
+ "smol_str",
  "target-spec",
  "test-case",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,10 @@ members = [
 # make backtrace + color-eyre faster on debug builds
 [profile.dev.package.backtrace]
 opt-level = 3
+
+# insta and similar are recommended by insta
+[profile.dev.package.insta]
+opt-level = 3
+
+[profile.dev.package.similar]
+opt-level = 3

--- a/cargo-nextest/src/errors.rs
+++ b/cargo-nextest/src/errors.rs
@@ -155,6 +155,11 @@ pub enum ExpectedError {
         #[from]
         err: ConfigureHandleInheritanceError,
     },
+    #[error("show test groups error")]
+    ShowTestGroupsError {
+        #[from]
+        err: ShowTestGroupsError,
+    },
     #[error("test run failed")]
     TestRunFailed,
     #[cfg(feature = "self-update")]
@@ -329,7 +334,8 @@ impl ExpectedError {
             | Self::CargoMetadataParseError { .. }
             | Self::TestBinaryArgsParseError { .. }
             | Self::DialoguerError { .. }
-            | Self::SignalHandlerSetupError { .. } => NextestExitCode::SETUP_ERROR,
+            | Self::SignalHandlerSetupError { .. }
+            | Self::ShowTestGroupsError { .. } => NextestExitCode::SETUP_ERROR,
             #[cfg(feature = "self-update")]
             Self::UpdateVersionParseError { .. } => NextestExitCode::SETUP_ERROR,
             Self::DoubleSpawnParseArgsError { .. } | Self::DoubleSpawnExecError { .. } => {
@@ -588,6 +594,10 @@ impl ExpectedError {
             Self::TestRunFailed => {
                 log::error!("test run failed");
                 None
+            }
+            Self::ShowTestGroupsError { err } => {
+                log::error!("{err}");
+                err.source()
             }
             #[cfg(feature = "self-update")]
             Self::UpdateVersionParseError { err } => {

--- a/fixtures/nextest-tests/.config/nextest.toml
+++ b/fixtures/nextest-tests/.config/nextest.toml
@@ -18,6 +18,7 @@ retries = 5
 [[profile.with-retries.overrides]]
 filter = "test(test_flaky_mod)"
 retries = 4
+test-group = 'flaky'
 
 [profile.with-termination]
 slow-timeout = { period = "1s", terminate-after = 2 }
@@ -26,6 +27,7 @@ slow-timeout = { period = "1s", terminate-after = 2 }
 filter = 'test(=test_slow_timeout_2)'
 # This is set to 1 second
 slow-timeout = { period = "500ms", terminate-after = 2 }
+test-group = '@global'
 
 [profile.with-junit]
 retries = 2
@@ -35,3 +37,9 @@ path = "junit.xml"
 
 [profile.retries-with-backoff]
 retries = { backoff = "exponential", count = 2, jitter = true, delay = "1s" }
+
+[test-groups.flaky]
+max-threads = 4
+
+[test-groups.unused]
+max-threads = 20

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -26,3 +26,4 @@ once_cell = "1.17.0"
 tempfile = "3.3.0"
 regex = "1.7.0"
 serde_json = "1.0.91"
+insta = { version = "1.23.0", default-features = false }

--- a/integration-tests/tests/integration/fixtures.rs
+++ b/integration-tests/tests/integration/fixtures.rs
@@ -9,7 +9,7 @@ use nextest_metadata::{
 };
 use once_cell::sync::Lazy;
 use regex::Regex;
-use std::{fmt, process::Command};
+use std::{borrow::Cow, fmt, process::Command};
 
 pub struct TestInfo {
     id: RustBinaryId,
@@ -190,6 +190,10 @@ pub struct CargoNextestOutput {
 }
 
 impl CargoNextestOutput {
+    pub fn stdout_as_str(&self) -> Cow<'_, str> {
+        String::from_utf8_lossy(&self.stdout)
+    }
+
     pub fn decode_test_list_json(&self) -> Result<TestListSummary> {
         Ok(serde_json::from_slice(&self.stdout)?)
     }

--- a/integration-tests/tests/integration/fixtures.rs
+++ b/integration-tests/tests/integration/fixtures.rs
@@ -5,14 +5,14 @@ use super::temp_project::TempProject;
 use camino::Utf8PathBuf;
 use color_eyre::Result;
 use nextest_metadata::{
-    BinaryListSummary, BuildPlatform, RustTestSuiteStatusSummary, TestListSummary,
+    BinaryListSummary, BuildPlatform, RustBinaryId, RustTestSuiteStatusSummary, TestListSummary,
 };
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::{fmt, process::Command};
 
 pub struct TestInfo {
-    id: &'static str,
+    id: RustBinaryId,
     platform: BuildPlatform,
     test_cases: Vec<(&'static str, bool)>,
 }
@@ -24,7 +24,7 @@ impl TestInfo {
         test_cases: Vec<(&'static str, bool)>,
     ) -> Self {
         Self {
-            id,
+            id: id.into(),
             platform,
             test_cases,
         }
@@ -280,7 +280,7 @@ pub fn check_list_full_output(stdout: &[u8], platform: Option<BuildPlatform>) {
             _ => {}
         }
 
-        let entry = result.rust_suites.get(test.id);
+        let entry = result.rust_suites.get(&test.id);
         let entry = match entry {
             Some(e) => e,
             _ => panic!("Missing binary: {}", test.id),

--- a/integration-tests/tests/integration/main.rs
+++ b/integration-tests/tests/integration/main.rs
@@ -392,3 +392,94 @@ fn test_run_from_archive() {
     );
     check_run_output(&output.stderr, true);
 }
+
+#[test]
+fn test_show_config_test_groups() {
+    set_env_vars();
+    let p = TempProject::new().unwrap();
+
+    let default_profile_output = CargoNextestCli::new()
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "show-config",
+            "test-groups",
+            "--workspace",
+            "--all-targets",
+        ])
+        .output();
+
+    insta::assert_snapshot!(default_profile_output.stdout_as_str());
+
+    let default_profile_all_output = CargoNextestCli::new()
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "show-config",
+            "test-groups",
+            "--workspace",
+            "--all-targets",
+            "--show-default",
+        ])
+        .output();
+
+    insta::assert_snapshot!(default_profile_all_output.stdout_as_str());
+
+    let with_retries_output = CargoNextestCli::new()
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "show-config",
+            "test-groups",
+            "--workspace",
+            "--all-targets",
+            "--profile=with-retries",
+        ])
+        .output();
+
+    insta::assert_snapshot!(with_retries_output.stdout_as_str());
+
+    let with_retries_all_output = CargoNextestCli::new()
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "show-config",
+            "test-groups",
+            "--workspace",
+            "--all-targets",
+            "--profile=with-retries",
+            "--show-default",
+        ])
+        .output();
+
+    insta::assert_snapshot!(with_retries_all_output.stdout_as_str());
+
+    let with_termination_output = CargoNextestCli::new()
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "show-config",
+            "test-groups",
+            "--workspace",
+            "--all-targets",
+            "--profile=with-termination",
+        ])
+        .output();
+
+    insta::assert_snapshot!(with_termination_output.stdout_as_str());
+
+    let with_termination_all_output = CargoNextestCli::new()
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "show-config",
+            "test-groups",
+            "--workspace",
+            "--all-targets",
+            "--profile=with-termination",
+            "--show-default",
+        ])
+        .output();
+
+    insta::assert_snapshot!(with_termination_all_output.stdout_as_str());
+}

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-2.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-2.snap
@@ -1,0 +1,49 @@
+---
+source: integration-tests/tests/integration/main.rs
+expression: default_profile_all_output.stdout_as_str()
+---
+group: flaky (max threads = 4)
+    (no matches)
+group: unused (max threads = 20)
+    (no matches)
+group: @global
+  * from default settings:
+      cdylib-example:
+          tests::test_multiply_two_cdylib
+      cdylib-link:
+          test_multiply_two
+      nextest-derive::proc-macro/nextest-derive:
+          it_works
+      nextest-tests:
+          tests::call_dylib_add_two
+          tests::unit_test_success
+      nextest-tests::basic:
+          test_cargo_env_vars
+          test_cwd
+          test_execute_bin
+          test_failure_assert
+          test_failure_error
+          test_failure_should_panic
+          test_flaky_mod_4
+          test_flaky_mod_6
+          test_result_failure
+          test_stdin_closed
+          test_subprocess_doesnt_exit
+          test_success
+          test_success_should_panic
+      nextest-tests::other:
+          other_test_success
+      nextest-tests::segfault:
+          test_segfault
+      nextest-tests::bench/my-bench:
+          bench_add_two
+          tests::test_execute_bin
+      nextest-tests::bin/nextest-tests:
+          tests::bin_success
+      nextest-tests::bin/other:
+          tests::other_bin_success
+      nextest-tests::example/nextest-tests:
+          tests::example_success
+      nextest-tests::example/other:
+          tests::other_example_success
+

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-3.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-3.snap
@@ -1,0 +1,12 @@
+---
+source: integration-tests/tests/integration/main.rs
+expression: with_retries_output.stdout_as_str()
+---
+group: flaky (max threads = 4)
+  * override for with-retries profile with filter 'test(test_flaky_mod)':
+      nextest-tests::basic:
+          test_flaky_mod_4
+          test_flaky_mod_6
+group: unused (max threads = 20)
+    (no matches)
+

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-4.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-4.snap
@@ -1,0 +1,50 @@
+---
+source: integration-tests/tests/integration/main.rs
+expression: with_retries_all_output.stdout_as_str()
+---
+group: flaky (max threads = 4)
+  * override for with-retries profile with filter 'test(test_flaky_mod)':
+      nextest-tests::basic:
+          test_flaky_mod_4
+          test_flaky_mod_6
+group: unused (max threads = 20)
+    (no matches)
+group: @global
+  * from default settings:
+      cdylib-example:
+          tests::test_multiply_two_cdylib
+      cdylib-link:
+          test_multiply_two
+      nextest-derive::proc-macro/nextest-derive:
+          it_works
+      nextest-tests:
+          tests::call_dylib_add_two
+          tests::unit_test_success
+      nextest-tests::basic:
+          test_cargo_env_vars
+          test_cwd
+          test_execute_bin
+          test_failure_assert
+          test_failure_error
+          test_failure_should_panic
+          test_result_failure
+          test_stdin_closed
+          test_subprocess_doesnt_exit
+          test_success
+          test_success_should_panic
+      nextest-tests::other:
+          other_test_success
+      nextest-tests::segfault:
+          test_segfault
+      nextest-tests::bench/my-bench:
+          bench_add_two
+          tests::test_execute_bin
+      nextest-tests::bin/nextest-tests:
+          tests::bin_success
+      nextest-tests::bin/other:
+          tests::other_bin_success
+      nextest-tests::example/nextest-tests:
+          tests::example_success
+      nextest-tests::example/other:
+          tests::other_example_success
+

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-5.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-5.snap
@@ -1,0 +1,12 @@
+---
+source: integration-tests/tests/integration/main.rs
+expression: with_termination_output.stdout_as_str()
+---
+group: flaky (max threads = 4)
+    (no matches)
+group: unused (max threads = 20)
+    (no matches)
+group: @global
+  * override for with-termination profile with filter 'test(=test_slow_timeout_2)':
+      nextest-tests::basic:
+

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-6.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-6.snap
@@ -1,0 +1,51 @@
+---
+source: integration-tests/tests/integration/main.rs
+expression: with_termination_all_output.stdout_as_str()
+---
+group: flaky (max threads = 4)
+    (no matches)
+group: unused (max threads = 20)
+    (no matches)
+group: @global
+  * override for with-termination profile with filter 'test(=test_slow_timeout_2)':
+      nextest-tests::basic:
+  * from default settings:
+      cdylib-example:
+          tests::test_multiply_two_cdylib
+      cdylib-link:
+          test_multiply_two
+      nextest-derive::proc-macro/nextest-derive:
+          it_works
+      nextest-tests:
+          tests::call_dylib_add_two
+          tests::unit_test_success
+      nextest-tests::basic:
+          test_cargo_env_vars
+          test_cwd
+          test_execute_bin
+          test_failure_assert
+          test_failure_error
+          test_failure_should_panic
+          test_flaky_mod_4
+          test_flaky_mod_6
+          test_result_failure
+          test_stdin_closed
+          test_subprocess_doesnt_exit
+          test_success
+          test_success_should_panic
+      nextest-tests::other:
+          other_test_success
+      nextest-tests::segfault:
+          test_segfault
+      nextest-tests::bench/my-bench:
+          bench_add_two
+          tests::test_execute_bin
+      nextest-tests::bin/nextest-tests:
+          tests::bin_success
+      nextest-tests::bin/other:
+          tests::other_bin_success
+      nextest-tests::example/nextest-tests:
+          tests::example_success
+      nextest-tests::example/other:
+          tests::other_example_success
+

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups.snap
@@ -1,0 +1,9 @@
+---
+source: integration-tests/tests/integration/main.rs
+expression: default_profile_output.stdout_as_str()
+---
+group: flaky (max threads = 4)
+    (no matches)
+group: unused (max threads = 20)
+    (no matches)
+

--- a/nextest-metadata/Cargo.toml
+++ b/nextest-metadata/Cargo.toml
@@ -17,6 +17,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
 target-spec = { version = "1.2.2", features = ["summaries"] }
 nextest-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+smol_str = { version = "0.1.23", features = ["serde"] }
 
 [dev-dependencies]
 test-case = "2.2.2"

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -90,6 +90,7 @@ nextest-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 console-subscriber = { version = "0.1.8", optional = true }
 unicode-ident = "1.0.6"
 unicode-normalization = "0.1.22"
+indexmap = "1.9.2"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.139"

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -1008,6 +1008,24 @@ pub enum TargetRunnerError {
 #[error("error setting up signal handler")]
 pub struct SignalHandlerSetupError(#[from] std::io::Error);
 
+/// An error occurred while showing test groups.
+#[derive(Debug, Error)]
+pub enum ShowTestGroupsError {
+    /// Unknown test groups were specified.
+    #[error(
+        "unknown test groups specified: {}\n(known groups: {})",
+        unknown_groups.iter().join(", "),
+        known_groups.iter().join(", "),
+    )]
+    UnknownGroups {
+        /// The unknown test groups.
+        unknown_groups: BTreeSet<TestGroup>,
+
+        /// All known test groups.
+        known_groups: BTreeSet<TestGroup>,
+    },
+}
+
 #[cfg(feature = "self-update")]
 mod self_update_errors {
     use super::*;

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -15,6 +15,7 @@ use camino::{FromPathBufError, Utf8Path, Utf8PathBuf};
 use config::ConfigError;
 use itertools::Itertools;
 use nextest_filtering::errors::FilterExpressionParseErrors;
+use nextest_metadata::RustBinaryId;
 use smol_str::SmolStr;
 use std::{borrow::Cow, collections::BTreeSet, env::JoinPathsError, fmt, process::ExitStatus};
 use target_spec_miette::IntoMietteDiagnostic;
@@ -426,7 +427,7 @@ pub enum CreateTestListError {
     )]
     CwdIsNotDir {
         /// The binary ID for which the current directory wasn't found.
-        binary_id: String,
+        binary_id: RustBinaryId,
 
         /// The current directory that wasn't found.
         cwd: Utf8PathBuf,
@@ -439,7 +440,7 @@ pub enum CreateTestListError {
     )]
     CommandExecFail {
         /// The binary ID for which gathering the list of tests failed.
-        binary_id: String,
+        binary_id: RustBinaryId,
 
         /// The command that was run.
         command: Vec<String>,
@@ -459,7 +460,7 @@ pub enum CreateTestListError {
     )]
     CommandFail {
         /// The binary ID for which gathering the list of tests failed.
-        binary_id: String,
+        binary_id: RustBinaryId,
 
         /// The command that was run.
         command: Vec<String>,
@@ -483,7 +484,7 @@ pub enum CreateTestListError {
     )]
     CommandNonUtf8 {
         /// The binary ID for which gathering the list of tests failed.
-        binary_id: String,
+        binary_id: RustBinaryId,
 
         /// The command that was run.
         command: Vec<String>,
@@ -499,7 +500,7 @@ pub enum CreateTestListError {
     #[error("for `{binary_id}`, {message}\nfull output:\n{full_output}")]
     ParseLine {
         /// The binary ID for which parsing the list of tests failed.
-        binary_id: String,
+        binary_id: RustBinaryId,
 
         /// A descriptive message.
         message: Cow<'static, str>,
@@ -530,12 +531,12 @@ pub enum CreateTestListError {
 
 impl CreateTestListError {
     pub(crate) fn parse_line(
-        binary_id: impl Into<String>,
+        binary_id: RustBinaryId,
         message: impl Into<Cow<'static, str>>,
         full_output: impl Into<String>,
     ) -> Self {
         Self::ParseLine {
-            binary_id: binary_id.into(),
+            binary_id,
             message: message.into(),
             full_output: full_output.into(),
         }

--- a/nextest-runner/src/helpers.rs
+++ b/nextest-runner/src/helpers.rs
@@ -5,6 +5,7 @@ use crate::{list::Styles, runner::AbortStatus};
 use camino::{Utf8Path, Utf8PathBuf};
 use owo_colors::OwoColorize;
 use std::{
+    fmt,
     io::{self, Write},
     path::PathBuf,
     process::ExitStatus,
@@ -183,6 +184,18 @@ pub(crate) fn display_nt_status(nt_status: windows::Win32::Foundation::NTSTATUS)
         nt_status.0,
         io::Error::from_raw_os_error(win32_code as i32)
     );
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct QuotedDisplay<'a, T: ?Sized>(pub(crate) &'a T);
+
+impl<'a, T: ?Sized> fmt::Display for QuotedDisplay<'a, T>
+where
+    T: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "'{}'", self.0)
+    }
 }
 
 // From https://twitter.com/8051Enthusiast/status/1571909110009921538

--- a/nextest-runner/src/lib.rs
+++ b/nextest-runner/src/lib.rs
@@ -22,6 +22,7 @@ pub mod platform;
 pub mod reporter;
 pub mod reuse_build;
 pub mod runner;
+pub mod show_config;
 pub mod signal;
 pub mod target_runner;
 mod test_command;

--- a/nextest-runner/src/list/binary_list.rs
+++ b/nextest-runner/src/list/binary_list.rs
@@ -11,8 +11,8 @@ use camino::{Utf8Path, Utf8PathBuf};
 use cargo_metadata::{Artifact, BuildScript, Message, PackageId};
 use guppy::graph::PackageGraph;
 use nextest_metadata::{
-    BinaryListSummary, BuildPlatform, RustNonTestBinaryKind, RustNonTestBinarySummary,
-    RustTestBinaryKind, RustTestBinarySummary,
+    BinaryListSummary, BuildPlatform, RustBinaryId, RustNonTestBinaryKind,
+    RustNonTestBinarySummary, RustTestBinaryKind, RustTestBinarySummary,
 };
 use owo_colors::OwoColorize;
 use std::{fmt::Write as _, io, io::Write};
@@ -21,7 +21,7 @@ use std::{fmt::Write as _, io, io::Write};
 #[derive(Clone, Debug)]
 pub struct RustTestBinary {
     /// A unique ID.
-    pub id: String,
+    pub id: RustBinaryId,
     /// The path to the binary artifact.
     pub path: Utf8PathBuf,
     /// The package this artifact belongs to.
@@ -248,6 +248,8 @@ impl<'g> BinaryListBuildState<'g> {
                     write!(id, "::{computed_kind}/{name}").unwrap();
                 }
 
+                let id = RustBinaryId::new(&id);
+
                 self.rust_binaries.push(RustTestBinary {
                     path,
                     package_id,
@@ -372,7 +374,7 @@ mod tests {
     #[test]
     fn test_parse_binary_list() {
         let fake_bin_test = RustTestBinary {
-            id: "fake-package::bin/fake-binary".to_owned(),
+            id: "fake-package::bin/fake-binary".into(),
             path: "/fake/binary".into(),
             package_id: "fake-package 0.1.0 (path+file:///Users/fakeuser/project/fake-package)"
                 .to_owned(),
@@ -381,7 +383,7 @@ mod tests {
             build_platform: BuildPlatform::Target,
         };
         let fake_macro_test = RustTestBinary {
-            id: "fake-macro::proc-macro/fake-macro".to_owned(),
+            id: "fake-macro::proc-macro/fake-macro".into(),
             path: "/fake/macro".into(),
             package_id: "fake-macro 0.1.0 (path+file:///Users/fakeuser/project/fake-macro)"
                 .to_owned(),

--- a/nextest-runner/src/list/display_filter.rs
+++ b/nextest-runner/src/list/display_filter.rs
@@ -1,0 +1,49 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use nextest_metadata::RustBinaryId;
+use std::collections::{HashMap, HashSet};
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct TestListDisplayFilter<'list> {
+    // This is a map of paths to the matching tests in those paths. The matching tests are stored as
+    // a set of test names.
+    // Invariant: hashset values are never empty.
+    map: HashMap<&'list RustBinaryId, HashSet<&'list str>>,
+}
+
+impl<'list> TestListDisplayFilter<'list> {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn insert(&mut self, binary_id: &'list RustBinaryId, test_name: &'list str) {
+        self.map.entry(binary_id).or_default().insert(test_name);
+    }
+
+    pub(crate) fn test_count(&self) -> usize {
+        self.map.values().map(|set| set.len()).sum()
+    }
+
+    pub(crate) fn matcher_for(
+        &self,
+        binary_id: &'list RustBinaryId,
+    ) -> Option<DisplayFilterMatcher<'list, '_>> {
+        self.map.get(binary_id).map(DisplayFilterMatcher::Some)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum DisplayFilterMatcher<'list, 'filter> {
+    All,
+    Some(&'filter HashSet<&'list str>),
+}
+
+impl<'list, 'filter> DisplayFilterMatcher<'list, 'filter> {
+    pub(crate) fn is_match(&self, test_name: &str) -> bool {
+        match self {
+            Self::All => true,
+            Self::Some(set) => set.contains(test_name),
+        }
+    }
+}

--- a/nextest-runner/src/list/mod.rs
+++ b/nextest-runner/src/list/mod.rs
@@ -8,11 +8,13 @@
 //! * [`BinaryList`] for test binaries
 
 mod binary_list;
+mod display_filter;
 mod output_format;
 mod rust_build_meta;
 mod test_list;
 
 pub use binary_list::*;
+pub(crate) use display_filter::*;
 pub use output_format::*;
 pub use rust_build_meta::*;
 pub use test_list::*;

--- a/nextest-runner/src/reporter.rs
+++ b/nextest-runner/src/reporter.rs
@@ -224,7 +224,9 @@ impl TestReporterBuilder {
         let styles = Box::default();
         let binary_id_width = test_list
             .iter()
-            .filter_map(|(_, info)| (info.status.test_count() > 0).then_some(info.binary_id.len()))
+            .filter_map(|test_suite| {
+                (test_suite.status.test_count() > 0).then_some(test_suite.binary_id.len())
+            })
             .max()
             .unwrap_or_default();
         let aggregator = EventAggregator::new(profile);

--- a/nextest-runner/src/reporter/aggregator.rs
+++ b/nextest-runner/src/reporter/aggregator.rs
@@ -158,7 +158,7 @@ impl<'cfg> MetadataJunit<'cfg> {
 
                 let mut testcase = TestCase::new(test_instance.name, testcase_status);
                 testcase
-                    .set_classname(&test_instance.suite_info.binary_id)
+                    .set_classname(test_instance.suite_info.binary_id.as_str())
                     .set_timestamp(to_datetime(main_status.start_time))
                     .set_time(main_status.time_taken);
 
@@ -235,8 +235,8 @@ impl<'cfg> MetadataJunit<'cfg> {
 
     fn testsuite_for(&mut self, test_instance: TestInstance<'cfg>) -> &mut TestSuite {
         self.test_suites
-            .entry(&test_instance.suite_info.binary_id)
-            .or_insert_with(|| TestSuite::new(&test_instance.suite_info.binary_id))
+            .entry(test_instance.suite_info.binary_id.as_str())
+            .or_insert_with(|| TestSuite::new(test_instance.suite_info.binary_id.as_str()))
     }
 }
 

--- a/nextest-runner/src/show_config/mod.rs
+++ b/nextest-runner/src/show_config/mod.rs
@@ -1,0 +1,9 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Functionality for showing output of various kinds.
+
+// mod overrides;
+mod test_groups;
+
+pub use test_groups::*;

--- a/nextest-runner/src/show_config/test_groups.rs
+++ b/nextest-runner/src/show_config/test_groups.rs
@@ -1,0 +1,293 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::{
+    config::{
+        CustomTestGroup, FinalConfig, NextestProfile, OverrideId, PreBuildPlatform,
+        ProfileOverrideImpl, TestGroup, TestGroupConfig,
+    },
+    errors::ShowTestGroupsError,
+    helpers::QuotedDisplay,
+    list::{TestInstance, TestList, TestListDisplayFilter},
+};
+use indexmap::IndexMap;
+use owo_colors::{OwoColorize, Style};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    io::{self, Write},
+};
+use target_spec::TargetSpec;
+
+/// Shows sets of tests that are in various groups.
+#[derive(Debug)]
+pub struct ShowTestGroups<'a> {
+    test_list: &'a TestList<'a>,
+    indexed_overrides: BTreeMap<TestGroup, IndexMap<OverrideId, ShowTestGroupsData<'a>>>,
+    test_group_config: &'a BTreeMap<CustomTestGroup, TestGroupConfig>,
+    // This is Some iff settings.show_default is true.
+    non_overrides: Option<TestListDisplayFilter<'a>>,
+}
+
+impl<'a> ShowTestGroups<'a> {
+    /// Validates that the given groups are known to this profile.
+    pub fn validate_groups(
+        profile: &NextestProfile<'_, PreBuildPlatform>,
+        groups: impl IntoIterator<Item = TestGroup>,
+    ) -> Result<ValidatedTestGroups, ShowTestGroupsError> {
+        let groups = groups.into_iter().collect();
+        let known_groups: BTreeSet<_> =
+            TestGroup::make_all_groups(profile.test_group_config().keys().cloned()).collect();
+        let unknown_groups = &groups - &known_groups;
+        if !unknown_groups.is_empty() {
+            return Err(ShowTestGroupsError::UnknownGroups {
+                unknown_groups,
+                known_groups,
+            });
+        }
+        Ok(ValidatedTestGroups(groups))
+    }
+
+    /// Creates a new `ShowTestGroups` from the given profile and test list.
+    pub fn new(
+        profile: &'a NextestProfile<'a>,
+        test_list: &'a TestList<'a>,
+        settings: &ShowTestGroupSettings,
+    ) -> Self {
+        let mut indexed_overrides: BTreeMap<_, _> =
+            TestGroup::make_all_groups(profile.test_group_config().keys().cloned())
+                .filter_map(|group| {
+                    settings
+                        .mode
+                        .matches_group(&group)
+                        .then(|| (group, IndexMap::new()))
+                })
+                .collect();
+        let mut non_overrides = settings.show_default.then(TestListDisplayFilter::new);
+
+        for suite in test_list.iter() {
+            for (test_name, test_case) in suite.status.test_cases() {
+                let test_instance = TestInstance::new(test_name, suite, test_case);
+                let query = test_instance.to_test_query();
+                let profile_overrides = profile.overrides_with_source_for(&query);
+
+                if let Some((test_group, source)) = profile_overrides.test_group_with_source() {
+                    let override_map = match indexed_overrides.get_mut(test_group) {
+                        Some(override_map) => override_map,
+                        None => continue,
+                    };
+                    let data = override_map
+                        .entry(source.id().clone())
+                        .or_insert_with(|| ShowTestGroupsData::new(source));
+                    data.matching_tests.insert(&suite.binary_id, test_name);
+                } else if let Some(non_overrides) = non_overrides.as_mut() {
+                    if settings.mode.matches_group(&TestGroup::Global) {
+                        non_overrides.insert(&suite.binary_id, test_name);
+                    }
+                }
+            }
+        }
+
+        Self {
+            test_list,
+            indexed_overrides,
+            test_group_config: profile.test_group_config(),
+            non_overrides,
+        }
+    }
+
+    fn should_show_group(&self, group: &TestGroup) -> bool {
+        // So this is a bit tricky. We want to show a group if it matches the filter.
+        //
+        //     group     filter    show-default   |   show?
+        //    -------   --------   -------------  |  -------
+        //    @global    matches       true       |   always
+        //    @global    matches      false       |   only if any overrides set @global
+        //    @global   no match         *        |   false  [1]
+        //     custom    matches         *        |   always
+        //     custom   no match         *        |   false  [1]
+        //
+        // [1]: filtered out by the constructor above, so not handled below
+
+        match (group, self.non_overrides.is_some()) {
+            (TestGroup::Global, true) => true,
+            (TestGroup::Global, false) => self
+                .indexed_overrides
+                .get(group)
+                .map(|override_map| !override_map.values().all(|data| data.is_empty()))
+                .unwrap_or(false),
+            _ => true,
+        }
+    }
+
+    /// Writes the test groups to the given writer in a human-friendly format.
+    pub fn write_human(&self, mut writer: &mut dyn Write, colorize: bool) -> io::Result<()> {
+        static INDENT: &str = "      ";
+
+        let mut styles = Styles::default();
+        if colorize {
+            styles.colorize();
+        }
+
+        for (test_group, override_map) in &self.indexed_overrides {
+            if !self.should_show_group(test_group) {
+                continue;
+            }
+
+            write!(writer, "group: {}", test_group.style(styles.group))?;
+            if let TestGroup::Custom(group) = test_group {
+                write!(
+                    writer,
+                    " (max threads = {})",
+                    self.test_group_config[group]
+                        .max_threads
+                        .style(styles.max_threads)
+                )?;
+            }
+            writeln!(writer)?;
+
+            let mut any_printed = false;
+
+            for (override_id, data) in override_map {
+                any_printed = true;
+                write!(
+                    writer,
+                    "  * override for {} profile",
+                    override_id.profile_name.style(styles.profile),
+                )?;
+
+                if let Some((filter_str, _)) = data.override_.filter() {
+                    write!(
+                        writer,
+                        " with filter {}",
+                        QuotedDisplay(filter_str).style(styles.filter)
+                    )?;
+                }
+                if let Some(target_spec) = data.override_.target_spec() {
+                    // TODO: add fmt::Display impl for target_spec.
+                    let platform_str = match target_spec {
+                        TargetSpec::Triple(triple) => triple.as_str(),
+                        TargetSpec::Expression(expr) => expr.expression_str(),
+                    };
+
+                    write!(
+                        writer,
+                        " on platform {}",
+                        QuotedDisplay(platform_str).style(styles.platform)
+                    )?;
+                }
+
+                writeln!(writer, ":")?;
+
+                let mut inner_writer = indent_write::io::IndentWriter::new(INDENT, writer);
+                self.test_list.write_human_with_filter(
+                    &data.matching_tests,
+                    &mut inner_writer,
+                    false,
+                    colorize,
+                )?;
+                inner_writer.flush()?;
+                writer = inner_writer.into_inner();
+            }
+
+            // Also show tests that don't match an override if they match the global config below.
+            if test_group == &TestGroup::Global {
+                if let Some(non_overrides) = &self.non_overrides {
+                    any_printed = true;
+                    writeln!(writer, "  * from default settings:")?;
+                    let mut inner_writer = indent_write::io::IndentWriter::new(INDENT, writer);
+                    self.test_list.write_human_with_filter(
+                        non_overrides,
+                        &mut inner_writer,
+                        false,
+                        colorize,
+                    )?;
+                    inner_writer.flush()?;
+                    writer = inner_writer.into_inner();
+                }
+            }
+
+            if !any_printed {
+                writeln!(writer, "    (no matches)")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Settings for showing test groups.
+#[derive(Clone, Debug)]
+pub struct ShowTestGroupSettings {
+    /// Whether to show tests that have default settings and don't match any overrides.
+    pub show_default: bool,
+
+    /// Which groups of tests to show.
+    pub mode: ShowTestGroupsMode,
+}
+
+/// Which groups of tests to show.
+#[derive(Clone, Debug)]
+pub enum ShowTestGroupsMode {
+    /// Show all groups.
+    All,
+    /// Show only the named groups.
+    Only(ValidatedTestGroups),
+}
+
+impl ShowTestGroupsMode {
+    fn matches_group(&self, group: &TestGroup) -> bool {
+        match self {
+            Self::All => true,
+            Self::Only(groups) => groups.0.contains(group),
+        }
+    }
+}
+
+/// Validated test groups, part of [`ShowTestGroupsMode`].
+#[derive(Clone, Debug)]
+pub struct ValidatedTestGroups(BTreeSet<TestGroup>);
+
+impl ValidatedTestGroups {
+    /// Returns the set of test groups.
+    pub fn into_inner(self) -> BTreeSet<TestGroup> {
+        self.0
+    }
+}
+
+#[derive(Debug)]
+struct ShowTestGroupsData<'a> {
+    override_: &'a ProfileOverrideImpl<FinalConfig>,
+    matching_tests: TestListDisplayFilter<'a>,
+}
+
+impl<'a> ShowTestGroupsData<'a> {
+    fn new(override_: &'a ProfileOverrideImpl<FinalConfig>) -> Self {
+        Self {
+            override_,
+            matching_tests: TestListDisplayFilter::new(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.matching_tests.test_count() == 0
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct Styles {
+    group: Style,
+    max_threads: Style,
+    profile: Style,
+    filter: Style,
+    platform: Style,
+}
+
+impl Styles {
+    fn colorize(&mut self) {
+        self.group = Style::new().bold().underline();
+        self.max_threads = Style::new().bold();
+        self.profile = Style::new().bold();
+        self.filter = Style::new().yellow();
+        self.platform = Style::new().yellow();
+    }
+}

--- a/nextest-runner/tests/integration/basic.rs
+++ b/nextest-runner/tests/integration/basic.rs
@@ -56,7 +56,7 @@ fn test_list_tests() -> Result<()> {
     for (name, expected) in &*EXPECTED_TESTS {
         let test_binary = FIXTURE_TARGETS
             .test_artifacts
-            .get(*name)
+            .get(name)
             .unwrap_or_else(|| panic!("unexpected test name {name}"));
         let info = summary
             .rust_suites
@@ -75,7 +75,7 @@ fn test_list_tests() -> Result<()> {
         let mut err_msg = "actual output has test suites missing in expected output:\n".to_owned();
         for missing_suite in summary.rust_suites.keys() {
             err_msg.push_str("  - ");
-            err_msg.push_str(missing_suite);
+            err_msg.push_str(missing_suite.as_str());
             err_msg.push('\n');
         }
         panic!("{}", err_msg);
@@ -111,7 +111,7 @@ fn test_run() -> Result<()> {
     for (binary_id, expected) in &*EXPECTED_TESTS {
         let test_binary = FIXTURE_TARGETS
             .test_artifacts
-            .get(*binary_id)
+            .get(binary_id)
             .unwrap_or_else(|| panic!("unexpected binary ID {binary_id}"));
         for fixture in expected {
             let instance_value = instance_statuses
@@ -212,7 +212,7 @@ fn test_run_ignored() -> Result<()> {
     for (name, expected) in &*EXPECTED_TESTS {
         let test_binary = FIXTURE_TARGETS
             .test_artifacts
-            .get(*name)
+            .get(name)
             .unwrap_or_else(|| panic!("unexpected test name {name}"));
         for fixture in expected {
             if fixture.name.contains("test_slow_timeout") {
@@ -417,7 +417,7 @@ fn test_retries(retries: Option<RetryPolicy>) -> Result<()> {
     for (name, expected) in &*EXPECTED_TESTS {
         let test_binary = FIXTURE_TARGETS
             .test_artifacts
-            .get(*name)
+            .get(name)
             .unwrap_or_else(|| panic!("unexpected test name {name}"));
         for fixture in expected {
             let instance_value =

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -5,7 +5,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use duct::cmd;
 use guppy::{graph::PackageGraph, MetadataCommand};
 use maplit::btreemap;
-use nextest_metadata::{FilterMatch, MismatchReason};
+use nextest_metadata::{FilterMatch, MismatchReason, RustBinaryId};
 use nextest_runner::{
     cargo_config::{CargoConfigs, EnvironmentMap},
     config::{get_num_cpus, NextestConfig},
@@ -102,11 +102,11 @@ impl FixtureStatus {
     }
 }
 
-pub(crate) static EXPECTED_TESTS: Lazy<BTreeMap<&'static str, Vec<TestFixture>>> = Lazy::new(
+pub(crate) static EXPECTED_TESTS: Lazy<BTreeMap<RustBinaryId, Vec<TestFixture>>> = Lazy::new(
     || {
         btreemap! {
             // Integration tests
-            "nextest-tests::basic" => vec![
+            "nextest-tests::basic".into() => vec![
                 TestFixture { name: "test_cargo_env_vars", status: FixtureStatus::Pass },
                 TestFixture { name: "test_cwd", status: FixtureStatus::Pass },
                 TestFixture { name: "test_execute_bin", status: FixtureStatus::Pass },
@@ -126,53 +126,53 @@ pub(crate) static EXPECTED_TESTS: Lazy<BTreeMap<&'static str, Vec<TestFixture>>>
                 TestFixture { name: "test_success", status: FixtureStatus::Pass },
                 TestFixture { name: "test_success_should_panic", status: FixtureStatus::Pass },
             ],
-            "nextest-tests::other" => vec![
+            "nextest-tests::other".into() => vec![
                 TestFixture { name: "other_test_success", status: FixtureStatus::Pass },
             ],
-            "nextest-tests::segfault" => vec![
+            "nextest-tests::segfault".into() => vec![
                 TestFixture { name: "test_segfault", status: FixtureStatus::Segfault },
             ],
             // Unit tests
-            "nextest-tests" => vec![
+            "nextest-tests".into() => vec![
                 TestFixture { name: "tests::call_dylib_add_two", status: FixtureStatus::Pass },
                 TestFixture { name: "tests::unit_test_success", status: FixtureStatus::Pass },
             ],
             // Binary tests
-            "nextest-tests::bin/nextest-tests" => vec![
+            "nextest-tests::bin/nextest-tests".into() => vec![
                 TestFixture { name: "tests::bin_success", status: FixtureStatus::Pass },
             ],
-            "nextest-tests::bin/other" => vec![
+            "nextest-tests::bin/other".into() => vec![
                 TestFixture { name: "tests::other_bin_success", status: FixtureStatus::Pass },
             ],
             // Example tests
-            "nextest-tests::example/nextest-tests" => vec![
+            "nextest-tests::example/nextest-tests".into() => vec![
                 TestFixture { name: "tests::example_success", status: FixtureStatus::Pass },
             ],
-            "nextest-tests::example/other" => vec![
+            "nextest-tests::example/other".into() => vec![
                 TestFixture { name: "tests::other_example_success", status: FixtureStatus::Pass },
             ],
             // Benchmarks
-            "nextest-tests::bench/my-bench" => vec![
+            "nextest-tests::bench/my-bench".into() => vec![
                 TestFixture { name: "bench_add_two", status: FixtureStatus::Pass },
                 TestFixture { name: "tests::test_execute_bin", status: FixtureStatus::Pass },
             ],
             // Proc-macro tests
-            "nextest-derive::proc-macro/nextest-derive" => vec![
+            "nextest-derive::proc-macro/nextest-derive".into() => vec![
                 TestFixture { name: "it_works", status: FixtureStatus::Pass },
             ],
             // Dynamic library tests
-            "cdylib-link" => vec![
+            "cdylib-link".into() => vec![
                 TestFixture { name: "test_multiply_two", status: FixtureStatus::Pass },
             ],
-            "dylib-test" => vec![],
-            "cdylib-example" => vec![
+            "dylib-test".into() => vec![],
+            "cdylib-example".into() => vec![
                 TestFixture { name: "tests::test_multiply_two_cdylib", status: FixtureStatus::Pass },
             ]
         }
     },
 );
 
-pub(crate) fn get_expected_test(binary_id: &str, test_name: &str) -> &'static TestFixture {
+pub(crate) fn get_expected_test(binary_id: &RustBinaryId, test_name: &str) -> &'static TestFixture {
     let v = EXPECTED_TESTS
         .get(binary_id)
         .unwrap_or_else(|| panic!("binary id {binary_id} not found"));
@@ -303,7 +303,7 @@ pub(crate) static FIXTURE_TARGETS: Lazy<FixtureTargets> = Lazy::new(FixtureTarge
 #[derive(Debug)]
 pub(crate) struct FixtureTargets {
     pub(crate) rust_build_meta: RustBuildMeta<TestListState>,
-    pub(crate) test_artifacts: BTreeMap<String, RustTestArtifact<'static>>,
+    pub(crate) test_artifacts: BTreeMap<RustBinaryId, RustTestArtifact<'static>>,
     pub(crate) env: EnvironmentMap,
 }
 

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -429,7 +429,10 @@ pub(crate) fn execute_collect(
         };
 
         instance_statuses.insert(
-            (test_instance.binary, test_instance.name),
+            (
+                test_instance.suite_info.binary_path.as_path(),
+                test_instance.name,
+            ),
             InstanceValue {
                 binary_id: test_instance.suite_info.binary_id.as_str(),
                 cwd: test_instance.suite_info.cwd.as_path(),

--- a/nextest-runner/tests/integration/target_runner.rs
+++ b/nextest-runner/tests/integration/target_runner.rs
@@ -218,7 +218,7 @@ fn test_run_with_target_runner() -> Result<()> {
     for (name, expected) in &*EXPECTED_TESTS {
         let test_binary = FIXTURE_TARGETS
             .test_artifacts
-            .get(*name)
+            .get(name)
             .unwrap_or_else(|| panic!("unexpected test name {name}"));
         for fixture in expected {
             let instance_value = instance_statuses

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -30,6 +30,7 @@ owo-colors = { version = "3.5.0", default-features = false, features = ["support
 rand = { version = "0.8.5", features = ["alloc", "getrandom", "libc", "rand_chacha", "std", "std_rng"] }
 serde = { version = "1.0.152", features = ["alloc", "derive", "serde_derive", "std"] }
 serde_json = { version = "1.0.91", features = ["std", "unbounded_depth"] }
+similar = { version = "2.2.1", features = ["bstr", "inline", "text", "unicode", "unicode-segmentation"] }
 target-spec = { version = "1.2.2", default-features = false, features = ["serde", "summaries"] }
 tokio = { version = "1.23.0", features = ["bytes", "io-util", "libc", "macros", "memchr", "mio", "num_cpus", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "sync", "time", "tokio-macros", "tracing"] }
 twox-hash = { version = "1.6.3", features = ["rand", "std"] }


### PR DESCRIPTION
Add a way to display test groups as they currently apply to tests.

In the future we'll add support for displaying other kinds of configuration, but hopefully this will be useful for now.