### PR TITLE
Support [profile.default-llvm-cov]

### DIFF
--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -1128,6 +1128,8 @@ impl App {
             // https://github.com/rust-lang/miri/pull/2398#issuecomment-1190747685
             if std::env::var_os("MIRI_SYSROOT").is_some() {
                 NextestConfig::DEFAULT_MIRI_PROFILE
+            } else if std::env::var_os("CARGO_LLVM_COV").is_some() {
+                NextestConfig::DEFAULT_LLVM_COV_PROFILE
             } else {
                 NextestConfig::DEFAULT_PROFILE
             }

--- a/nextest-runner/src/config/config_impl.rs
+++ b/nextest-runner/src/config/config_impl.rs
@@ -73,9 +73,12 @@ impl NextestConfig {
     /// The name of the default profile used for miri.
     pub const DEFAULT_MIRI_PROFILE: &'static str = "default-miri";
 
+    /// The name of the default profile used for cargo-llvm-cov
+    pub const DEFAULT_LLVM_COV_PROFILE: &'static str = "default-llvm-cov";
+
     /// A list containing the names of the Nextest defined reserved profile names.
     pub const DEFAULT_PROFILES: &'static [&'static str] =
-        &[Self::DEFAULT_PROFILE, Self::DEFAULT_MIRI_PROFILE];
+        &[Self::DEFAULT_PROFILE, Self::DEFAULT_MIRI_PROFILE, Self::DEFAULT_LLVM_COV_PROFILE];
 
     /// Reads the nextest config from the given file, or if not specified from `.config/nextest.toml`
     /// in the workspace root.


### PR DESCRIPTION
Depends on https://github.com/taiki-e/cargo-llvm-cov/pull/259

This is done similarly for miri and makes sense since both increase running times.