### PR TITLE
[nextest-filtering] handle multiline filter strings

### DIFF
--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -1082,7 +1082,7 @@ impl App {
             .build_filter
             .filter_expr
             .iter()
-            .map(|input| FilteringExpr::parse(input, self.base.graph()))
+            .map(|input| FilteringExpr::parse(input.clone(), self.base.graph()))
             .partition_result();
 
         if !all_errors.is_empty() {

--- a/fixtures/nextest-tests/.config/nextest.toml
+++ b/fixtures/nextest-tests/.config/nextest.toml
@@ -20,7 +20,7 @@ retries = 5
 # This is specified as a multiline filter to ensure that we can deal with such parsers.
 filter = """
     test(test_flaky_mod)
-    | test(test_flaky_mod_4)
+    | test(~test_flaky_mod_4)
 """
 
 retries = 4

--- a/fixtures/nextest-tests/.config/nextest.toml
+++ b/fixtures/nextest-tests/.config/nextest.toml
@@ -16,7 +16,13 @@ retries = 5
 # Ensure that the earlier retry setting for test_flaky_mod_6 overrides the later one,
 # and also run test_flaky_mod_4 with 4 retries (5 tries): try 4/5 should pass.
 [[profile.with-retries.overrides]]
-filter = "test(test_flaky_mod)"
+
+# This is specified as a multiline filter to ensure that we can deal with such parsers.
+filter = """
+    test(test_flaky_mod)
+    | test(test_flaky_mod_4)
+"""
+
 retries = 4
 test-group = 'flaky'
 

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-3.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-3.snap
@@ -3,7 +3,7 @@ source: integration-tests/tests/integration/main.rs
 expression: with_retries_output.stdout_as_str()
 ---
 group: flaky (max threads = 4)
-  * override for with-retries profile with filter 'test(~test_flaky_mod) | test(~test_flaky_mod_4)':
+  * override for with-retries profile with filter 'test(test_flaky_mod) | test(~test_flaky_mod_4)':
       nextest-tests::basic:
           test_flaky_mod_4
           test_flaky_mod_6

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-3.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-3.snap
@@ -3,9 +3,7 @@ source: integration-tests/tests/integration/main.rs
 expression: with_retries_output.stdout_as_str()
 ---
 group: flaky (max threads = 4)
-  * override for with-retries profile with filter '    test(test_flaky_mod)
-    | test(test_flaky_mod_4)
-':
+  * override for with-retries profile with filter 'test(~test_flaky_mod) | test(~test_flaky_mod_4)':
       nextest-tests::basic:
           test_flaky_mod_4
           test_flaky_mod_6

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-3.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-3.snap
@@ -3,7 +3,9 @@ source: integration-tests/tests/integration/main.rs
 expression: with_retries_output.stdout_as_str()
 ---
 group: flaky (max threads = 4)
-  * override for with-retries profile with filter 'test(test_flaky_mod)':
+  * override for with-retries profile with filter '    test(test_flaky_mod)
+    | test(test_flaky_mod_4)
+':
       nextest-tests::basic:
           test_flaky_mod_4
           test_flaky_mod_6

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-4.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-4.snap
@@ -3,7 +3,7 @@ source: integration-tests/tests/integration/main.rs
 expression: with_retries_all_output.stdout_as_str()
 ---
 group: flaky (max threads = 4)
-  * override for with-retries profile with filter 'test(~test_flaky_mod) | test(~test_flaky_mod_4)':
+  * override for with-retries profile with filter 'test(test_flaky_mod) | test(~test_flaky_mod_4)':
       nextest-tests::basic:
           test_flaky_mod_4
           test_flaky_mod_6

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-4.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-4.snap
@@ -3,9 +3,7 @@ source: integration-tests/tests/integration/main.rs
 expression: with_retries_all_output.stdout_as_str()
 ---
 group: flaky (max threads = 4)
-  * override for with-retries profile with filter '    test(test_flaky_mod)
-    | test(test_flaky_mod_4)
-':
+  * override for with-retries profile with filter 'test(~test_flaky_mod) | test(~test_flaky_mod_4)':
       nextest-tests::basic:
           test_flaky_mod_4
           test_flaky_mod_6

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-4.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-4.snap
@@ -3,7 +3,9 @@ source: integration-tests/tests/integration/main.rs
 expression: with_retries_all_output.stdout_as_str()
 ---
 group: flaky (max threads = 4)
-  * override for with-retries profile with filter 'test(test_flaky_mod)':
+  * override for with-retries profile with filter '    test(test_flaky_mod)
+    | test(test_flaky_mod_4)
+':
       nextest-tests::basic:
           test_flaky_mod_4
           test_flaky_mod_6

--- a/nextest-filtering/examples/parser.rs
+++ b/nextest-filtering/examples/parser.rs
@@ -53,7 +53,7 @@ fn main() {
     let args = Args::parse();
 
     let graph = load_graph(args.cargo_metadata);
-    match nextest_filtering::FilteringExpr::parse(&args.expr, &graph) {
+    match nextest_filtering::FilteringExpr::parse(args.expr, &graph) {
         Ok(expr) => println!("{expr:?}"),
         Err(FilterExpressionParseErrors { input, errors, .. }) => {
             for error in errors {

--- a/nextest-filtering/src/bin/generate-expr-corpus.rs
+++ b/nextest-filtering/src/bin/generate-expr-corpus.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use nextest_filtering::Expr;
+use nextest_filtering::ParsedExpr;
 use proptest::{
     strategy::{Strategy, ValueTree},
     test_runner::{Config, RngAlgorithm, TestRng, TestRunner},
@@ -17,7 +17,7 @@ static CORPUS_DIR: &str = "fuzz/corpus/fuzz_parsing";
 fn main() {
     let mut gen = ValueGenerator::from_seed("fuzz_parsing_corpus");
     for n in 0..1024 {
-        let value = gen.generate(Expr::strategy());
+        let value = gen.generate(ParsedExpr::strategy());
         let path = Path::new(CORPUS_DIR);
         let path = path.join(format!("seed-{n}"));
         std::fs::write(path, value.to_string()).unwrap();

--- a/nextest-filtering/src/compile.rs
+++ b/nextest-filtering/src/compile.rs
@@ -142,5 +142,10 @@ fn compile_expr(
         Intersection(expr_1, expr_2) => {
             FilteringExpr::Intersection(Box::new(expr_1), Box::new(expr_2))
         }
+        Difference(expr_1, expr_2) => FilteringExpr::Intersection(
+            Box::new(expr_1),
+            Box::new(FilteringExpr::Not(Box::new(expr_2))),
+        ),
+        Parens(expr_1) => expr_1,
     })
 }

--- a/nextest-filtering/src/expression.rs
+++ b/nextest-filtering/src/expression.rs
@@ -97,7 +97,7 @@ pub struct TestQuery<'a> {
     pub test_name: &'a str,
 }
 
-/// Filtering expression
+/// Filtering expression.
 ///
 /// Used to filter tests to run.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/nextest-filtering/src/lib.rs
+++ b/nextest-filtering/src/lib.rs
@@ -11,6 +11,7 @@ mod parsing;
 #[cfg(any(test, feature = "internal-testing"))]
 mod proptest_helpers;
 
-pub use expression::{BinaryQuery, FilteringExpr, FilteringSet, NameMatcher, TestQuery};
-#[doc(hidden)]
-pub use parsing::Expr;
+pub use expression::{
+    BinaryQuery, CompiledExpr, FilteringExpr, FilteringSet, NameMatcher, TestQuery,
+};
+pub use parsing::ParsedExpr;

--- a/nextest-filtering/src/proptest_helpers.rs
+++ b/nextest-filtering/src/proptest_helpers.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::{
-    parsing::{AndOperator, DifferenceOperator, Expr, NotOperator, OrOperator, SetDef},
+    parsing::{AndOperator, DifferenceOperator, NotOperator, OrOperator, ParsedExpr, SetDef},
     NameMatcher,
 };
 use guppy::graph::cargo::BuildPlatform;
 use proptest::prelude::*;
 
-impl Expr<()> {
+impl ParsedExpr<()> {
     #[doc(hidden)]
     pub fn strategy() -> impl Strategy<Value = Self> {
         let leaf = SetDef::strategy().prop_map(Self::Set);

--- a/nextest-runner/src/config/overrides.rs
+++ b/nextest-runner/src/config/overrides.rs
@@ -140,7 +140,7 @@ impl<Source: Copy> TestSettings<Source> {
                 continue;
             }
 
-            if let Some((_, expr)) = &override_.data.expr {
+            if let Some(expr) = &override_.data.expr {
                 if !expr.matches_test(query) {
                     continue;
                 }
@@ -327,7 +327,7 @@ pub(crate) struct OverrideId {
 #[derive(Clone, Debug)]
 pub(super) struct ProfileOverrideData {
     target_spec: Option<TargetSpec>,
-    expr: Option<(String, FilteringExpr)>,
+    expr: Option<FilteringExpr>,
     threads_required: Option<ThreadsRequired>,
     retries: Option<RetryPolicy>,
     slow_timeout: Option<SlowTimeout>,
@@ -362,7 +362,7 @@ impl CompiledOverride<PreBuildPlatform> {
             .map(|platform_str| TargetSpec::new(platform_str.to_owned()))
             .transpose();
         let filter_expr = source.filter.as_ref().map_or(Ok(None), |filter| {
-            Some(FilteringExpr::parse(filter, graph).map(|expr| (filter.clone(), expr))).transpose()
+            Some(FilteringExpr::parse(filter.clone(), graph)).transpose()
         });
 
         match (target_spec, filter_expr) {
@@ -446,12 +446,9 @@ impl CompiledOverride<FinalConfig> {
         self.data.target_spec.as_ref()
     }
 
-    /// Returns the filter string and expression, if any.
-    pub(crate) fn filter(&self) -> Option<(&str, &FilteringExpr)> {
-        self.data
-            .expr
-            .as_ref()
-            .map(|(filter, expr)| (filter.as_str(), expr))
+    /// Returns the filter expression, if any.
+    pub(crate) fn filter(&self) -> Option<&FilteringExpr> {
+        self.data.expr.as_ref()
     }
 }
 

--- a/nextest-runner/src/list/test_list.rs
+++ b/nextest-runner/src/list/test_list.rs
@@ -969,7 +969,10 @@ mod tests {
             None,
             iter::empty::<String>(),
             // Test against the platform() predicate because this is the most important one here.
-            vec![FilteringExpr::parse("platform(target)", &PACKAGE_GRAPH_FIXTURE).unwrap()],
+            vec![
+                FilteringExpr::parse("platform(target)".to_owned(), &PACKAGE_GRAPH_FIXTURE)
+                    .unwrap(),
+            ],
         )
         .unwrap();
         let fake_cwd: Utf8PathBuf = "/fake/cwd".into();

--- a/nextest-runner/src/show_config/test_groups.rs
+++ b/nextest-runner/src/show_config/test_groups.rs
@@ -161,11 +161,11 @@ impl<'a> ShowTestGroups<'a> {
                     override_id.profile_name.style(styles.profile),
                 )?;
 
-                if let Some((filter_str, _)) = data.override_.filter() {
+                if let Some(expr) = data.override_.filter() {
                     write!(
                         writer,
                         " with filter {}",
-                        QuotedDisplay(filter_str).style(styles.filter)
+                        QuotedDisplay(&expr.parsed).style(styles.filter)
                     )?;
                 }
                 if let Some(target_spec) = data.override_.target_spec() {

--- a/nextest-runner/tests/integration/basic.rs
+++ b/nextest-runner/tests/integration/basic.rs
@@ -182,7 +182,8 @@ fn test_run() -> Result<()> {
 fn test_run_ignored() -> Result<()> {
     set_env_vars();
 
-    let expr = FilteringExpr::parse("not test(test_slow_timeout)", &PACKAGE_GRAPH).unwrap();
+    let expr =
+        FilteringExpr::parse("not test(test_slow_timeout)".to_owned(), &PACKAGE_GRAPH).unwrap();
 
     let test_filter = TestFilterBuilder::new(
         RunIgnored::IgnoredOnly,
@@ -255,7 +256,7 @@ fn test_filter_expr_with_string_filters() -> Result<()> {
     set_env_vars();
 
     let expr = FilteringExpr::parse(
-        "test(test_multiply_two) | test(=tests::call_dylib_add_two)",
+        "test(test_multiply_two) | test(=tests::call_dylib_add_two)".to_owned(),
         &PACKAGE_GRAPH,
     )
     .expect("filter expression is valid");
@@ -318,7 +319,7 @@ fn test_filter_expr_without_string_filters() -> Result<()> {
     set_env_vars();
 
     let expr = FilteringExpr::parse(
-        "test(test_multiply_two) | test(=tests::call_dylib_add_two)",
+        "test(test_multiply_two) | test(=tests::call_dylib_add_two)".to_owned(),
         &PACKAGE_GRAPH,
     )
     .expect("filter expression is valid");
@@ -526,7 +527,8 @@ fn test_retries(retries: Option<RetryPolicy>) -> Result<()> {
 fn test_termination() -> Result<()> {
     set_env_vars();
 
-    let expr = FilteringExpr::parse("test(/^test_slow_timeout/)", &PACKAGE_GRAPH).unwrap();
+    let expr =
+        FilteringExpr::parse("test(/^test_slow_timeout/)".to_owned(), &PACKAGE_GRAPH).unwrap();
     let test_filter = TestFilterBuilder::new(
         RunIgnored::IgnoredOnly,
         None,


### PR DESCRIPTION
No reason for filters to be restricted to one line.

Also make `show-config` provide a cleaner representation of the string. This was a bit of a rabbit hole (required adding some fidelity to `ParsedExpr`) but not too bad overall.

Closes #868.