### PR TITLE
[nextest-runner] add support for custom targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-expr"
-version = "0.15.1"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8790cf1286da485c72cf5fc7aeba308438800036ec67d89425924c4807268c9"
+checksum = "215c0072ecc28f92eeb0eea38ba63ddfcb65c2828c46311d646f1a3ff5f9841c"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -954,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "guppy"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f822a2716041492e071691606474f5a7e4fa7c2acbfd7da7b29884fb448291c7"
+checksum = "7908f6137bed4f010d97c1863652aad548026a3460c1849ee1cb32ba7654e444"
 dependencies = [
  "camino",
  "cargo_metadata",
@@ -2719,21 +2719,22 @@ checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
 
 [[package]]
 name = "target-spec"
-version = "1.4.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf4306559bd50cb358e7af5692694d6f6fad95cf2c0bea2571dd419f5298e12"
+checksum = "afb5c6b004c233467bdcdfbf856f45bfbe0e9aacf20cc31617c98fb4f5080af5"
 dependencies = [
  "cfg-expr",
  "guppy-workspace-hack",
  "serde",
+ "serde_json",
  "target-lexicon",
 ]
 
 [[package]]
 name = "target-spec-miette"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05f99f2cd9ad6c8431ab04c9040e0da05b9ef2f05ca4a48c63939e285ee3cad"
+checksum = "1f3440b0d3af524ba5fffdc27f18cf755f2b235dbc2d66a54fa2428c4ba35d14"
 dependencies = [
  "guppy-workspace-hack",
  "miette",

--- a/cargo-nextest/Cargo.toml
+++ b/cargo-nextest/Cargo.toml
@@ -22,7 +22,7 @@ duct = "0.13.6"
 enable-ansi-support = "0.2.1"
 # we don't use the default formatter so we don't need default features
 env_logger = { version = "0.10.0", default-features = false }
-guppy = "0.15.2"
+guppy = "0.16.0"
 log = "0.4.19"
 itertools = "0.10.5"
 miette = { version = "5.9.0", features = ["fancy"] }

--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -1497,9 +1497,10 @@ fn discover_target_triple(
     match TargetTriple::find(cargo_configs, target_cli_option) {
         Ok(Some(triple)) => {
             log::debug!(
-                "using target triple `{}` defined by `{}`",
+                "using target triple `{}` defined by `{}`; {}",
                 triple.platform.triple_str(),
-                triple.source
+                triple.source,
+                triple.location,
             );
             Some(triple)
         }

--- a/fixtures/custom-target/my-target.json
+++ b/fixtures/custom-target/my-target.json
@@ -1,0 +1,46 @@
+{
+  "arch": "x86_64",
+  "cpu": "x86-64",
+  "crt-static-respected": true,
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  "dynamic-linking": true,
+  "env": "gnu",
+  "has-rpath": true,
+  "has-thread-local": true,
+  "llvm-target": "x86_64-unknown-linux-gnu",
+  "max-atomic-width": 64,
+  "os": "linux",
+  "position-independent-executables": true,
+  "pre-link-args": {
+    "gcc": [
+      "-m64"
+    ]
+  },
+  "relro-level": "full",
+  "stack-probes": {
+    "kind": "inline-or-call",
+    "min-llvm-version-for-inline": [
+      16,
+      0,
+      0
+    ]
+  },
+  "static-position-independent-executables": true,
+  "supported-sanitizers": [
+    "address",
+    "cfi",
+    "leak",
+    "memory",
+    "thread"
+  ],
+  "supported-split-debuginfo": [
+    "packed",
+    "unpacked",
+    "off"
+  ],
+  "supports-xray": true,
+  "target-family": [
+    "unix"
+  ],
+  "target-pointer-width": "64"
+}

--- a/nextest-filtering/Cargo.toml
+++ b/nextest-filtering/Cargo.toml
@@ -26,7 +26,7 @@ internal-testing = ["dep:proptest", "dep:test-strategy", "dep:twox-hash"]
 # trace = ["nom-tracable/trace"]
 
 [dependencies]
-guppy = "0.15.2"
+guppy = "0.16.0"
 miette = "5.9.0"
 nom = "7.1.3"
 nom-tracable = "0.9.0"

--- a/nextest-metadata/Cargo.toml
+++ b/nextest-metadata/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.66"
 camino = { version = "1.1.4", features = ["serde1"] }
 serde = { version = "1.0.164", features = ["derive"] }
 serde_json = "1.0.97"
-target-spec = { version = "1.4.0", features = ["summaries"] }
+target-spec = { version = "2.0.1", features = ["custom", "summaries"] }
 nextest-workspace-hack = { version = "0.1", path = "../workspace-hack" }
 smol_str = { version = "0.2.0", features = ["serde"] }
 

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -26,7 +26,7 @@ chrono = "0.4.26"
 debug-ignore = "1.0.5"
 either = "1.8.1"
 futures = "0.3.28"
-guppy = "0.15.2"
+guppy = "0.16.0"
 # Used to find the cargo root directory, which is needed in case the user has
 # added a config.toml there
 home = "0.5.5"
@@ -53,8 +53,8 @@ smol_str = { version = "0.2.0", features = ["serde"] }
 strip-ansi-escapes = "0.1.1"
 tar = "0.4.38"
 # For cfg expression evaluation for [target.'cfg()'] expressions
-target-spec = { version = "1.4.0", features = ["summaries"] }
-target-spec-miette = "0.1.0"
+target-spec = { version = "2.0.1", features = ["custom", "summaries"] }
+target-spec-miette = "0.2.0"
 thiserror = "1.0.40"
 # For parsing of .cargo/config.toml files
 tokio = { version = "1.28.2", features = [

--- a/nextest-runner/src/cargo_config/env.rs
+++ b/nextest-runner/src/cargo_config/env.rs
@@ -287,8 +287,13 @@ mod tests {
         let dir_foo_path = dir_path.join("foo");
         let dir_foo_bar_path = dir_foo_path.join("bar");
 
-        let configs =
-            CargoConfigs::new_with_isolation(&[] as &[&str], &dir_foo_bar_path, &dir_path).unwrap();
+        let configs = CargoConfigs::new_with_isolation(
+            &[] as &[&str],
+            &dir_foo_bar_path,
+            &dir_path,
+            Vec::new(),
+        )
+        .unwrap();
         let env = EnvironmentMap::new(&configs);
         let var = env
             .map
@@ -300,6 +305,7 @@ mod tests {
             ["env.SOME_VAR=\"cli-config\""],
             &dir_foo_bar_path,
             &dir_path,
+            Vec::new(),
         )
         .unwrap();
         let env = EnvironmentMap::new(&configs);
@@ -321,6 +327,7 @@ mod tests {
             ["env.SOME_VAR={value = \"path\", relative = true }"],
             &dir_foo_bar_path,
             &dir_path,
+            Vec::new(),
         )
         .expect_err("CLI configs can't be relative");
 
@@ -328,6 +335,7 @@ mod tests {
             ["env.SOME_VAR.value=\"path\"", "env.SOME_VAR.relative=true"],
             &dir_foo_bar_path,
             &dir_path,
+            Vec::new(),
         )
         .expect_err("CLI configs can't be relative");
     }

--- a/nextest-runner/src/cargo_config/test_helpers.rs
+++ b/nextest-runner/src/cargo_config/test_helpers.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use camino::Utf8PathBuf;
 use camino_tempfile::Utf8TempDir;
 use color_eyre::eyre::{Context, Result};
 
@@ -13,6 +14,21 @@ pub(super) fn setup_temp_dir() -> Result<Utf8TempDir> {
         .wrap_err("error creating foo/.cargo subdir")?;
     std::fs::create_dir_all(dir.path().join("foo/bar/.cargo"))
         .wrap_err("error creating foo/bar/.cargo subdir")?;
+    std::fs::create_dir_all(dir.path().join("foo/bar/custom1/.cargo"))
+        .wrap_err("error creating foo/bar/custom1/.cargo subdir")?;
+    std::fs::create_dir_all(dir.path().join("foo/bar/custom2/.cargo"))
+        .wrap_err("error creating foo/bar/custom2/.cargo subdir")?;
+
+    std::fs::create_dir_all(dir.path().join("custom-target"))
+        .wrap_err("error creating custom-target")?;
+    let custom_target_path = custom_target_path();
+    println!("{custom_target_path}");
+
+    std::fs::copy(
+        &custom_target_path,
+        dir.path().join("custom-target/my-target.json"),
+    )
+    .wrap_err("error copying custom target")?;
 
     std::fs::write(
         dir.path().join("foo/.cargo/config"),
@@ -25,12 +41,34 @@ pub(super) fn setup_temp_dir() -> Result<Utf8TempDir> {
     )
     .wrap_err("error writing foo/bar/.cargo/config.toml")?;
     std::fs::write(
+        dir.path().join("foo/bar/custom1/.cargo/config.toml"),
+        FOO_BAR_CUSTOM1_CARGO_CONFIG_CONTENTS,
+    )
+    .wrap_err("error writing foo/bar/custom1/.cargo/config.toml")?;
+    std::fs::write(
+        dir.path().join("foo/bar/custom2/.cargo/config.toml"),
+        FOO_BAR_CUSTOM2_CARGO_CONFIG_CONTENTS,
+    )
+    .wrap_err("error writing foo/bar/custom2/.cargo/config.toml")?;
+    std::fs::write(
         dir.path().join("foo/extra-config.toml"),
         FOO_EXTRA_CONFIG_CONTENTS,
     )
     .wrap_err("error writing foo/extra-config.toml")?;
+    std::fs::write(
+        dir.path().join("foo/extra-custom-config.toml"),
+        FOO_EXTRA_CUSTOM_CONFIG_CONTENTS,
+    )
+    .wrap_err("error writing foo/extra-custom-config.toml")?;
 
     Ok(dir)
+}
+
+pub(super) fn custom_target_path() -> Utf8PathBuf {
+    Utf8PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
+        .parent()
+        .unwrap()
+        .join("fixtures/custom-target/my-target.json")
 }
 
 static FOO_CARGO_CONFIG_CONTENTS: &str = r#"
@@ -49,7 +87,22 @@ target = "x86_64-unknown-linux-gnu"
 SOME_VAR = { value = "foo-bar-config", force = true }
 "#;
 
+static FOO_BAR_CUSTOM1_CARGO_CONFIG_CONTENTS: &str = r#"
+[build]
+target = "my-target"
+"#;
+
+static FOO_BAR_CUSTOM2_CARGO_CONFIG_CONTENTS: &str = r#"
+[build]
+target = "../../../custom-target/my-target.json"
+"#;
+
 static FOO_EXTRA_CONFIG_CONTENTS: &str = r#"
 [build]
 target = "aarch64-unknown-linux-gnu"
+"#;
+
+static FOO_EXTRA_CUSTOM_CONFIG_CONTENTS: &str = r#"
+[build]
+target = "custom-target/my-target.json"
 "#;

--- a/nextest-runner/src/config/test_helpers.rs
+++ b/nextest-runner/src/config/test_helpers.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::{
-    cargo_config::{TargetTriple, TargetTripleSource},
+    cargo_config::{TargetDefinitionLocation, TargetTriple, TargetTripleSource},
     config::{CustomTestGroup, TestGroup},
     platform::BuildPlatforms,
 };
@@ -44,6 +44,7 @@ pub(super) fn build_platforms() -> BuildPlatforms {
         Some(TargetTriple {
             platform: Platform::new("aarch64-apple-darwin", TargetFeatures::Unknown).unwrap(),
             source: TargetTripleSource::Env,
+            location: TargetDefinitionLocation::Builtin,
         }),
     )
 }

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -995,6 +995,20 @@ pub enum TargetTripleError {
         #[source]
         error: target_spec::Error,
     },
+
+    /// For a custom platform, reading the target path failed.
+    #[error("target path `{path}` is not a valid file")]
+    TargetPathReadError {
+        /// The source from which the triple couldn't be parsed.
+        source: TargetTripleSource,
+
+        /// The path that we tried to read.
+        path: Utf8PathBuf,
+
+        /// The error that occurred parsing the triple.
+        #[source]
+        error: std::io::Error,
+    },
 }
 
 /// An error occurred determining the target runner

--- a/nextest-runner/src/list/binary_list.rs
+++ b/nextest-runner/src/list/binary_list.rs
@@ -365,7 +365,10 @@ impl<'g> BinaryListBuildState<'g> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{cargo_config::TargetTripleSource, list::SerializableFormat};
+    use crate::{
+        cargo_config::{TargetDefinitionLocation, TargetTripleSource},
+        list::SerializableFormat,
+    };
     use indoc::indoc;
     use maplit::btreeset;
     use pretty_assertions::assert_eq;
@@ -395,6 +398,7 @@ mod tests {
         let fake_triple = TargetTriple {
             platform: Platform::new("x86_64-unknown-linux-gnu", TargetFeatures::Unknown).unwrap(),
             source: TargetTripleSource::CliOption,
+            location: TargetDefinitionLocation::Builtin,
         };
         let mut rust_build_meta = RustBuildMeta::new("/fake/target", Some(fake_triple));
         rust_build_meta

--- a/nextest-runner/src/list/test_list.rs
+++ b/nextest-runner/src/list/test_list.rs
@@ -936,7 +936,7 @@ pub struct TestExecuteContext<'a> {
 mod tests {
     use super::*;
     use crate::{
-        cargo_config::{TargetTriple, TargetTripleSource},
+        cargo_config::{TargetDefinitionLocation, TargetTriple, TargetTripleSource},
         list::SerializableFormat,
         test_filter::RunIgnored,
     };
@@ -1010,6 +1010,7 @@ mod tests {
             )
             .unwrap(),
             source: TargetTripleSource::CliOption,
+            location: TargetDefinitionLocation::Builtin,
         };
         let fake_env = EnvironmentMap::empty();
         let rust_build_meta =

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -314,6 +314,7 @@ impl FixtureTargets {
             [workspace_root().join(".cargo/extra-config.toml")],
             &workspace_root(),
             &workspace_root(),
+            Vec::new(),
         )
         .unwrap();
         let env = EnvironmentMap::new(&cargo_configs);

--- a/nextest-runner/tests/integration/target_runner.rs
+++ b/nextest-runner/tests/integration/target_runner.rs
@@ -22,6 +22,7 @@ fn runner_for_target(triple: Option<&str>) -> Result<(BuildPlatforms, TargetRunn
         Vec::<String>::new(),
         &workspace_root(),
         &workspace_root(),
+        Vec::new(),
     )
     .unwrap();
     let triple = TargetTriple::find(&configs, triple)?;
@@ -66,9 +67,13 @@ fn parse_triple(triple: &'static str) -> target_spec::Platform {
 fn parses_cargo_config_exact() {
     let workspace_root = workspace_root();
     let windows = parse_triple("x86_64-pc-windows-gnu");
-    let configs =
-        CargoConfigs::new_with_isolation(Vec::<String>::new(), &workspace_root, &workspace_root)
-            .unwrap();
+    let configs = CargoConfigs::new_with_isolation(
+        Vec::<String>::new(),
+        &workspace_root,
+        &workspace_root,
+        Vec::new(),
+    )
+    .unwrap();
     let runner = PlatformRunner::find_config(&configs, &windows)
         .unwrap()
         .unwrap();
@@ -81,9 +86,13 @@ fn parses_cargo_config_exact() {
 fn disregards_non_matching() {
     let workspace_root = workspace_root();
     let windows = parse_triple("x86_64-unknown-linux-gnu");
-    let configs =
-        CargoConfigs::new_with_isolation(Vec::<String>::new(), &workspace_root, &workspace_root)
-            .unwrap();
+    let configs = CargoConfigs::new_with_isolation(
+        Vec::<String>::new(),
+        &workspace_root,
+        &workspace_root,
+        Vec::new(),
+    )
+    .unwrap();
     assert!(PlatformRunner::find_config(&configs, &windows)
         .unwrap()
         .is_none());
@@ -93,9 +102,13 @@ fn disregards_non_matching() {
 fn parses_cargo_config_cfg() {
     let workspace_root = workspace_root();
     let android = parse_triple("aarch64-linux-android");
-    let configs =
-        CargoConfigs::new_with_isolation(Vec::<String>::new(), &workspace_root, &workspace_root)
-            .unwrap();
+    let configs = CargoConfigs::new_with_isolation(
+        Vec::<String>::new(),
+        &workspace_root,
+        &workspace_root,
+        Vec::new(),
+    )
+    .unwrap();
     let runner = PlatformRunner::find_config(&configs, &android)
         .unwrap()
         .unwrap();

--- a/nextest-runner/tests/integration/target_triple.rs
+++ b/nextest-runner/tests/integration/target_triple.rs
@@ -2,20 +2,24 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::fixtures::*;
+use camino::Utf8PathBuf;
 use color_eyre::Result;
-use nextest_runner::cargo_config::{CargoConfigs, TargetTriple, TargetTripleSource};
+use nextest_runner::cargo_config::{
+    CargoConfigs, TargetDefinitionLocation, TargetTriple, TargetTripleSource,
+};
 use target_spec::{Platform, TargetFeatures};
 
 #[test]
 fn parses_target_cli_option() {
     std::env::set_var("CARGO_BUILD_TARGET", "x86_64-unknown-linux-musl");
-    let triple = target_triple(Some("aarch64-unknown-linux-gnu")).unwrap();
+    let triple = target_triple(Some("aarch64-unknown-linux-gnu"), Vec::new()).unwrap();
 
     assert_eq!(
         triple,
         Some(TargetTriple {
             platform: platform("aarch64-unknown-linux-gnu"),
             source: TargetTripleSource::CliOption,
+            location: TargetDefinitionLocation::Builtin,
         })
     )
 }
@@ -23,22 +27,142 @@ fn parses_target_cli_option() {
 #[test]
 fn parses_cargo_env() {
     std::env::set_var("CARGO_BUILD_TARGET", "x86_64-unknown-linux-musl");
-    let triple = target_triple(None).unwrap();
+    let triple = target_triple(None, Vec::new()).unwrap();
 
     assert_eq!(
         triple,
         Some(TargetTriple {
             platform: platform("x86_64-unknown-linux-musl"),
             source: TargetTripleSource::Env,
+            location: TargetDefinitionLocation::Builtin,
         })
     )
 }
 
-fn target_triple(target_cli_option: Option<&str>) -> Result<Option<TargetTriple>> {
+static MY_TARGET_TRIPLE_STR: &str = "my-target";
+static MY_TARGET_JSON_PATH: &str = "../custom-target/my-target.json";
+
+#[test]
+fn parses_custom_target_cli() {
+    std::env::set_var("CARGO_BUILD_TARGET", "x86_64-unknown-linux-musl");
+    let expected_path = workspace_root()
+        .join(MY_TARGET_JSON_PATH)
+        .canonicalize_utf8()
+        .expect("canonicalization succeeded");
+    let triple = target_triple(Some(MY_TARGET_JSON_PATH), Vec::new())
+        .unwrap()
+        .expect("platform found");
+    assert_eq!(
+        triple.platform.triple_str(),
+        MY_TARGET_TRIPLE_STR,
+        "custom platform name"
+    );
+
+    assert!(triple.platform.is_custom(), "custom platform");
+    assert_eq!(triple.source, TargetTripleSource::CliOption);
+    assert_eq!(
+        triple.location,
+        TargetDefinitionLocation::DirectPath(expected_path)
+    );
+}
+
+#[test]
+fn parses_custom_target_env() {
+    std::env::set_var("CARGO_BUILD_TARGET", MY_TARGET_JSON_PATH);
+    let expected_path = workspace_root()
+        .join(MY_TARGET_JSON_PATH)
+        .canonicalize_utf8()
+        .expect("canonicalization succeeded");
+    let triple = target_triple(None, Vec::new())
+        .unwrap()
+        .expect("platform found");
+    assert_eq!(
+        triple.platform.triple_str(),
+        MY_TARGET_TRIPLE_STR,
+        "custom platform name"
+    );
+
+    assert!(triple.platform.is_custom(), "custom platform");
+    assert_eq!(triple.source, TargetTripleSource::Env);
+    assert_eq!(
+        triple.location,
+        TargetDefinitionLocation::DirectPath(expected_path)
+    );
+}
+
+#[test]
+fn parses_custom_target_cli_from_rust_target_path() {
+    let target_paths = vec![workspace_root().join("../custom-target")];
+    let expected_path = workspace_root()
+        .join(MY_TARGET_JSON_PATH)
+        .canonicalize_utf8()
+        .expect("canonicalization succeeded");
+    let triple = target_triple(Some(MY_TARGET_TRIPLE_STR), target_paths)
+        .unwrap()
+        .expect("platform found");
+    assert_eq!(
+        triple.platform.triple_str(),
+        MY_TARGET_TRIPLE_STR,
+        "custom platform name"
+    );
+
+    assert!(triple.platform.is_custom(), "custom platform");
+    assert_eq!(triple.source, TargetTripleSource::CliOption);
+    assert_eq!(
+        triple.location,
+        TargetDefinitionLocation::RustTargetPath(expected_path)
+    );
+}
+
+#[test]
+fn parses_custom_target_env_from_rust_target_path() {
+    std::env::set_var("CARGO_BUILD_TARGET", MY_TARGET_TRIPLE_STR);
+    let target_paths = vec![workspace_root().join("../custom-target")];
+    let expected_path = workspace_root()
+        .join(MY_TARGET_JSON_PATH)
+        .canonicalize_utf8()
+        .expect("canonicalization succeeded");
+    let triple = target_triple(None, target_paths)
+        .unwrap()
+        .expect("platform found");
+    assert_eq!(
+        triple.platform.triple_str(),
+        MY_TARGET_TRIPLE_STR,
+        "custom platform name"
+    );
+
+    assert!(triple.platform.is_custom(), "custom platform");
+    assert_eq!(triple.source, TargetTripleSource::Env);
+    assert_eq!(
+        triple.location,
+        TargetDefinitionLocation::RustTargetPath(expected_path)
+    );
+}
+
+#[test]
+fn parses_custom_target_cli_heuristic() {
+    // This target is never going to exist.
+    let triple = target_triple(Some("armv5te-unknown-linux-musl"), Vec::new()).unwrap();
+
+    assert_eq!(
+        triple,
+        Some(TargetTriple {
+            platform: platform("armv5te-unknown-linux-musl"),
+            source: TargetTripleSource::CliOption,
+            location: TargetDefinitionLocation::Heuristic,
+        })
+    )
+}
+
+fn target_triple(
+    target_cli_option: Option<&str>,
+    target_paths: Vec<Utf8PathBuf>,
+) -> Result<Option<TargetTriple>> {
     let configs = CargoConfigs::new_with_isolation(
         Vec::<String>::new(),
         &workspace_root(),
         &workspace_root(),
+        target_paths,
     )
     .unwrap();
     let triple = TargetTriple::find(&configs, target_cli_option)?;

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -32,7 +32,7 @@ rand = { version = "0.8.5" }
 serde = { version = "1.0.164", features = ["alloc", "derive"] }
 serde_json = { version = "1.0.97", features = ["unbounded_depth"] }
 similar = { version = "2.2.1", features = ["inline", "unicode"] }
-target-spec = { version = "1.4.0", default-features = false, features = ["summaries"] }
+target-spec = { version = "2.0.1", default-features = false, features = ["custom", "summaries"] }
 tokio = { version = "1.28.2", features = ["io-util", "macros", "process", "rt-multi-thread", "signal", "sync", "time", "tracing"] }
 twox-hash = { version = "1.6.3" }
 uuid = { version = "1.3.4", features = ["v4"] }


### PR DESCRIPTION
Pull in target-spec version 2, which implements support for custom targets.

Note that custom targets are not supported in `platform` overrides, just in `--target`/`CARGO_BUILD_TARGET`/`build.target`.