### PR TITLE
[quick-junit] Add support for test case properties

### DIFF
--- a/quick-junit/src/report.rs
+++ b/quick-junit/src/report.rs
@@ -301,6 +301,9 @@ pub struct TestCase {
 
     /// Other fields that may be set as attributes, such as "classname".
     pub extra: IndexMap<String, String>,
+
+    /// Custom properties set during test execution, e.g. steps.
+    pub properties: Vec<Property>,
 }
 
 impl TestCase {
@@ -316,6 +319,7 @@ impl TestCase {
             system_out: None,
             system_err: None,
             extra: IndexMap::new(),
+            properties: vec![],
         }
     }
 
@@ -367,6 +371,23 @@ impl TestCase {
     /// The output is converted to a string, lossily.
     pub fn set_system_err_lossy(&mut self, system_err: impl AsRef<[u8]>) -> &mut Self {
         self.set_system_err(String::from_utf8_lossy(system_err.as_ref()))
+    }
+
+    /// Adds a property to this TestCase.
+    pub fn add_property(&mut self, property: impl Into<Property>) -> &mut Self {
+        self.properties.push(property.into());
+        self
+    }
+
+    /// Adds several properties to this TestCase.
+    pub fn add_properties(
+        &mut self,
+        properties: impl IntoIterator<Item = impl Into<Property>>,
+    ) -> &mut Self {
+        for property in properties {
+            self.add_property(property);
+        }
+        self
     }
 }
 

--- a/quick-junit/src/serialize.rs
+++ b/quick-junit/src/serialize.rs
@@ -181,6 +181,7 @@ fn serialize_test_case(
         system_out,
         system_err,
         extra,
+        properties,
     } = test_case;
 
     let mut testcase_tag = BytesStart::new(TESTCASE_TAG);
@@ -203,6 +204,14 @@ fn serialize_test_case(
         testcase_tag.push_attribute((k.as_str(), v.as_str()));
     }
     writer.write_event(Event::Start(testcase_tag))?;
+
+    if !properties.is_empty() {
+        serialize_empty_start_tag(PROPERTIES_TAG, writer)?;
+        for property in properties {
+            serialize_property(property, writer)?;
+        }
+        serialize_end_tag(PROPERTIES_TAG, writer)?;
+    }
 
     match status {
         TestCaseStatus::Success { flaky_runs } => {

--- a/quick-junit/tests/fixture_tests.rs
+++ b/quick-junit/tests/fixture_tests.rs
@@ -130,6 +130,11 @@ fn basic_report() -> Report {
     test_case.set_time(Duration::from_millis(156));
     test_suite.add_test_case(test_case);
 
+    let test_case_status = TestCaseStatus::success();
+    let mut test_case = TestCase::new("testcase6", test_case_status);
+    test_case.add_property(Property::new("step", "foobar"));
+    test_suite.add_test_case(test_case);
+
     test_suite.add_property(Property::new("env", "FOOBAR"));
 
     report.add_test_suite(test_suite);

--- a/quick-junit/tests/fixtures/basic_report.xml
+++ b/quick-junit/tests/fixtures/basic_report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="my-test-run" tests="6" failures="2" errors="1" timestamp="2021-04-01T10:52:37.000-08:00" time="42.235">
-    <testsuite name="testsuite0" tests="6" disabled="1" errors="1" failures="2" timestamp="2021-04-01T10:52:39.000-08:00">
+<testsuites name="my-test-run" tests="7" failures="2" errors="1" timestamp="2021-04-01T10:52:37.000-08:00" time="42.235">
+    <testsuite name="testsuite0" tests="7" disabled="1" errors="1" failures="2" timestamp="2021-04-01T10:52:39.000-08:00">
         <properties>
             <property name="env" value="FOOBAR"/>
         </properties>
@@ -35,6 +35,11 @@
                 <stackTrace>retry error stack trace</stackTrace>
                 <system-out>retry error system output</system-out>
             </rerunError>
+        </testcase>
+        <testcase name="testcase6">
+            <properties>
+                <property name="step" value="foobar"/>
+            </properties>
         </testcase>
     </testsuite>
 </testsuites>


### PR DESCRIPTION
Fixes #897

Simple change adding support for test case properties. These properties are used by some systems for metadata like attachments, links, and test steps, so are useful to be able to set.