### PR TITLE
Add flag `--cargo-quiet`

### DIFF
--- a/cargo-nextest/src/cargo_cli.rs
+++ b/cargo-nextest/src/cargo_cli.rs
@@ -82,6 +82,10 @@ pub(crate) struct CargoOptions {
     #[arg(long, value_name = "NAME", group = "cargo-opts")]
     cargo_profile: Option<String>,
 
+    /// Run cargo in quiet mode
+    #[arg(long, group = "cargo-opts")]
+    cargo_quiet: bool,
+
     /// Number of build jobs to run
     #[arg(long, value_name = "JOBS", group = "cargo-opts")]
     build_jobs: Option<String>,
@@ -234,6 +238,9 @@ impl<'a> CargoCli<'a> {
         }
         if let Some(profile) = &options.cargo_profile {
             self.add_args(["--profile", profile]);
+        }
+        if options.cargo_quiet {
+            self.add_arg("--quiet");
         }
         if let Some(build_jobs) = &options.build_jobs {
             self.add_args(["--jobs", build_jobs.as_str()]);


### PR DESCRIPTION
Change:
- Add `--cargo-quiet` flag to `nextest run` to suppress standard build output. Warnings and errors are still printed.

This makes it possible to run it with less noise. LMK if anything is missing.

Does this file need to be updated? Dont know how that is used https://github.com/ggwpez/nextest/blob/71ebdf65fbe24a64382524ae01e1ab57804f111e/site/help-text/list-help.txt#L31