### PR TITLE
[nextest-runner] wrap test events in TestEventKind

### DIFF
--- a/nextest-runner/src/time/stopwatch.rs
+++ b/nextest-runner/src/time/stopwatch.rs
@@ -63,6 +63,10 @@ impl StopwatchStart {
         }
     }
 
+    pub(crate) fn elapsed(&self) -> Duration {
+        self.instant.elapsed() - self.paused_time
+    }
+
     pub(crate) fn end(&self) -> StopwatchEnd {
         StopwatchEnd {
             start_time: self.start_time,

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -13,7 +13,7 @@ use nextest_runner::{
     list::{
         BinaryList, RustBuildMeta, RustTestArtifact, TestExecuteContext, TestList, TestListState,
     },
-    reporter::TestEvent,
+    reporter::TestEventKind,
     reuse_build::PathMapper,
     runner::{
         configure_handle_inheritance, AbortStatus, ExecutionResult, ExecutionStatuses, RunStats,
@@ -416,12 +416,12 @@ pub(crate) fn execute_collect(
     let mut instance_statuses = HashMap::new();
     configure_handle_inheritance(false).expect("configuring handle inheritance on Windows failed");
     let run_stats = runner.execute(|event| {
-        let (test_instance, status) = match event {
-            TestEvent::TestSkipped {
+        let (test_instance, status) = match event.kind {
+            TestEventKind::TestSkipped {
                 test_instance,
                 reason,
             } => (test_instance, InstanceStatus::Skipped(reason)),
-            TestEvent::TestFinished {
+            TestEventKind::TestFinished {
                 test_instance,
                 run_statuses,
                 ..


### PR DESCRIPTION
All test events now also carry a total time elapsed. This will be useful for DTrace support if/when we get to it.