### PR TITLE
[meta] updates for Rust 1.73

### DIFF
--- a/nextest-runner/src/cargo_config/discovery.rs
+++ b/nextest-runner/src/cargo_config/discovery.rs
@@ -120,15 +120,17 @@ impl CargoConfigs {
         //
         // 2 and 3 used to be reversed in older versions of Rust, but this has been fixed as of Rust
         // 1.68 (https://github.com/rust-lang/cargo/pull/11077).
-        let cli_option_iter = self.cli_configs.iter().filter_map(|(source, config)| {
-            matches!(source, CargoConfigSource::CliOption)
-                .then(|| DiscoveredConfig::CliOption { config, source })
-        });
+        let cli_option_iter = self
+            .cli_configs
+            .iter()
+            .filter(|(source, _)| matches!(source, CargoConfigSource::CliOption))
+            .map(|(source, config)| DiscoveredConfig::CliOption { config, source });
 
-        let cli_file_iter = self.cli_configs.iter().filter_map(|(source, config)| {
-            matches!(source, CargoConfigSource::File(_))
-                .then(|| DiscoveredConfig::File { config, source })
-        });
+        let cli_file_iter = self
+            .cli_configs
+            .iter()
+            .filter(|(source, _)| matches!(source, CargoConfigSource::File(_)))
+            .map(|(source, config)| DiscoveredConfig::File { config, source });
 
         let cargo_config_file_iter = self
             .discovered
@@ -222,7 +224,7 @@ fn parse_cli_config(config_str: &str) -> Result<CargoConfig, CargoConfigError> {
                         return Err(CargoConfigError::InvalidCliConfig {
                             config_str: config_str.to_owned(),
                             reason: InvalidCargoCliConfigReason::IncludesNonWhitespaceDecoration,
-                        })?;
+                        });
                     }
                     table = nt;
                 }
@@ -230,14 +232,14 @@ fn parse_cli_config(config_str: &str) -> Result<CargoConfig, CargoConfigError> {
                     return Err(CargoConfigError::InvalidCliConfig {
                         config_str: config_str.to_owned(),
                         reason: InvalidCargoCliConfigReason::SetsValueToInlineTable,
-                    })?;
+                    });
                 }
                 Item::Value(v) => {
                     if non_empty_decor(v.decor()) {
                         return Err(CargoConfigError::InvalidCliConfig {
                             config_str: config_str.to_owned(),
                             reason: InvalidCargoCliConfigReason::IncludesNonWhitespaceDecoration,
-                        })?;
+                        });
                     }
                     got_to_value = true;
                     break;
@@ -246,13 +248,13 @@ fn parse_cli_config(config_str: &str) -> Result<CargoConfig, CargoConfigError> {
                     return Err(CargoConfigError::InvalidCliConfig {
                         config_str: config_str.to_owned(),
                         reason: InvalidCargoCliConfigReason::SetsValueToArrayOfTables,
-                    })?;
+                    });
                 }
                 Item::None => {
                     return Err(CargoConfigError::InvalidCliConfig {
                         config_str: config_str.to_owned(),
                         reason: InvalidCargoCliConfigReason::DoesntProvideValue,
-                    })?;
+                    });
                 }
             }
         }
@@ -262,7 +264,7 @@ fn parse_cli_config(config_str: &str) -> Result<CargoConfig, CargoConfigError> {
         return Err(CargoConfigError::InvalidCliConfig {
             config_str: config_str.to_owned(),
             reason: InvalidCargoCliConfigReason::NotDottedKv,
-        })?;
+        });
     }
 
     let cargo_config: CargoConfig =

--- a/nextest-runner/src/config/nextest_version.rs
+++ b/nextest-runner/src/config/nextest_version.rs
@@ -114,7 +114,7 @@ impl VersionOnlyConfig {
     ) -> Result<VersionOnlyDeserialize, ConfigParseError> {
         let toml_str = std::fs::read_to_string(config_file.as_str()).map_err(|error| {
             ConfigParseError::new(
-                config_file.clone(),
+                config_file,
                 tool,
                 ConfigParseErrorKind::VersionOnlyReadError(error),
             )
@@ -123,14 +123,14 @@ impl VersionOnlyConfig {
         let v: VersionOnlyDeserialize =
             serde_path_to_error::deserialize(toml_de).map_err(|error| {
                 ConfigParseError::new(
-                    config_file.clone(),
+                    config_file,
                     tool,
                     ConfigParseErrorKind::VersionOnlyDeserializeError(Box::new(error)),
                 )
             })?;
         if tool.is_some() && !v.experimental.is_empty() {
             return Err(ConfigParseError::new(
-                config_file.clone(),
+                config_file,
                 tool,
                 ConfigParseErrorKind::ExperimentalFeaturesInToolConfig {
                     features: v.experimental,

--- a/nextest-runner/src/config/scripts.rs
+++ b/nextest-runner/src/config/scripts.rs
@@ -41,12 +41,10 @@ impl<'profile> SetupScripts<'profile> {
     ) -> Self {
         Self::new_with_queries(
             profile,
-            test_list.iter_tests().filter_map(|test| {
-                test.test_info
-                    .filter_match
-                    .is_match()
-                    .then(|| test.to_test_query())
-            }),
+            test_list
+                .iter_tests()
+                .filter(|test| test.test_info.filter_match.is_match())
+                .map(|test| test.to_test_query()),
         )
     }
 

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -1333,9 +1333,8 @@ mod self_update_errors {
 
         let display_versions: Vec<_> = versions
             .iter()
-            .filter_map(|(v, status)| {
-                (v.pre.is_empty() && *status == ReleaseStatus::Active).then(|| v.to_string())
-            })
+            .filter(|(v, status)| v.pre.is_empty() && *status == ReleaseStatus::Active)
+            .map(|(v, _)| v.to_string())
             .take(DISPLAY_COUNT)
             .collect();
         let mut display_str = display_versions.join(", ");

--- a/nextest-runner/src/list/test_list.rs
+++ b/nextest-runner/src/list/test_list.rs
@@ -114,13 +114,14 @@ impl<'g> RustTestArtifact<'g> {
                 match rust_build_meta.non_test_binaries.get(package_id.repr()) {
                     Some(binaries) => binaries
                         .iter()
-                        .filter_map(|binary| {
+                        .filter(|binary| {
                             // Only expose BIN_EXE non-test files.
-                            (binary.kind == RustNonTestBinaryKind::BIN_EXE).then(|| {
-                                // Convert relative paths to absolute ones by joining with the target directory.
-                                let abs_path = rust_build_meta.target_directory.join(&binary.path);
-                                (binary.name.clone(), abs_path)
-                            })
+                            binary.kind == RustNonTestBinaryKind::BIN_EXE
+                        })
+                        .map(|binary| {
+                            // Convert relative paths to absolute ones by joining with the target directory.
+                            let abs_path = rust_build_meta.target_directory.join(&binary.path);
+                            (binary.name.clone(), abs_path)
                         })
                         .collect(),
                     None => BTreeSet::new(),

--- a/nextest-runner/src/reporter/aggregator.rs
+++ b/nextest-runner/src/reporter/aggregator.rs
@@ -259,7 +259,7 @@ fn to_datetime(system_time: SystemTime) -> DateTime<FixedOffset> {
 
 // This regex works for the default panic handler for Rust -- other panic handlers may not work,
 // which is why this is heuristic.
-static PANICKED_AT_REGEX_STR: &str = "^thread '([^']+)' panicked at '";
+static PANICKED_AT_REGEX_STR: &str = "^thread '([^']+)' panicked at ";
 static PANICKED_AT_REGEX: Lazy<Regex> = Lazy::new(|| {
     let mut builder = RegexBuilder::new(PANICKED_AT_REGEX_STR);
     builder.multi_line(true);

--- a/nextest-runner/src/update.rs
+++ b/nextest-runner/src/update.rs
@@ -126,7 +126,8 @@ impl NextestReleases {
                 let known_triples = version_data
                     .locations
                     .iter()
-                    .filter_map(|data| (data.format == TAR_GZ_SUFFIX).then(|| data.target.clone()))
+                    .filter(|data| data.format == TAR_GZ_SUFFIX)
+                    .map(|data| data.target.clone())
                     .collect();
                 UpdateError::NoTargetData {
                     version: version.clone(),


### PR DESCRIPTION
Consists of a few clippy warnings, and also the ability to parse the new test panic messages produced by Rust 1.73.