### PR TITLE
Strip ANSI escapes from JUnit output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,6 +1995,7 @@ dependencies = [
  "nextest-workspace-hack",
  "owo-colors",
  "quick-xml 0.30.0",
+ "strip-ansi-escapes",
  "thiserror",
  "uuid",
 ]

--- a/quick-junit/Cargo.toml
+++ b/quick-junit/Cargo.toml
@@ -18,6 +18,7 @@ quick-xml = "0.30.0"
 thiserror = "1.0.50"
 uuid = "1.5.0"
 nextest-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+strip-ansi-escapes = "0.2.0"
 
 [dev-dependencies]
 goldenfile = "1.5.2"

--- a/quick-junit/src/report.rs
+++ b/quick-junit/src/report.rs
@@ -689,9 +689,10 @@ pub struct Output {
 }
 
 impl Output {
-    /// Creates a new output, removing any non-printable characters from it.
+    /// Creates a new output, removing any ANSI escapes and non-printable characters from it.
     pub fn new(output: impl AsRef<str>) -> Self {
         let output = output.as_ref();
+        let output = strip_ansi_escapes::strip_str(output);
         let output = output
             .replace(
                 |c| matches!(c, '\x00'..='\x08' | '\x0b' | '\x0c' | '\x0e'..='\x1f'),

--- a/quick-junit/tests/fixtures/basic_report.xml
+++ b/quick-junit/tests/fixtures/basic_report.xml
@@ -24,7 +24,7 @@
             <flakyError type="flaky error type">flaky error description
                 <stackTrace>flaky stack trace</stackTrace>
                 <system-out>flaky system output</system-out>
-                <system-err>flaky system error with [34mANSI escape codes[39m</system-err>
+                <system-err>flaky system error with ANSI escape codes</system-err>
             </flakyError>
         </testcase>
         <testcase name="testcase5" time="0.156">


### PR DESCRIPTION
Previously the escape character itself was removed, but the rest of the escape sequence was left in place, resulting in useless and seemingly random characters in the output. (Unless some tools expect this and know how to handle it, but that isn't the case for the tools I use.)

There was already a test that asserted this. I assumed the goal of that test was just to validate that illegal characters (like the escape character) didn't make it into the output, and I've adjusted it to verify that the entire sequence is stripped out.
