### PR TITLE
Use bare minimum chrono features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,6 +1735,7 @@ version = "0.1.0"
 dependencies = [
  "backtrace",
  "cc",
+ "chrono",
  "clap",
  "clap_builder",
  "console",

--- a/quick-junit/Cargo.toml
+++ b/quick-junit/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 rust-version = "1.66"
 
 [dependencies]
-chrono = "0.4.31"
+chrono = { version = "0.4.31", default-features = false, features = ["std"] }
 indexmap = "2.0.2"
 quick-xml = "0.31.0"
 thiserror = "1.0.50"

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -15,6 +15,7 @@ publish = false
 ### BEGIN HAKARI SECTION
 [dependencies]
 backtrace = { version = "0.3.69", features = ["gimli-symbolize"] }
+chrono = { version = "0.4.31" }
 clap = { version = "4.4.7", features = ["derive", "env"] }
 clap_builder = { version = "4.4.7", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
 console = { version = "0.15.7" }


### PR DESCRIPTION
Hey, we are using quick-junit in Deno. I'm trying to get rid of dynamic library that cost startup time. It turns out `chrono`'s "clock" features pulls in `iana-time-zone` which pulls in the `core-foundation` on macOS. 

This PR just disables the default features (including "clock") in chrono, no functional changes.