### PR TITLE
[nextest-filtering] better error reporting for invalid escapes

### DIFF
--- a/nextest-filtering/src/errors.rs
+++ b/nextest-filtering/src/errors.rs
@@ -69,6 +69,10 @@ pub enum ParseSingleError {
     #[error("expected close parenthesis")]
     ExpectedCloseParenthesis(#[label("missing `)`")] SourceSpan),
 
+    /// An invalid escape character was found.
+    #[error("invalid escape character")]
+    InvalidEscapeCharacter(#[label("invalid escape character")] SourceSpan),
+
     /// An expression was expected in this position but not found.
     #[error("expected expression")]
     ExpectedExpr(#[label("missing expression")] SourceSpan),


### PR DESCRIPTION
Previously we'd report something like

```
  error: expected close parenthesis
   ╭────
 1 │ package(nexte\$)
   ·              ▲
   ·              ╰── missing `)`
   ╰────

  error: expected end of expression
   ╭────
 1 │ package(nexte\$)
   ·              ─┬─
   ·               ╰── unparsed input
   ╰────
```

Now, we report:

```
  error: invalid escape character
   ╭────
 1 │ package(nexte\$)
   ·              ─┬
   ·               ╰── invalid escape character
   ╰────
```