### PR TITLE
[nextest-runner] also expose build script output dirs

### DIFF
--- a/fixtures/nextest-tests/Cargo.lock
+++ b/fixtures/nextest-tests/Cargo.lock
@@ -31,3 +31,7 @@ name = "uuid"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
+
+[[package]]
+name = "with-build-script"
+version = "0.1.0"

--- a/fixtures/nextest-tests/Cargo.toml
+++ b/fixtures/nextest-tests/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "cdylib/cdylib-link",
     "derive",
     "dylib-test",
+    "with-build-script",
 ]
 
 [dependencies]

--- a/fixtures/nextest-tests/cdylib/cdylib-link/build.rs
+++ b/fixtures/nextest-tests/cdylib/cdylib-link/build.rs
@@ -9,6 +9,7 @@ use std::{
 fn main() {
     // Set the target directory to be within the output directory.
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR is valid"));
+
     std::env::set_var("CARGO_TARGET_DIR", out_dir.join("target"));
 
     let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());

--- a/fixtures/nextest-tests/cdylib/cdylib-link/src/lib.rs
+++ b/fixtures/nextest-tests/cdylib/cdylib-link/src/lib.rs
@@ -8,4 +8,5 @@ extern "C" {
 #[test]
 fn test_multiply_two() {
     assert_eq!(unsafe { multiply_two(3, 3) }, 9);
+
 }

--- a/fixtures/nextest-tests/tests/basic.rs
+++ b/fixtures/nextest-tests/tests/basic.rs
@@ -128,6 +128,7 @@ fn test_cargo_env_vars() {
     for (k, v) in std::env::vars() {
         println!("{} = {}", k, v);
     }
+
     assert_eq!(
         std::env::var("NEXTEST").as_deref(),
         Ok("1"),
@@ -244,6 +245,19 @@ fn test_cargo_env_vars() {
             Ok("test-PASSED-value-set-by-environment"),
         );
     }
+
+    // Since this test doesn't have a build script, assert that OUT_DIR isn't present at either
+    // compile time or runtime.
+    assert_eq!(
+        option_env!("OUT_DIR"),
+        None,
+        "OUT_DIR not present at compile time"
+    );
+    assert_eq!(
+        std::env::var("OUT_DIR"),
+        Err(std::env::VarError::NotPresent),
+        "OUT_DIR not present at runtime"
+    );
 
     assert_eq!(std::env::var("MY_ENV_VAR").as_deref(), Ok("my-env-var"));
 }

--- a/fixtures/nextest-tests/with-build-script/Cargo.toml
+++ b/fixtures/nextest-tests/with-build-script/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "with-build-script"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/fixtures/nextest-tests/with-build-script/build.rs
+++ b/fixtures/nextest-tests/with-build-script/build.rs
@@ -1,0 +1,12 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::path::PathBuf;
+
+fn main() {
+    // Set the target directory to be within the output directory.
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR is valid"));
+
+    // The presence of this file is checked by a test.
+    std::fs::write(out_dir.join("this-is-a-test-file"), "test-contents").unwrap();
+}

--- a/fixtures/nextest-tests/with-build-script/src/lib.rs
+++ b/fixtures/nextest-tests/with-build-script/src/lib.rs
@@ -1,0 +1,15 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_out_dir_present() {
+        // Since this package has a build script, ensure that OUT_DIR is correct by the presence of
+        // the file that the script writes.
+        let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR is valid");
+        let path = std::path::Path::new(&out_dir).join("this-is-a-test-file");
+        let contents = std::fs::read(&path).expect("test file exists in OUT_DIR");
+        assert_eq!(contents, b"test-contents");
+    }
+}

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-2.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-2.snap
@@ -46,3 +46,6 @@ group: @global
           tests::example_success
       nextest-tests::example/other:
           tests::other_example_success
+      with-build-script:
+          tests::test_out_dir_present
+

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-4.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-4.snap
@@ -47,3 +47,6 @@ group: @global
           tests::example_success
       nextest-tests::example/other:
           tests::other_example_success
+      with-build-script:
+          tests::test_out_dir_present
+

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-6.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-6.snap
@@ -48,3 +48,6 @@ group: @global
           tests::example_success
       nextest-tests::example/other:
           tests::other_example_success
+      with-build-script:
+          tests::test_out_dir_present
+

--- a/nextest-metadata/src/test_list.rs
+++ b/nextest-metadata/src/test_list.rs
@@ -473,6 +473,13 @@ pub struct RustBuildMetaSummary {
     /// Information about non-test binaries, keyed by package ID.
     pub non_test_binaries: BTreeMap<String, BTreeSet<RustNonTestBinarySummary>>,
 
+    /// Build script output directory, relative to the target directory and keyed by package ID.
+    /// Only present for workspace packages that have build scripts.
+    ///
+    /// Added in cargo-nextest 0.9.65.
+    #[serde(default)]
+    pub build_script_out_dirs: BTreeMap<String, Utf8PathBuf>,
+
     /// Linked paths, relative to the target directory.
     pub linked_paths: BTreeSet<Utf8PathBuf>,
 
@@ -694,6 +701,7 @@ mod tests {
         target_directory: "/foo".into(),
         base_output_directories: BTreeSet::new(),
         non_test_binaries: BTreeMap::new(),
+        build_script_out_dirs: BTreeMap::new(),
         linked_paths: BTreeSet::new(),
         target_platform: None,
         target_platforms: vec![],
@@ -708,6 +716,7 @@ mod tests {
         target_directory: "/foo".into(),
         base_output_directories: BTreeSet::new(),
         non_test_binaries: BTreeMap::new(),
+        build_script_out_dirs: BTreeMap::new(),
         linked_paths: BTreeSet::new(),
         target_platform: Some("x86_64-unknown-linux-gnu".to_owned()),
         target_platforms: vec![],

--- a/nextest-runner/src/config/scripts.rs
+++ b/nextest-runner/src/config/scripts.rs
@@ -151,6 +151,7 @@ impl<'profile> SetupScript<'profile> {
         test_list: &TestList<'_>,
     ) -> Result<SetupScriptCommand, SetupScriptError> {
         let lctx = LocalExecuteContext {
+            rust_build_meta: test_list.rust_build_meta(),
             double_spawn,
             dylib_path: test_list.updated_dylib_path(),
             env: test_list.cargo_env(),

--- a/nextest-runner/src/helpers.rs
+++ b/nextest-runner/src/helpers.rs
@@ -12,6 +12,56 @@ use std::{
     time::Duration,
 };
 
+pub(crate) mod plural {
+    pub(crate) fn setup_scripts_str(count: usize) -> &'static str {
+        if count == 1 {
+            "setup script"
+        } else {
+            "setup scripts"
+        }
+    }
+
+    pub(crate) fn tests_str(count: usize) -> &'static str {
+        if count == 1 {
+            "test"
+        } else {
+            "tests"
+        }
+    }
+
+    pub(crate) fn binaries_str(count: usize) -> &'static str {
+        if count == 1 {
+            "binary"
+        } else {
+            "binaries"
+        }
+    }
+
+    pub(crate) fn paths_str(count: usize) -> &'static str {
+        if count == 1 {
+            "path"
+        } else {
+            "paths"
+        }
+    }
+
+    pub(crate) fn files_str(count: usize) -> &'static str {
+        if count == 1 {
+            "file"
+        } else {
+            "files"
+        }
+    }
+
+    pub(crate) fn directories_str(count: usize) -> &'static str {
+        if count == 1 {
+            "directory"
+        } else {
+            "directories"
+        }
+    }
+}
+
 /// Write out a test name.
 pub(crate) fn write_test_name(
     name: &str,
@@ -117,6 +167,13 @@ pub(crate) fn convert_rel_path_to_main_sep(rel_path: &Utf8Path) -> Utf8PathBuf {
 #[cfg(not(windows))]
 pub(crate) fn convert_rel_path_to_main_sep(rel_path: &Utf8Path) -> Utf8PathBuf {
     rel_path.to_path_buf()
+}
+
+/// Join relative paths using forward slashes.
+pub(crate) fn rel_path_join(rel_path: &Utf8Path, path: &Utf8Path) -> Utf8PathBuf {
+    assert!(rel_path.is_relative(), "rel_path {rel_path} is relative");
+    assert!(path.is_relative(), "path {path} is relative",);
+    format!("{}/{}", rel_path, path).into()
 }
 
 pub(crate) fn format_duration(duration: Duration) -> String {

--- a/nextest-runner/src/list/rust_build_meta.rs
+++ b/nextest-runner/src/list/rust_build_meta.rs
@@ -29,6 +29,10 @@ pub struct RustBuildMeta<State> {
     /// Information about non-test executables, keyed by package ID.
     pub non_test_binaries: BTreeMap<String, BTreeSet<RustNonTestBinarySummary>>,
 
+    /// Build script output directory, relative to the target directory and keyed by package ID.
+    /// Only present for workspace packages that have build scripts.
+    pub build_script_out_dirs: BTreeMap<String, Utf8PathBuf>,
+
     /// A list of linked paths, relative to the target directory. These directories are
     /// added to the dynamic library path.
     ///
@@ -54,6 +58,7 @@ impl RustBuildMeta<BinaryListState> {
             target_directory: target_directory.into(),
             base_output_directories: BTreeSet::new(),
             non_test_binaries: BTreeMap::new(),
+            build_script_out_dirs: BTreeMap::new(),
             linked_paths: BTreeMap::new(),
             state: PhantomData,
             target_triple,
@@ -70,6 +75,7 @@ impl RustBuildMeta<BinaryListState> {
             // Since these are relative paths, they don't need to be mapped.
             base_output_directories: self.base_output_directories.clone(),
             non_test_binaries: self.non_test_binaries.clone(),
+            build_script_out_dirs: self.build_script_out_dirs.clone(),
             linked_paths: self.linked_paths.clone(),
             state: PhantomData,
             target_triple: self.target_triple.clone(),
@@ -85,6 +91,7 @@ impl RustBuildMeta<TestListState> {
             target_directory: Utf8PathBuf::new(),
             base_output_directories: BTreeSet::new(),
             non_test_binaries: BTreeMap::new(),
+            build_script_out_dirs: BTreeMap::new(),
             linked_paths: BTreeMap::new(),
             state: PhantomData,
             target_triple: None,
@@ -142,6 +149,7 @@ impl<State> RustBuildMeta<State> {
         Ok(Self {
             target_directory: summary.target_directory,
             base_output_directories: summary.base_output_directories,
+            build_script_out_dirs: summary.build_script_out_dirs,
             non_test_binaries: summary.non_test_binaries,
             linked_paths: summary
                 .linked_paths
@@ -159,6 +167,7 @@ impl<State> RustBuildMeta<State> {
             target_directory: self.target_directory.clone(),
             base_output_directories: self.base_output_directories.clone(),
             non_test_binaries: self.non_test_binaries.clone(),
+            build_script_out_dirs: self.build_script_out_dirs.clone(),
             linked_paths: self.linked_paths.keys().cloned().collect(),
             target_platform: self
                 .target_triple

--- a/nextest-runner/src/list/test_list.rs
+++ b/nextest-runner/src/list/test_list.rs
@@ -222,6 +222,7 @@ impl<'g> TestList<'g> {
             updated_dylib_path.to_string_lossy(),
         );
         let lctx = LocalExecuteContext {
+            rust_build_meta: &rust_build_meta,
             double_spawn: ctx.double_spawn,
             dylib_path: &updated_dylib_path,
             env: &env,
@@ -934,6 +935,7 @@ impl<'a> TestInstance<'a> {
         }
 
         let lctx = LocalExecuteContext {
+            rust_build_meta: &test_list.rust_build_meta,
             double_spawn: ctx.double_spawn,
             dylib_path: test_list.updated_dylib_path(),
             env: &test_list.env,
@@ -1143,6 +1145,7 @@ mod tests {
                 "target-directory": "/fake",
                 "base-output-directories": [],
                 "non-test-binaries": {},
+                "build-script-out-dirs": {},
                 "linked-paths": [],
                 "target-platforms": [
                   {

--- a/nextest-runner/src/reporter.rs
+++ b/nextest-runner/src/reporter.rs
@@ -9,7 +9,7 @@ mod aggregator;
 use crate::{
     config::{NextestProfile, ScriptId},
     errors::WriteEventError,
-    helpers::write_test_name,
+    helpers::{plural, write_test_name},
     list::{TestInstance, TestList},
     reporter::aggregator::EventAggregator,
     runner::{
@@ -582,8 +582,8 @@ impl<'a> TestReporterImpl<'a> {
 
                 let count_style = self.styles.count;
 
-                let tests_str = tests_str(test_list.run_count());
-                let binaries_str = binaries_str(test_list.binary_count());
+                let tests_str = plural::tests_str(test_list.run_count());
+                let binaries_str = plural::binaries_str(test_list.binary_count());
 
                 write!(
                     writer,
@@ -850,14 +850,14 @@ impl<'a> TestReporterImpl<'a> {
 
                 // At the moment, we can have either setup scripts or tests running, but not both.
                 if *setup_scripts_running > 0 {
-                    let s = setup_scripts_str(*setup_scripts_running);
+                    let s = plural::setup_scripts_str(*setup_scripts_running);
                     write!(
                         writer,
                         ": {} {s} still running",
                         setup_scripts_running.style(self.styles.count),
                     )?;
                 } else if *running > 0 {
-                    let tests_str = tests_str(*running);
+                    let tests_str = plural::tests_str(*running);
                     write!(
                         writer,
                         ": {} {tests_str} still running",
@@ -879,14 +879,14 @@ impl<'a> TestReporterImpl<'a> {
 
                 // At the moment, we can have either setup scripts or tests running, but not both.
                 if *setup_scripts_running > 0 {
-                    let s = setup_scripts_str(*setup_scripts_running);
+                    let s = plural::setup_scripts_str(*setup_scripts_running);
                     write!(
                         writer,
                         ": {} {s} running",
                         setup_scripts_running.style(self.styles.count),
                     )?;
                 } else if *running > 0 {
-                    let tests_str = tests_str(*running);
+                    let tests_str = plural::tests_str(*running);
                     write!(
                         writer,
                         ": {} {tests_str} running",
@@ -908,14 +908,14 @@ impl<'a> TestReporterImpl<'a> {
 
                 // At the moment, we can have either setup scripts or tests running, but not both.
                 if *setup_scripts_running > 0 {
-                    let s = setup_scripts_str(*setup_scripts_running);
+                    let s = plural::setup_scripts_str(*setup_scripts_running);
                     write!(
                         writer,
                         ": {} {s} running",
                         setup_scripts_running.style(self.styles.count),
                     )?;
                 } else if *running > 0 {
-                    let tests_str = tests_str(*running);
+                    let tests_str = plural::tests_str(*running);
                     write!(
                         writer,
                         ": {} {tests_str} running",
@@ -1412,30 +1412,6 @@ impl<'a> TestReporterImpl<'a> {
 
     fn failure_output(&self, test_setting: TestOutputDisplay) -> TestOutputDisplay {
         self.force_failure_output.unwrap_or(test_setting)
-    }
-}
-
-fn setup_scripts_str(count: usize) -> &'static str {
-    if count == 1 {
-        "setup script"
-    } else {
-        "setup scripts"
-    }
-}
-
-fn tests_str(count: usize) -> &'static str {
-    if count == 1 {
-        "test"
-    } else {
-        "tests"
-    }
-}
-
-fn binaries_str(count: usize) -> &'static str {
-    if count == 1 {
-        "binary"
-    } else {
-        "binaries"
     }
 }
 

--- a/nextest-runner/src/reuse_build/unarchiver.rs
+++ b/nextest-runner/src/reuse_build/unarchiver.rs
@@ -126,12 +126,15 @@ impl<'a> Unarchiver<'a> {
                 let test_binary_count = this_binary_list.rust_binaries.len();
                 let non_test_binary_count =
                     this_binary_list.rust_build_meta.non_test_binaries.len();
+                let build_script_out_dir_count =
+                    this_binary_list.rust_build_meta.build_script_out_dirs.len();
                 let linked_path_count = this_binary_list.rust_build_meta.linked_paths.len();
 
                 // Report begin extraction.
                 callback(ArchiveEvent::ExtractStarted {
                     test_binary_count,
                     non_test_binary_count,
+                    build_script_out_dir_count,
                     linked_path_count,
                     dest_dir: &dest_dir,
                 })

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -167,7 +167,11 @@ pub(crate) static EXPECTED_TESTS: Lazy<BTreeMap<RustBinaryId, Vec<TestFixture>>>
             "dylib-test".into() => vec![],
             "cdylib-example".into() => vec![
                 TestFixture { name: "tests::test_multiply_two_cdylib", status: FixtureStatus::Pass },
-            ]
+            ],
+            // Build script tests
+            "with-build-script".into() => vec![
+                TestFixture { name: "tests::test_out_dir_present", status: FixtureStatus::Pass },
+            ],
         }
     },
 );
@@ -238,6 +242,10 @@ pub(crate) fn set_env_vars() {
         "__NEXTEST_TESTING_EXTRA_CONFIG_OVERRIDE_FORCE_FALSE",
         "test-PASSED-value-set-by-environment",
     );
+
+    // Remove OUT_DIR from the environment, as it interferes with tests (some of them expect that
+    // OUT_DIR isn't set.)
+    std::env::remove_var("OUT_DIR");
 }
 
 pub(crate) fn workspace_root() -> Utf8PathBuf {

--- a/site/src/CHANGELOG.md
+++ b/site/src/CHANGELOG.md
@@ -3,6 +3,29 @@
 This page documents new features and bugfixes for cargo-nextest. Please see the [stability
 policy](book/stability.md) for how versioning works with cargo-nextest.
 
+## Unreleased
+
+### Added
+
+Improvements to [build script `OUT_DIR`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script)
+support:
+
+- Matching the behavior of `cargo test`, nextest now sets the `OUT_DIR` environment variable at
+  runtime if there's a corresponding build script.
+
+- While [creating archives](https://nexte.st/book/reusing-builds), nextest now archives `OUT_DIR`s if:
+
+  - The build script is for a crate in the workspace, and
+  - There's at least one test binary for that crate.
+
+  This is so that the `OUT_DIR` environment variable continues to be relevant for test runs out of
+  archives.
+
+  Currently, `OUT_DIR`s are only archived one level deep to avoid bloating archives too much. In the
+  future, we may add configuration to archive more or less of the output directory. If you have a
+  use case that would benefit from this, please [file an
+  issue](https://github.com/nextest-rs/nextest/issues/new).
+
 ## [0.9.64] - 2023-12-03
 
 ### Added


### PR DESCRIPTION
- Set `OUT_DIR`, similar to what Cargo does.
- Archive build script output dirs to one level for workspace packages. We may have to add configuration to allow more to be nested in the future, but this should start off as being conservative.

Closes #1140.