### PR TITLE
Fix missing license files in published crates

### DIFF
--- a/cargo-nextest/LICENSE-APACHE
+++ b/cargo-nextest/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/cargo-nextest/LICENSE-MIT
+++ b/cargo-nextest/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/nextest-filtering/LICENSE-APACHE
+++ b/nextest-filtering/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/nextest-filtering/LICENSE-MIT
+++ b/nextest-filtering/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/nextest-metadata/LICENSE-APACHE
+++ b/nextest-metadata/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/nextest-metadata/LICENSE-MIT
+++ b/nextest-metadata/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/nextest-runner/LICENSE-APACHE
+++ b/nextest-runner/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/nextest-runner/LICENSE-MIT
+++ b/nextest-runner/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/quick-junit/LICENSE-APACHE
+++ b/quick-junit/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/quick-junit/LICENSE-MIT
+++ b/quick-junit/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
For each source directory with a `Cargo.toml` corresponding to a published crate, add symlinks to the top-level license files.

These are: `cargo-nextest`, `nextest-filtering`, `nextest-metadata`, `nextest-runner`, and `quick-junit`.

Fixes #1149.