### PR TITLE
[nextest-filering] Remove reliance on Incomplete

### DIFF
--- a/nextest-filtering/src/parsing.rs
+++ b/nextest-filtering/src/parsing.rs
@@ -22,7 +22,6 @@ use nom::{
     combinator::{eof, map, peek, recognize, value, verify},
     multi::{fold_many0, many0},
     sequence::{delimited, pair, preceded, terminated},
-    Slice,
 };
 use nom_tracable::tracable_parser;
 use std::{cell::RefCell, fmt};
@@ -333,11 +332,6 @@ fn parse_matcher_text(input: Span) -> IResult<Option<String>> {
     )(input.clone())
     {
         Ok((i, res)) => (i, res.flatten()),
-        Err(nom::Err::Incomplete(_)) => {
-            let i = input.slice(input.fragment().len()..);
-            // No need for error reporting, missing closing ')' will be detected after
-            (i, None)
-        }
         Err(_) => unreachable!(),
     };
 

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -7,8 +7,8 @@ use super::{expect_n, IResult, Span, SpanLength};
 use crate::errors::ParseSingleError;
 use nom::{
     branch::alt,
-    bytes::streaming::{is_not, take_while_m_n},
-    character::streaming::char,
+    bytes::complete::{is_not, take_while_m_n},
+    character::complete::char,
     combinator::{map, map_opt, map_res, value, verify},
     multi::fold_many0,
     sequence::{delimited, preceded},
@@ -128,8 +128,6 @@ fn parse_fragment(input: Span) -> IResult<Option<StringFragment<'_>>> {
 /// Construct a string by consuming the input until the next unescaped ) or ,.
 ///
 /// Returns None if the string isn't valid.
-///
-/// Returns Err(Incomplete(1)) if an ending delimiter ) or , is not found.
 #[tracable_parser]
 pub(super) fn parse_string(input: Span) -> IResult<Option<String>> {
     fold_many0(


### PR DESCRIPTION
Incomplete specifically means that there isn't enough data to continue processing.
Its a bit of a hack to reuse this for error recovery. This will no longer work if/when moving to `winnow`.

At least judging by the tests, nothing fails when removing this so its good enough?