### PR TITLE
Fix default-config.toml comment on `retry` semantics

### DIFF
--- a/nextest-runner/default-config.toml
+++ b/nextest-runner/default-config.toml
@@ -11,7 +11,7 @@ dir = "target/nextest"
 [profile.default]
 # "retries" defines the number of times a test should be retried. If set to a
 # non-zero value, tests that succeed on a subsequent attempt will be marked as
-# non-flaky. Can be overridden through the `--retries` option.
+# flaky. Can be overridden through the `--retries` option.
 # Examples
 # * retries = 3
 # * retries = { backoff = "fixed", count = 2, delay = "1s" }


### PR DESCRIPTION
Did I understand wrong that after a retry if the test succeeds is marked as flakey?

If so, should the text in the default-config.toml be as suggested by this PR?