### PR TITLE
[nextest-filtering] Replace `nom` parser with `winnow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -149,7 +149,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -476,7 +476,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -665,7 +665,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -973,7 +973,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -1553,7 +1553,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -1643,7 +1643,7 @@ dependencies = [
  "test-strategy",
  "thiserror",
  "twox-hash",
- "winnow 0.4.11",
+ "winnow",
 ]
 
 [[package]]
@@ -1773,7 +1773,7 @@ dependencies = [
  "serde",
  "serde_json",
  "similar",
- "syn 2.0.48",
+ "syn",
  "tokio",
  "twox-hash",
  "uuid",
@@ -1867,7 +1867,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -1955,7 +1955,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -2063,7 +2063,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -2481,7 +2481,7 @@ checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -2707,7 +2707,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -2718,7 +2718,7 @@ checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -2753,17 +2753,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b6c2cb240ab5dd21ed4906895ee23fe5a48acdbd15a3ce388e7b62a9b66baf7"
 dependencies = [
  "is-terminal",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
 ]
 
 [[package]]
@@ -2887,7 +2876,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -2898,7 +2887,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
  "test-case-core",
 ]
 
@@ -2911,7 +2900,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -2942,7 +2931,7 @@ checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -3007,7 +2996,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -3096,7 +3085,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.5.28",
+ "winnow",
 ]
 
 [[package]]
@@ -3177,7 +3166,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]
@@ -3394,7 +3383,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -3428,7 +3417,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3711,18 +3700,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.4.11"
+version = "0.5.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "656953b22bcbfb1ec8179d60734981d1904494ecc91f8a3f0ee5c7389bb8eb4b"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.5.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c830786f7720c2fd27a1a0e27a709dbd3c4d009b56d098fc742d4f4eab91fe2"
+checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
 dependencies = [
  "memchr",
 ]
@@ -3786,7 +3766,7 @@ checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,12 +320,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
-name = "bytecount"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1641,9 +1635,6 @@ dependencies = [
  "miette",
  "nextest-metadata",
  "nextest-workspace-hack",
- "nom",
- "nom-tracable",
- "nom_locate",
  "proptest",
  "recursion",
  "regex",
@@ -1652,6 +1643,7 @@ dependencies = [
  "test-strategy",
  "thiserror",
  "twox-hash",
+ "winnow 0.3.8",
 ]
 
 [[package]]
@@ -1809,38 +1801,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "nom-tracable"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a39d3ec4e5bc9816ca540bd6b1e4885c0275536eb3293d317d984bb17f9a294"
-dependencies = [
- "nom",
- "nom-tracable-macros",
- "nom_locate",
-]
-
-[[package]]
-name = "nom-tracable-macros"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9c68f5316254dae193b3ce083f6caf19ae1a58471e6585e89f0796b9e5bdf4a"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "nom_locate"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e3c83c053b0713da60c5b8de47fe8e494fe3ece5267b2f23090a07a053ba8f3"
-dependencies = [
- "bytecount",
- "memchr",
- "nom",
 ]
 
 [[package]]
@@ -3136,7 +3096,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.28",
 ]
 
 [[package]]
@@ -3748,6 +3708,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "winnow"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da01e24d23aeb852fb05609f2701ce4da9f73d58857239ed3853667cf178f204"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1643,7 +1643,7 @@ dependencies = [
  "test-strategy",
  "thiserror",
  "twox-hash",
- "winnow 0.3.8",
+ "winnow 0.4.11",
 ]
 
 [[package]]
@@ -3711,9 +3711,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.3.8"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da01e24d23aeb852fb05609f2701ce4da9f73d58857239ed3853667cf178f204"
+checksum = "656953b22bcbfb1ec8179d60734981d1904494ecc91f8a3f0ee5c7389bb8eb4b"
 dependencies = [
  "memchr",
 ]

--- a/nextest-filtering/Cargo.toml
+++ b/nextest-filtering/Cargo.toml
@@ -38,7 +38,7 @@ proptest = { version = "1.4.0", optional = true }
 test-strategy = { version = "0.3.1", optional = true }
 twox-hash = { version = "1.6.3", optional = true }
 nextest-workspace-hack.workspace = true
-winnow = "0.4.11"
+winnow = "0.5.34"
 
 [dev-dependencies]
 clap = { version = "4.4.14", features = ["derive"] }

--- a/nextest-filtering/Cargo.toml
+++ b/nextest-filtering/Cargo.toml
@@ -38,7 +38,7 @@ proptest = { version = "1.4.0", optional = true }
 test-strategy = { version = "0.3.1", optional = true }
 twox-hash = { version = "1.6.3", optional = true }
 nextest-workspace-hack.workspace = true
-winnow = "0.3.8"
+winnow = "0.4.11"
 
 [dev-dependencies]
 clap = { version = "4.4.14", features = ["derive"] }

--- a/nextest-filtering/Cargo.toml
+++ b/nextest-filtering/Cargo.toml
@@ -29,9 +29,6 @@ internal-testing = ["dep:proptest", "dep:test-strategy", "dep:twox-hash"]
 globset.workspace = true
 guppy = "0.17.4"
 miette = "5.10.0"
-nom = "7.1.3"
-nom-tracable = "0.9.1"
-nom_locate = "4.2.0"
 recursion = "0.5.1"
 regex = "1.10.2"
 regex-syntax = "0.8.2"
@@ -41,6 +38,7 @@ proptest = { version = "1.4.0", optional = true }
 test-strategy = { version = "0.3.1", optional = true }
 twox-hash = { version = "1.6.3", optional = true }
 nextest-workspace-hack.workspace = true
+winnow = "0.3.8"
 
 [dev-dependencies]
 clap = { version = "4.4.14", features = ["derive"] }

--- a/nextest-filtering/src/errors.rs
+++ b/nextest-filtering/src/errors.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use miette::{Diagnostic, SourceSpan};
-use nom_tracable::TracableInfo;
 use std::cell::RefCell;
 use thiserror::Error;
 
@@ -155,33 +154,15 @@ pub enum GlobConstructError {
 pub(crate) struct State<'a> {
     // A `RefCell` is required here because the state must implement `Clone` to work with nom.
     errors: &'a RefCell<Vec<ParseSingleError>>,
-    tracable_info: TracableInfo,
 }
 
 impl<'a> State<'a> {
     pub fn new(errors: &'a RefCell<Vec<ParseSingleError>>) -> Self {
-        let tracable_info = nom_tracable::TracableInfo::new()
-            .forward(true)
-            .backward(true);
-        Self {
-            errors,
-            tracable_info,
-        }
+        Self { errors }
     }
 
     pub fn report_error(&self, error: ParseSingleError) {
         self.errors.borrow_mut().push(error);
-    }
-}
-
-impl<'a> nom_tracable::HasTracableInfo for State<'a> {
-    fn get_tracable_info(&self) -> TracableInfo {
-        self.tracable_info.get_tracable_info()
-    }
-
-    fn set_tracable_info(mut self, info: TracableInfo) -> Self {
-        self.tracable_info = self.tracable_info.set_tracable_info(info);
-        self
     }
 }
 

--- a/nextest-filtering/src/errors.rs
+++ b/nextest-filtering/src/errors.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use miette::{Diagnostic, SourceSpan};
-use std::cell::RefCell;
 use thiserror::Error;
 
 /// A set of errors that occurred while parsing a filter expression.
@@ -150,19 +149,19 @@ pub enum GlobConstructError {
     RegexError(String),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct State<'a> {
     // A `RefCell` is required here because the state must implement `Clone` to work with nom.
-    errors: &'a RefCell<Vec<ParseSingleError>>,
+    errors: &'a mut Vec<ParseSingleError>,
 }
 
 impl<'a> State<'a> {
-    pub fn new(errors: &'a RefCell<Vec<ParseSingleError>>) -> Self {
+    pub fn new(errors: &'a mut Vec<ParseSingleError>) -> Self {
         Self { errors }
     }
 
-    pub fn report_error(&self, error: ParseSingleError) {
-        self.errors.borrow_mut().push(error);
+    pub fn report_error(&mut self, error: ParseSingleError) {
+        self.errors.push(error);
     }
 }
 

--- a/nextest-filtering/src/expression.rs
+++ b/nextest-filtering/src/expression.rs
@@ -15,7 +15,7 @@ use guppy::{
 use miette::SourceSpan;
 use nextest_metadata::{RustBinaryId, RustTestBinaryKind};
 use recursion::{Collapsible, CollapsibleExt, MappableFrame, PartiallyApplied};
-use std::{cell::RefCell, collections::HashSet, fmt};
+use std::{collections::HashSet, fmt};
 
 /// Matcher for name
 ///
@@ -227,11 +227,9 @@ impl FilteringSet {
 impl FilteringExpr {
     /// Parse a filtering expression
     pub fn parse(input: String, graph: &PackageGraph) -> Result<Self, FilterExpressionParseErrors> {
-        let errors = RefCell::new(Vec::new());
-        match parse(new_span(&input, &errors)) {
+        let mut errors = Vec::new();
+        match parse(new_span(&input, &mut errors)) {
             Ok(parsed_expr) => {
-                let errors = errors.into_inner();
-
                 if !errors.is_empty() {
                     return Err(FilterExpressionParseErrors::new(input.clone(), errors));
                 }

--- a/nextest-filtering/src/expression.rs
+++ b/nextest-filtering/src/expression.rs
@@ -4,8 +4,8 @@
 use crate::{
     errors::{FilterExpressionParseErrors, ParseSingleError, State},
     parsing::{
-        parse, DisplayParsedRegex, DisplayParsedString, ExprResult, GenericGlob, ParsedExpr,
-        SetDef, Span,
+        new_span, parse, DisplayParsedRegex, DisplayParsedString, ExprResult, GenericGlob,
+        ParsedExpr, SetDef,
     },
 };
 use guppy::{
@@ -228,7 +228,7 @@ impl FilteringExpr {
     /// Parse a filtering expression
     pub fn parse(input: String, graph: &PackageGraph) -> Result<Self, FilterExpressionParseErrors> {
         let errors = RefCell::new(Vec::new());
-        match parse(Span::new_extra(&input, State::new(&errors))) {
+        match parse(new_span(&input, State::new(&errors))) {
             Ok(parsed_expr) => {
                 let errors = errors.into_inner();
 

--- a/nextest-filtering/src/expression.rs
+++ b/nextest-filtering/src/expression.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::{
-    errors::{FilterExpressionParseErrors, ParseSingleError, State},
+    errors::{FilterExpressionParseErrors, ParseSingleError},
     parsing::{
         new_span, parse, DisplayParsedRegex, DisplayParsedString, ExprResult, GenericGlob,
         ParsedExpr, SetDef,
@@ -228,7 +228,7 @@ impl FilteringExpr {
     /// Parse a filtering expression
     pub fn parse(input: String, graph: &PackageGraph) -> Result<Self, FilterExpressionParseErrors> {
         let errors = RefCell::new(Vec::new());
-        match parse(new_span(&input, State::new(&errors))) {
+        match parse(new_span(&input, &errors)) {
             Ok(parsed_expr) => {
                 let errors = errors.into_inner();
 

--- a/nextest-filtering/src/parsing.rs
+++ b/nextest-filtering/src/parsing.rs
@@ -20,7 +20,7 @@ use winnow::{
     branch::alt,
     bytes::{one_of, tag, take_till0, take_till1},
     character::line_ending,
-    combinator::{eof, map, peek, value, verify},
+    combinator::{eof, map, peek, value},
     multi::{fold_many0, many0},
     sequence::{delimited, preceded, terminated},
     stream::Location,
@@ -402,7 +402,7 @@ fn parse_regex_inner(input: Span<'_>) -> IResult<'_, String> {
 
         let parse_escape = map(alt((map(r"\/", |_| '/'), '\\')), Frag::Escape);
         let parse_literal = map(
-            verify(take_till1("\\/"), |s: &str| !s.is_empty()),
+            take_till1("\\/").verify(|s: &str| !s.is_empty()),
             |s: &str| Frag::Literal(s),
         );
         let parse_frag = alt((parse_escape, parse_literal));

--- a/nextest-filtering/src/parsing.rs
+++ b/nextest-filtering/src/parsing.rs
@@ -785,18 +785,14 @@ fn parse_or_operator<'i>(input: &mut Span<'i>) -> PResult<'i, Option<OrOperator>
         ws(alt((
             |input: &mut Span<'i>| {
                 let start = input.location();
-                let i = input.clone();
                 // This is not a valid OR operator in this position, but catch it to provide a better
                 // experience.
-                alt(("||", "OR "))
-                    .map(move |op: &str| {
-                        // || is not supported in filter expressions: suggest using | instead.
-                        let length = op.len();
-                        let err = ParseSingleError::InvalidOrOperator((start, length).into());
-                        i.state.report_error(err);
-                        None
-                    })
-                    .parse_next(input)
+                let op = alt(("||", "OR ")).parse_next(input)?;
+                // || is not supported in filter expressions: suggest using | instead.
+                let length = op.len();
+                let err = ParseSingleError::InvalidOrOperator((start, length).into());
+                input.state.report_error(err);
+                Ok(None)
             },
             "or ".value(Some(OrOperator::LiteralOr)),
             '|'.value(Some(OrOperator::Pipe)),
@@ -893,16 +889,12 @@ fn parse_and_or_difference_operator<'i>(
         ws(alt((
             |input: &mut Span<'i>| {
                 let start = input.location();
-                let i = input.clone();
-                alt(("&&", "AND "))
-                    .map(move |op: &str| {
-                        // && is not supported in filter expressions: suggest using & instead.
-                        let length = op.len();
-                        let err = ParseSingleError::InvalidAndOperator((start, length).into());
-                        i.state.report_error(err);
-                        None
-                    })
-                    .parse_next(input)
+                let op = alt(("&&", "AND ")).parse_next(input)?;
+                // && is not supported in filter expressions: suggest using & instead.
+                let length = op.len();
+                let err = ParseSingleError::InvalidAndOperator((start, length).into());
+                input.state.report_error(err);
+                Ok(None)
             },
             "and ".value(Some(AndOrDifferenceOperator::And(AndOperator::LiteralAnd))),
             '&'.value(Some(AndOrDifferenceOperator::And(AndOperator::Ampersand))),

--- a/nextest-filtering/src/parsing.rs
+++ b/nextest-filtering/src/parsing.rs
@@ -400,7 +400,7 @@ fn parse_regex_inner(input: Span<'_>) -> IResult<'_, String> {
         }
 
         let parse_escape = alt((r"\/".value('/'), '\\')).map(Frag::Escape);
-        let parse_literal = take_till1("\\/")
+        let parse_literal = take_till1(('\\', '/'))
             .verify(|s: &str| !s.is_empty())
             .map(|s: &str| Frag::Literal(s));
         let parse_frag = alt((parse_escape, parse_literal));

--- a/nextest-filtering/src/parsing.rs
+++ b/nextest-filtering/src/parsing.rs
@@ -22,7 +22,7 @@ use winnow::{
     character::complete::{char, line_ending},
     combinator::{eof, map, peek, recognize, value, verify},
     multi::{fold_many0, many0},
-    sequence::{delimited, pair, preceded, terminated},
+    sequence::{delimited, preceded, terminated},
     stream::Location,
     stream::SliceLen,
     trace::trace,
@@ -705,7 +705,7 @@ fn parse_expr_not(input: Span<'_>) -> IResult<'_, ExprResult> {
     trace(
         "parse_expr_not",
         map(
-            pair(
+            (
                 alt((
                     value(NotOperator::LiteralNot, "not "),
                     value(NotOperator::Exclamation, '!'),
@@ -747,7 +747,7 @@ fn parse_expr(input: Span<'_>) -> IResult<'_, ExprResult> {
         let (input, expr) = expect_expr(parse_and_or_difference_expr).parse_next(input)?;
 
         let (input, ops) = fold_many0(
-            pair(parse_or_operator, expect_expr(parse_and_or_difference_expr)),
+            (parse_or_operator, expect_expr(parse_and_or_difference_expr)),
             Vec::new,
             |mut ops, (op, expr)| {
                 ops.push((op, expr));
@@ -846,7 +846,7 @@ fn parse_and_or_difference_expr(input: Span<'_>) -> IResult<'_, ExprResult> {
         let (input, expr) = expect_expr(parse_basic_expr).parse_next(input)?;
 
         let (input, ops) = fold_many0(
-            pair(
+            (
                 parse_and_or_difference_operator,
                 expect_expr(parse_basic_expr),
             ),

--- a/nextest-filtering/src/parsing.rs
+++ b/nextest-filtering/src/parsing.rs
@@ -17,14 +17,12 @@ use guppy::graph::cargo::BuildPlatform;
 use miette::SourceSpan;
 use std::{cell::RefCell, fmt};
 use winnow::{
-    branch::alt,
-    bytes::{one_of, tag, take_till0, take_till1},
-    character::line_ending,
-    combinator::{eof, peek},
+    ascii::line_ending,
+    combinator::{alt, delimited, eof, peek, preceded, terminated},
     multi::{fold_many0, many0},
-    sequence::{delimited, preceded, terminated},
     stream::Location,
     stream::SliceLen,
+    token::{one_of, tag, take_till0, take_till1},
     trace::trace,
     Parser,
 };

--- a/nextest-filtering/src/parsing.rs
+++ b/nextest-filtering/src/parsing.rs
@@ -452,9 +452,7 @@ fn parse_regex<'i>(input: Span<'i>) -> IResult<'i, Option<NameMatcher>> {
         let (i, res) = match parse_regex_inner(input.clone()) {
             Ok((i, res)) => (i, res),
             Err(_) => {
-                match take_till0::<_, _, winnow::error::Error<Span<'_>>>(|c| c == ')')(
-                    input.clone(),
-                ) {
+                match take_till0::<_, _, winnow::error::Error<Span<'_>>>(')')(input.clone()) {
                     Ok((i, _)) => {
                         let start = i.location();
                         let err = ParseSingleError::ExpectedCloseRegex((start, 0).into());
@@ -515,7 +513,7 @@ fn recover_unexpected_comma<'i>(input: Span<'i>) -> IResult<'i, ()> {
                 let pos = i.location();
                 i.state
                     .report_error(ParseSingleError::UnexpectedComma((pos..0).into()));
-                match take_till0::<_, _, winnow::error::Error<Span<'_>>>(|c| c == ')')(i) {
+                match take_till0::<_, _, winnow::error::Error<Span<'_>>>(')')(i) {
                     Ok((i, _)) => Ok((i, ())),
                     Err(_) => unreachable!(),
                 }

--- a/nextest-filtering/src/parsing.rs
+++ b/nextest-filtering/src/parsing.rs
@@ -19,9 +19,7 @@ use std::fmt;
 use winnow::{
     ascii::line_ending,
     combinator::{alt, delimited, eof, fold_repeat, peek, preceded, repeat, terminated},
-    stream::Location,
-    stream::SliceLen,
-    stream::Stream,
+    stream::{Location, SliceLen, Stream},
     token::{tag, take_till},
     trace::trace,
     Parser,

--- a/nextest-filtering/src/parsing.rs
+++ b/nextest-filtering/src/parsing.rs
@@ -35,6 +35,7 @@ pub(crate) use unicode_string::DisplayParsedString;
 pub(crate) type Span<'a> = winnow::Stateful<winnow::Located<&'a str>, State<'a>>;
 type Error<'a> = winnow::error::InputError<Span<'a>>;
 type IResult<'a, T> = winnow::IResult<Span<'a>, T, Error<'a>>;
+type PResult<'a, T> = winnow::PResult<T, Error<'a>>;
 
 impl<'a> ToSourceSpan for Span<'a> {
     fn to_span(&self) -> SourceSpan {
@@ -347,7 +348,7 @@ fn parse_matcher_text<'i>(input: Span<'i>) -> IResult<'i, Option<String>> {
         "parse_matcher_text",
         unpeek(|input: Span<'i>| {
             let (i, res) = match expect(
-                unpeek(unicode_string::parse_string),
+                unicode_string::parse_string,
                 ParseSingleError::InvalidString,
             )
             .parse_peek(input.clone())

--- a/nextest-filtering/src/parsing.rs
+++ b/nextest-filtering/src/parsing.rs
@@ -499,10 +499,7 @@ fn parse_regex_matcher(input: Span<'_>) -> IResult<'_, Option<NameMatcher>> {
 fn parse_glob_matcher(input: Span<'_>) -> IResult<'_, Option<NameMatcher>> {
     trace(
         "parse_glob_matcher",
-        ws(preceded(
-            '#',
-            unpeek(|input| glob::parse_glob(input, false)),
-        )),
+        ws(preceded('#', glob::parse_glob(false))),
     )
     .parse_peek(input)
 }
@@ -584,7 +581,7 @@ impl DefaultMatcher {
             Self::Contains => unpeek(parse_matcher_text)
                 .map(|res: Option<String>| res.map(NameMatcher::implicit_contains))
                 .parse_peek(input),
-            Self::Glob => glob::parse_glob(input, true),
+            Self::Glob => glob::parse_glob(true).parse_peek(input),
         })
     }
 }

--- a/nextest-filtering/src/parsing.rs
+++ b/nextest-filtering/src/parsing.rs
@@ -18,7 +18,8 @@ use miette::SourceSpan;
 use std::{cell::RefCell, fmt};
 use winnow::{
     branch::alt,
-    bytes::complete::{is_not, tag, take_till},
+    bytes::complete::{is_not, take_till},
+    bytes::tag,
     character::complete::{char, line_ending},
     combinator::{eof, map, peek, recognize, value, verify},
     multi::{fold_many0, many0},

--- a/nextest-filtering/src/parsing.rs
+++ b/nextest-filtering/src/parsing.rs
@@ -21,7 +21,7 @@ use winnow::{
     combinator::{alt, delimited, eof, fold_repeat, peek, preceded, repeat, terminated},
     stream::Location,
     stream::SliceLen,
-    token::{one_of, tag, take_till0, take_till1},
+    token::{tag, take_till0, take_till1},
     trace::trace,
     Parser,
 };
@@ -288,7 +288,7 @@ fn expect_char<'a>(
     c: char,
     make_err: fn(SourceSpan) -> ParseSingleError,
 ) -> impl Parser<Span<'a>, Option<char>, Error<'a>> {
-    expect_inner(ws(one_of(c)), make_err, SpanLength::Exact(0))
+    expect_inner(ws(c), make_err, SpanLength::Exact(0))
 }
 
 fn silent_expect<'a, F, T>(mut parser: F) -> impl Parser<Span<'a>, Option<T>, Error<'a>>
@@ -313,7 +313,7 @@ fn ws<'a, T, P: Parser<Span<'a>, T, Error<'a>>>(
             0..,
             alt((
                 // Match individual space characters.
-                one_of(' ').void(),
+                ' '.void(),
                 // Match CRLF and LF line endings. This allows filters to be specified as multiline TOML
                 // strings.
                 line_ending.void(),
@@ -400,7 +400,7 @@ fn parse_regex_inner(input: Span<'_>) -> IResult<'_, String> {
             Escape(char),
         }
 
-        let parse_escape = alt((tag(r"\/").value('/'), '\\')).map(Frag::Escape);
+        let parse_escape = alt((r"\/".value('/'), '\\')).map(Frag::Escape);
         let parse_literal = take_till1("\\/")
             .verify(|s: &str| !s.is_empty())
             .map(|s: &str| Frag::Literal(s));
@@ -702,8 +702,8 @@ fn parse_expr_not(input: Span<'_>) -> IResult<'_, ExprResult> {
         "parse_expr_not",
         (
             alt((
-                tag("not ").value(NotOperator::LiteralNot),
-                one_of('!').value(NotOperator::Exclamation),
+                "not ".value(NotOperator::LiteralNot),
+                '!'.value(NotOperator::Exclamation),
             )),
             expect_expr(ws(parse_basic_expr)),
         )
@@ -786,9 +786,9 @@ fn parse_or_operator<'i>(input: Span<'i>) -> IResult<'i, Option<OrOperator>> {
                     })
                     .parse_next(input)
             },
-            tag("or ").value(Some(OrOperator::LiteralOr)),
-            one_of('|').value(Some(OrOperator::Pipe)),
-            one_of('+').value(Some(OrOperator::Plus)),
+            "or ".value(Some(OrOperator::LiteralOr)),
+            '|'.value(Some(OrOperator::Pipe)),
+            '+'.value(Some(OrOperator::Plus)),
         ))),
     )
     .parse_next(input)
@@ -892,9 +892,9 @@ fn parse_and_or_difference_operator<'i>(
                     })
                     .parse_next(input)
             },
-            tag("and ").value(Some(AndOrDifferenceOperator::And(AndOperator::LiteralAnd))),
-            one_of('&').value(Some(AndOrDifferenceOperator::And(AndOperator::Ampersand))),
-            one_of('-').value(Some(AndOrDifferenceOperator::Difference(
+            "and ".value(Some(AndOrDifferenceOperator::And(AndOperator::LiteralAnd))),
+            '&'.value(Some(AndOrDifferenceOperator::And(AndOperator::Ampersand))),
+            '-'.value(Some(AndOrDifferenceOperator::Difference(
                 DifferenceOperator::Minus,
             ))),
         ))),

--- a/nextest-filtering/src/parsing.rs
+++ b/nextest-filtering/src/parsing.rs
@@ -41,6 +41,10 @@ impl<'a> ToSourceSpan for Span<'a> {
     }
 }
 
+pub(crate) fn new_span<'a>(input: &'a str, state: State<'a>) -> Span<'a> {
+    Span::new_extra(input, state)
+}
+
 /// A filter expression that hasn't been compiled against a package graph.
 ///
 /// Not part of the public API. Exposed for testing only.
@@ -107,7 +111,7 @@ pub enum ParsedExpr<S = SourceSpan> {
 impl ParsedExpr {
     pub fn parse(input: &str) -> Result<Self, Vec<ParseSingleError>> {
         let errors = RefCell::new(Vec::new());
-        match parse(Span::new_extra(input, State::new(&errors))).unwrap() {
+        match parse(new_span(input, State::new(&errors))).unwrap() {
             ExprResult::Valid(expr) => Ok(expr),
             ExprResult::Error => Err(errors.into_inner()),
         }
@@ -866,7 +870,7 @@ mod tests {
     #[track_caller]
     fn parse_regex(input: &str) -> NameMatcher {
         let errors = RefCell::new(Vec::new());
-        parse_regex_matcher(Span::new_extra(input, State::new(&errors)))
+        parse_regex_matcher(new_span(input, State::new(&errors)))
             .unwrap()
             .1
             .unwrap()
@@ -903,7 +907,7 @@ mod tests {
     #[track_caller]
     fn parse_glob(input: &str) -> NameMatcher {
         let errors = RefCell::new(Vec::new());
-        let matcher = parse_glob_matcher(Span::new_extra(input, State::new(&errors)))
+        let matcher = parse_glob_matcher(new_span(input, State::new(&errors)))
             .unwrap_or_else(|error| {
                 panic!("for input {input}, parse_glob_matcher returned an error: {error}")
             })
@@ -954,7 +958,7 @@ mod tests {
     #[track_caller]
     fn parse_set(input: &str) -> SetDef {
         let errors = RefCell::new(Vec::new());
-        parse_set_def(Span::new_extra(input, State::new(&errors)))
+        parse_set_def(new_span(input, State::new(&errors)))
             .unwrap()
             .1
             .unwrap()
@@ -1385,7 +1389,7 @@ mod tests {
         }
 
         let errors = RefCell::new(Vec::new());
-        if parse_future_syntax(Span::new_extra("something(aa, bb)", State::new(&errors))).is_err() {
+        if parse_future_syntax(new_span("something(aa, bb)", State::new(&errors))).is_err() {
             panic!("Failed to parse comma separated matchers");
         }
     }
@@ -1393,7 +1397,7 @@ mod tests {
     #[track_caller]
     fn parse_err(input: &str) -> Vec<ParseSingleError> {
         let errors = RefCell::new(Vec::new());
-        super::parse(Span::new_extra(input, State::new(&errors))).unwrap();
+        super::parse(new_span(input, State::new(&errors))).unwrap();
         errors.into_inner()
     }
 

--- a/nextest-filtering/src/parsing.rs
+++ b/nextest-filtering/src/parsing.rs
@@ -115,7 +115,8 @@ pub enum ParsedExpr<S = SourceSpan> {
 impl ParsedExpr {
     pub fn parse(input: &str) -> Result<Self, Vec<ParseSingleError>> {
         let errors = RefCell::new(Vec::new());
-        match parse(new_span(input, &errors)).unwrap() {
+        let span = new_span(input, &errors);
+        match parse(span).unwrap() {
             ExprResult::Valid(expr) => Ok(expr),
             ExprResult::Error => Err(errors.into_inner()),
         }
@@ -922,10 +923,8 @@ mod tests {
     #[track_caller]
     fn parse_regex(input: &str) -> NameMatcher {
         let errors = RefCell::new(Vec::new());
-        parse_regex_matcher(new_span(input, &errors))
-            .unwrap()
-            .1
-            .unwrap()
+        let span = new_span(input, &errors);
+        parse_regex_matcher(span).unwrap().1.unwrap()
     }
 
     #[test]
@@ -959,7 +958,8 @@ mod tests {
     #[track_caller]
     fn parse_glob(input: &str) -> NameMatcher {
         let errors = RefCell::new(Vec::new());
-        let matcher = parse_glob_matcher(new_span(input, &errors))
+        let span = new_span(input, &errors);
+        let matcher = parse_glob_matcher(span)
             .unwrap_or_else(|error| {
                 panic!("for input {input}, parse_glob_matcher returned an error: {error}")
             })
@@ -1010,7 +1010,8 @@ mod tests {
     #[track_caller]
     fn parse_set(input: &str) -> SetDef {
         let errors = RefCell::new(Vec::new());
-        parse_set_def(new_span(input, &errors)).unwrap().1.unwrap()
+        let span = new_span(input, &errors);
+        parse_set_def(span).unwrap().1.unwrap()
     }
 
     macro_rules! assert_set_def {
@@ -1438,7 +1439,8 @@ mod tests {
         }
 
         let errors = RefCell::new(Vec::new());
-        if parse_future_syntax(new_span("something(aa, bb)", &errors)).is_err() {
+        let span = new_span("something(aa, bb)", &errors);
+        if parse_future_syntax(span).is_err() {
             panic!("Failed to parse comma separated matchers");
         }
     }
@@ -1446,7 +1448,8 @@ mod tests {
     #[track_caller]
     fn parse_err(input: &str) -> Vec<ParseSingleError> {
         let errors = RefCell::new(Vec::new());
-        super::parse(new_span(input, &errors)).unwrap();
+        let span = new_span(input, &errors);
+        super::parse(span).unwrap();
         errors.into_inner()
     }
 

--- a/nextest-filtering/src/parsing.rs
+++ b/nextest-filtering/src/parsing.rs
@@ -20,7 +20,7 @@ use winnow::{
     branch::alt,
     bytes::complete::is_not,
     bytes::{one_of, tag, take_till0},
-    character::complete::line_ending,
+    character::line_ending,
     combinator::{eof, map, peek, recognize, value, verify},
     multi::{fold_many0, many0},
     sequence::{delimited, preceded, terminated},

--- a/nextest-filtering/src/parsing.rs
+++ b/nextest-filtering/src/parsing.rs
@@ -1451,21 +1451,21 @@ mod tests {
         assert_eq_both_ways(&expr, r"test(~a\,)");
 
         // string parsing is compatible with possible future syntax
-        fn parse_future_syntax(
-            input: Span<'_>,
-        ) -> IResult<'_, (Option<NameMatcher>, Option<NameMatcher>)> {
-            let (i, _) = "something".parse_peek(input)?;
-            let (i, _) = '('.parse_peek(i)?;
-            let (i, n1) = set_matcher(DefaultMatcher::Contains).parse_peek(i)?;
-            let (i, _) = ws(',').parse_peek(i)?;
-            let (i, n2) = set_matcher(DefaultMatcher::Contains).parse_peek(i)?;
-            let (i, _) = ')'.parse_peek(i)?;
-            Ok((i, (n1, n2)))
+        fn parse_future_syntax<'i>(
+            input: &mut Span<'i>,
+        ) -> PResult<'i, (Option<NameMatcher>, Option<NameMatcher>)> {
+            let _ = "something".parse_next(input)?;
+            let _ = '('.parse_next(input)?;
+            let n1 = set_matcher(DefaultMatcher::Contains).parse_next(input)?;
+            let _ = ws(',').parse_next(input)?;
+            let n2 = set_matcher(DefaultMatcher::Contains).parse_next(input)?;
+            let _ = ')'.parse_next(input)?;
+            Ok((n1, n2))
         }
 
         let errors = RefCell::new(Vec::new());
-        let span = new_span("something(aa, bb)", &errors);
-        if parse_future_syntax(span).is_err() {
+        let mut span = new_span("something(aa, bb)", &errors);
+        if parse_future_syntax.parse_next(&mut span).is_err() {
             panic!("Failed to parse comma separated matchers");
         }
     }

--- a/nextest-filtering/src/parsing.rs
+++ b/nextest-filtering/src/parsing.rs
@@ -19,8 +19,8 @@ use std::{cell::RefCell, fmt};
 use winnow::{
     branch::alt,
     bytes::complete::{is_not, take_till},
-    bytes::tag,
-    character::complete::{char, line_ending},
+    bytes::{one_of, tag},
+    character::complete::line_ending,
     combinator::{eof, map, peek, recognize, value, verify},
     multi::{fold_many0, many0},
     sequence::{delimited, preceded, terminated},
@@ -292,7 +292,7 @@ fn expect_char<'a>(
     c: char,
     make_err: fn(SourceSpan) -> ParseSingleError,
 ) -> impl Parser<Span<'a>, Option<char>, Error<'a>> {
-    expect_inner(ws(char(c)), make_err, SpanLength::Exact(0))
+    expect_inner(ws(one_of(c)), make_err, SpanLength::Exact(0))
 }
 
 fn silent_expect<'a, F, T>(mut parser: F) -> impl Parser<Span<'a>, Option<T>, Error<'a>>

--- a/nextest-filtering/src/parsing/glob.rs
+++ b/nextest-filtering/src/parsing/glob.rs
@@ -60,9 +60,7 @@ impl GenericGlob {
 }
 
 // This never returns Err(()) -- instead, it reports an error to the parsing state.
-pub(super) fn parse_glob<'i>(
-    implicit: bool,
-) -> impl Parser<Span<'i>, Option<NameMatcher>, Error<'i>> {
+pub(super) fn parse_glob<'i>(implicit: bool) -> impl Parser<Span<'i>, Option<NameMatcher>, Error> {
     trace("parse_glob", move |input: &mut Span<'i>| {
         let start = input.location();
         let res = match parse_matcher_text.parse_next(input) {

--- a/nextest-filtering/src/parsing/glob.rs
+++ b/nextest-filtering/src/parsing/glob.rs
@@ -3,7 +3,7 @@
 
 //! Glob matching.
 
-use super::{parse_matcher_text, IResult, Span};
+use super::{parse_matcher_text, Error, Span};
 use crate::{
     errors::{GlobConstructError, ParseSingleError},
     NameMatcher,
@@ -61,10 +61,12 @@ impl GenericGlob {
 }
 
 // This never returns Err(()) -- instead, it reports an error to the parsing state.
-pub(super) fn parse_glob<'i>(input: Span<'i>, implicit: bool) -> IResult<'i, Option<NameMatcher>> {
+pub(super) fn parse_glob<'i>(
+    implicit: bool,
+) -> impl Parser<Span<'i>, Option<NameMatcher>, Error<'i>> {
     trace(
         "parse_glob",
-        unpeek(|input: Span<'i>| {
+        unpeek(move |input: Span<'i>| {
             let (i, res) = match parse_matcher_text(input.clone()) {
                 Ok((i, res)) => (i, res),
                 Err(_) => {
@@ -91,5 +93,4 @@ pub(super) fn parse_glob<'i>(input: Span<'i>, implicit: bool) -> IResult<'i, Opt
             }
         }),
     )
-    .parse_peek(input)
 }

--- a/nextest-filtering/src/parsing/glob.rs
+++ b/nextest-filtering/src/parsing/glob.rs
@@ -8,9 +8,7 @@ use crate::{
     errors::{GlobConstructError, ParseSingleError},
     NameMatcher,
 };
-use winnow::stream::Location;
-use winnow::trace::trace;
-use winnow::Parser;
+use winnow::{stream::Location, trace::trace, Parser};
 
 /// A glob pattern.
 ///

--- a/nextest-filtering/src/parsing/glob.rs
+++ b/nextest-filtering/src/parsing/glob.rs
@@ -10,7 +10,6 @@ use crate::{
 };
 use winnow::stream::Location;
 use winnow::trace::trace;
-use winnow::unpeek;
 use winnow::Parser;
 
 /// A glob pattern.
@@ -66,7 +65,7 @@ pub(super) fn parse_glob<'i>(
 ) -> impl Parser<Span<'i>, Option<NameMatcher>, Error<'i>> {
     trace("parse_glob", move |input: &mut Span<'i>| {
         let start = input.location();
-        let res = match unpeek(parse_matcher_text).parse_next(input) {
+        let res = match parse_matcher_text.parse_next(input) {
             Ok(res) => res,
             Err(_) => {
                 unreachable!("parse_matcher_text should never fail")

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -17,7 +17,7 @@ use winnow::{
 
 fn run_str_parser<'a, T, I>(mut inner: I) -> impl Parser<Span<'a>, T, super::Error<'a>>
 where
-    I: Parser<&'a str, T, winnow::error::Error<&'a str>>,
+    I: Parser<&'a str, T, winnow::error::InputError<&'a str>>,
 {
     move |input: Span<'a>| match inner.parse_next(input.next_slice(input.slice_len()).1) {
         Ok((i, res)) => {
@@ -25,18 +25,18 @@ where
             Ok((input.next_slice(eaten).0, res))
         }
         Err(winnow::error::ErrMode::Backtrack(err)) => {
-            let winnow::error::Error { input: i, kind } = err;
+            let winnow::error::InputError { input: i, kind } = err;
             let eaten = input.slice_len() - i.len();
-            let err = winnow::error::Error {
+            let err = winnow::error::InputError {
                 input: input.next_slice(eaten).0,
                 kind,
             };
             Err(winnow::error::ErrMode::Backtrack(err))
         }
         Err(winnow::error::ErrMode::Cut(err)) => {
-            let winnow::error::Error { input: i, kind } = err;
+            let winnow::error::InputError { input: i, kind } = err;
             let eaten = input.slice_len() - i.len();
-            let err = winnow::error::Error {
+            let err = winnow::error::InputError {
                 input: input.next_slice(eaten).0,
                 kind,
             };

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -107,7 +107,7 @@ impl fmt::Display for DisplayParsedString<'_> {
 }
 fn parse_literal<'i>(input: Span<'i>) -> IResult<'i, &str> {
     trace("parse_literal", |input: Span<'i>| {
-        let not_quote_slash = take_till1(",)\\");
+        let not_quote_slash = take_till1((',', ')', '\\'));
         let res = not_quote_slash
             .verify(|s: &str| !s.is_empty())
             .parse_next(input.clone());

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -7,12 +7,11 @@ use super::{expect_n, IResult, Span, SpanLength};
 use crate::errors::ParseSingleError;
 use std::fmt;
 use winnow::{
-    bytes::take_while_m_n,
     combinator::{alt, delimited, preceded},
     multi::fold_many0,
     stream::SliceLen,
     stream::Stream,
-    token::{one_of, take_till1},
+    token::{one_of, take_till1, take_while},
     trace::trace,
     Parser,
 };
@@ -52,7 +51,7 @@ where
 
 fn parse_unicode(input: Span<'_>) -> IResult<'_, char> {
     trace("parse_unicode", |input| {
-        let parse_hex = take_while_m_n(1, 6, |c: char| c.is_ascii_hexdigit());
+        let parse_hex = take_while(1..=6, |c: char| c.is_ascii_hexdigit());
         let parse_delimited_hex = preceded('u', delimited('{', parse_hex, '}'));
         let parse_u32 = parse_delimited_hex.map_res(|hex| u32::from_str_radix(hex, 16));
         run_str_parser(parse_u32.verify_map(std::char::from_u32)).parse_next(input)

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -83,7 +83,8 @@ fn parse_escaped_char(input: Span<'_>) -> IResult<'_, Option<char>> {
                 // -1 to account for the preceding backslash.
                 SpanLength::Offset(-1, 2),
             ),
-        )(input)
+        )
+        .parse_next(input)
     })
     .parse_next(input)
 }

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -8,8 +8,7 @@ use crate::errors::ParseSingleError;
 use std::fmt;
 use winnow::{
     branch::alt,
-    bytes::complete::is_not,
-    bytes::take_while_m_n,
+    bytes::{take_till1, take_while_m_n},
     combinator::{map, map_opt, map_res, value, verify},
     multi::fold_many0,
     sequence::{delimited, preceded},
@@ -110,7 +109,7 @@ impl fmt::Display for DisplayParsedString<'_> {
 }
 fn parse_literal<'i>(input: Span<'i>) -> IResult<'i, &str> {
     trace("parse_literal", |input: Span<'i>| {
-        let not_quote_slash = is_not(",)\\");
+        let not_quote_slash = take_till1(",)\\");
         let res = verify(not_quote_slash, |s: &str| !s.is_empty())(input.clone());
         res
     })

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -9,7 +9,6 @@ use std::fmt;
 use winnow::{
     branch::alt,
     bytes::complete::{is_not, take_while_m_n},
-    character::complete::char,
     combinator::{map, map_opt, map_res, value, verify},
     multi::fold_many0,
     sequence::{delimited, preceded},
@@ -55,7 +54,7 @@ where
 fn parse_unicode(input: Span<'_>) -> IResult<'_, char> {
     trace("parse_unicode", |input| {
         let parse_hex = take_while_m_n(1, 6, |c: char| c.is_ascii_hexdigit());
-        let parse_delimited_hex = preceded(char('u'), delimited(char('{'), parse_hex, char('}')));
+        let parse_delimited_hex = preceded('u', delimited('{', parse_hex, '}'));
         let parse_u32 = map_res(parse_delimited_hex, |hex| u32::from_str_radix(hex, 16));
         run_str_parser(map_opt(parse_u32, std::char::from_u32)).parse_next(input)
     })
@@ -66,18 +65,18 @@ fn parse_escaped_char(input: Span<'_>) -> IResult<'_, Option<char>> {
     trace("parse_escaped_char", |input| {
         let valid = alt((
             parse_unicode,
-            value('\n', char('n')),
-            value('\r', char('r')),
-            value('\t', char('t')),
-            value('\u{08}', char('b')),
-            value('\u{0C}', char('f')),
-            value('\\', char('\\')),
-            value('/', char('/')),
-            value(')', char(')')),
-            value(',', char(',')),
+            value('\n', 'n'),
+            value('\r', 'r'),
+            value('\t', 't'),
+            value('\u{08}', 'b'),
+            value('\u{0C}', 'f'),
+            value('\\', '\\'),
+            value('/', '/'),
+            value(')', ')'),
+            value(',', ','),
         ));
         preceded(
-            char('\\'),
+            '\\',
             // If none of the valid characters are found, this will report an error.
             expect_n(
                 valid,

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -13,7 +13,7 @@ use winnow::{
     Parser,
 };
 
-fn parse_unicode<'i>(input: &mut Span<'i>) -> PResult<'i, char> {
+fn parse_unicode<'i>(input: &mut Span<'i>) -> PResult<char> {
     trace("parse_unicode", |input: &mut _| {
         let parse_hex = take_while(1..=6, |c: char| c.is_ascii_hexdigit());
         let parse_delimited_hex = preceded('u', delimited('{', parse_hex, '}'));
@@ -23,7 +23,7 @@ fn parse_unicode<'i>(input: &mut Span<'i>) -> PResult<'i, char> {
     .parse_next(input)
 }
 
-fn parse_escaped_char<'i>(input: &mut Span<'i>) -> PResult<'i, Option<char>> {
+fn parse_escaped_char<'i>(input: &mut Span<'i>) -> PResult<Option<char>> {
     trace("parse_escaped_char", |input: &mut _| {
         let valid = alt((
             parse_unicode,
@@ -70,7 +70,7 @@ impl fmt::Display for DisplayParsedString<'_> {
         Ok(())
     }
 }
-fn parse_literal<'i>(input: &mut Span<'i>) -> PResult<'i, &'i str> {
+fn parse_literal<'i>(input: &mut Span<'i>) -> PResult<&'i str> {
     trace("parse_literal", |input: &mut _| {
         let not_quote_slash = take_till(1.., (',', ')', '\\'));
         let res = not_quote_slash
@@ -87,7 +87,7 @@ enum StringFragment<'a> {
     EscapedChar(char),
 }
 
-fn parse_fragment<'i>(input: &mut Span<'i>) -> PResult<'i, Option<StringFragment<'i>>> {
+fn parse_fragment<'i>(input: &mut Span<'i>) -> PResult<Option<StringFragment<'i>>> {
     trace(
         "parse_fragment",
         alt((
@@ -101,7 +101,7 @@ fn parse_fragment<'i>(input: &mut Span<'i>) -> PResult<'i, Option<StringFragment
 /// Construct a string by consuming the input until the next unescaped ) or ,.
 ///
 /// Returns None if the string isn't valid.
-pub(super) fn parse_string<'i>(input: &mut Span<'i>) -> PResult<'i, Option<String>> {
+pub(super) fn parse_string<'i>(input: &mut Span<'i>) -> PResult<Option<String>> {
     trace(
         "parse_string",
         fold_repeat(

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -7,12 +7,12 @@ use super::{expect_n, IResult, Span, SpanLength};
 use crate::errors::ParseSingleError;
 use std::fmt;
 use winnow::{
-    branch::alt,
-    bytes::{one_of, take_till1, take_while_m_n},
+    bytes::take_while_m_n,
+    combinator::{alt, delimited, preceded},
     multi::fold_many0,
-    sequence::{delimited, preceded},
     stream::SliceLen,
     stream::Stream,
+    token::{one_of, take_till1},
     trace::trace,
     Parser,
 };

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use winnow::{
     branch::alt,
     bytes::{take_till1, take_while_m_n},
-    combinator::{map_opt, map_res, value},
+    combinator::{map_res, value},
     multi::fold_many0,
     sequence::{delimited, preceded},
     stream::SliceLen,
@@ -56,7 +56,7 @@ fn parse_unicode(input: Span<'_>) -> IResult<'_, char> {
         let parse_hex = take_while_m_n(1, 6, |c: char| c.is_ascii_hexdigit());
         let parse_delimited_hex = preceded('u', delimited('{', parse_hex, '}'));
         let parse_u32 = map_res(parse_delimited_hex, |hex| u32::from_str_radix(hex, 16));
-        run_str_parser(map_opt(parse_u32, std::char::from_u32)).parse_next(input)
+        run_str_parser(parse_u32.verify_map(std::char::from_u32)).parse_next(input)
     })
     .parse_next(input)
 }

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -13,7 +13,7 @@ use winnow::{
     Parser,
 };
 
-fn parse_unicode<'i>(input: &mut Span<'i>) -> PResult<char> {
+fn parse_unicode(input: &mut Span<'_>) -> PResult<char> {
     trace("parse_unicode", |input: &mut _| {
         let parse_hex = take_while(1..=6, |c: char| c.is_ascii_hexdigit());
         let parse_delimited_hex = preceded('u', delimited('{', parse_hex, '}'));
@@ -23,7 +23,7 @@ fn parse_unicode<'i>(input: &mut Span<'i>) -> PResult<char> {
     .parse_next(input)
 }
 
-fn parse_escaped_char<'i>(input: &mut Span<'i>) -> PResult<Option<char>> {
+fn parse_escaped_char(input: &mut Span<'_>) -> PResult<Option<char>> {
     trace("parse_escaped_char", |input: &mut _| {
         let valid = alt((
             parse_unicode,
@@ -73,10 +73,10 @@ impl fmt::Display for DisplayParsedString<'_> {
 fn parse_literal<'i>(input: &mut Span<'i>) -> PResult<&'i str> {
     trace("parse_literal", |input: &mut _| {
         let not_quote_slash = take_till(1.., (',', ')', '\\'));
-        let res = not_quote_slash
+
+        not_quote_slash
             .verify(|s: &str| !s.is_empty())
-            .parse_next(input);
-        res
+            .parse_next(input)
     })
     .parse_next(input)
 }
@@ -101,7 +101,7 @@ fn parse_fragment<'i>(input: &mut Span<'i>) -> PResult<Option<StringFragment<'i>
 /// Construct a string by consuming the input until the next unescaped ) or ,.
 ///
 /// Returns None if the string isn't valid.
-pub(super) fn parse_string<'i>(input: &mut Span<'i>) -> PResult<Option<String>> {
+pub(super) fn parse_string(input: &mut Span<'_>) -> PResult<Option<String>> {
     trace(
         "parse_string",
         fold_repeat(

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -8,7 +8,8 @@ use crate::errors::ParseSingleError;
 use std::fmt;
 use winnow::{
     branch::alt,
-    bytes::complete::{is_not, take_while_m_n},
+    bytes::complete::is_not,
+    bytes::take_while_m_n,
     combinator::{map, map_opt, map_res, value, verify},
     multi::fold_many0,
     sequence::{delimited, preceded},

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use winnow::{
     branch::alt,
     bytes::{take_till1, take_while_m_n},
-    combinator::{map, map_opt, map_res, value},
+    combinator::{map_opt, map_res, value},
     multi::fold_many0,
     sequence::{delimited, preceded},
     stream::SliceLen,
@@ -128,10 +128,8 @@ fn parse_fragment(input: Span<'_>) -> IResult<'_, Option<StringFragment<'_>>> {
     trace(
         "parse_fragment",
         alt((
-            map(parse_literal, |span| Some(StringFragment::Literal(span))),
-            map(parse_escaped_char, |res| {
-                res.map(StringFragment::EscapedChar)
-            }),
+            parse_literal.map(|span| Some(StringFragment::Literal(span))),
+            parse_escaped_char.map(|res| res.map(StringFragment::EscapedChar)),
         )),
     )
     .parse_next(input)

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -28,25 +28,27 @@ where
             let eaten = input.slice_len() - i.len();
             Ok((input.next_slice(eaten).0, res))
         }
-        Err(winnow::Err::Backtrack(err)) => {
+        Err(winnow::error::ErrMode::Backtrack(err)) => {
             let winnow::error::Error { input: i, kind } = err;
             let eaten = input.slice_len() - i.len();
             let err = winnow::error::Error {
                 input: input.next_slice(eaten).0,
                 kind,
             };
-            Err(winnow::Err::Backtrack(err))
+            Err(winnow::error::ErrMode::Backtrack(err))
         }
-        Err(winnow::Err::Cut(err)) => {
+        Err(winnow::error::ErrMode::Cut(err)) => {
             let winnow::error::Error { input: i, kind } = err;
             let eaten = input.slice_len() - i.len();
             let err = winnow::error::Error {
                 input: input.next_slice(eaten).0,
                 kind,
             };
-            Err(winnow::Err::Cut(err))
+            Err(winnow::error::ErrMode::Cut(err))
         }
-        Err(winnow::Err::Incomplete(err)) => Err(winnow::Err::Incomplete(err)),
+        Err(winnow::error::ErrMode::Incomplete(err)) => {
+            Err(winnow::error::ErrMode::Incomplete(err))
+        }
     }
 }
 

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -52,7 +52,7 @@ fn parse_unicode(input: Span<'_>) -> IResult<'_, char> {
     trace("parse_unicode", |input| {
         let parse_hex = take_while(1..=6, |c: char| c.is_ascii_hexdigit());
         let parse_delimited_hex = preceded('u', delimited('{', parse_hex, '}'));
-        let parse_u32 = parse_delimited_hex.map_res(|hex| u32::from_str_radix(hex, 16));
+        let parse_u32 = parse_delimited_hex.try_map(|hex| u32::from_str_radix(hex, 16));
         run_str_parser(parse_u32.verify_map(std::char::from_u32)).parse_next(input)
     })
     .parse_next(input)

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use winnow::{
     branch::alt,
     bytes::{take_till1, take_while_m_n},
-    combinator::{map_res, value},
+    combinator::value,
     multi::fold_many0,
     sequence::{delimited, preceded},
     stream::SliceLen,
@@ -55,7 +55,7 @@ fn parse_unicode(input: Span<'_>) -> IResult<'_, char> {
     trace("parse_unicode", |input| {
         let parse_hex = take_while_m_n(1, 6, |c: char| c.is_ascii_hexdigit());
         let parse_delimited_hex = preceded('u', delimited('{', parse_hex, '}'));
-        let parse_u32 = map_res(parse_delimited_hex, |hex| u32::from_str_radix(hex, 16));
+        let parse_u32 = parse_delimited_hex.map_res(|hex| u32::from_str_radix(hex, 16));
         run_str_parser(parse_u32.verify_map(std::char::from_u32)).parse_next(input)
     })
     .parse_next(input)

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -10,7 +10,7 @@ use winnow::{
     combinator::{alt, delimited, fold_repeat, preceded},
     stream::SliceLen,
     stream::Stream,
-    token::{take_till1, take_while},
+    token::{take_till, take_while},
     trace::trace,
     unpeek, Parser,
 };
@@ -117,7 +117,7 @@ fn parse_literal<'i>(input: Span<'i>) -> IResult<'i, &str> {
     trace(
         "parse_literal",
         unpeek(|input: Span<'i>| {
-            let not_quote_slash = take_till1((',', ')', '\\'));
+            let not_quote_slash = take_till(1.., (',', ')', '\\'));
             let res = not_quote_slash
                 .verify(|s: &str| !s.is_empty())
                 .parse_peek(input.clone());

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -8,8 +8,7 @@ use crate::errors::ParseSingleError;
 use std::fmt;
 use winnow::{
     branch::alt,
-    bytes::{take_till1, take_while_m_n},
-    combinator::value,
+    bytes::{one_of, take_till1, take_while_m_n},
     multi::fold_many0,
     sequence::{delimited, preceded},
     stream::SliceLen,
@@ -65,15 +64,15 @@ fn parse_escaped_char(input: Span<'_>) -> IResult<'_, Option<char>> {
     trace("parse_escaped_char", |input| {
         let valid = alt((
             parse_unicode,
-            value('\n', 'n'),
-            value('\r', 'r'),
-            value('\t', 't'),
-            value('\u{08}', 'b'),
-            value('\u{0C}', 'f'),
-            value('\\', '\\'),
-            value('/', '/'),
-            value(')', ')'),
-            value(',', ','),
+            one_of('n').value('\n'),
+            one_of('r').value('\r'),
+            one_of('t').value('\t'),
+            one_of('b').value('\u{08}'),
+            one_of('f').value('\u{0C}'),
+            one_of('\\').value('\\'),
+            one_of('/').value('/'),
+            one_of(')').value(')'),
+            one_of(',').value(','),
         ));
         preceded(
             '\\',

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -10,7 +10,7 @@ use winnow::{
     combinator::{alt, delimited, fold_repeat, preceded},
     stream::SliceLen,
     stream::Stream,
-    token::{one_of, take_till1, take_while},
+    token::{take_till1, take_while},
     trace::trace,
     Parser,
 };
@@ -62,15 +62,15 @@ fn parse_escaped_char(input: Span<'_>) -> IResult<'_, Option<char>> {
     trace("parse_escaped_char", |input| {
         let valid = alt((
             parse_unicode,
-            one_of('n').value('\n'),
-            one_of('r').value('\r'),
-            one_of('t').value('\t'),
-            one_of('b').value('\u{08}'),
-            one_of('f').value('\u{0C}'),
-            one_of('\\').value('\\'),
-            one_of('/').value('/'),
-            one_of(')').value(')'),
-            one_of(',').value(','),
+            'n'.value('\n'),
+            'r'.value('\r'),
+            't'.value('\t'),
+            'b'.value('\u{08}'),
+            'f'.value('\u{0C}'),
+            '\\'.value('\\'),
+            '/'.value('/'),
+            ')'.value(')'),
+            ','.value(','),
         ));
         preceded(
             '\\',

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use winnow::{
     branch::alt,
     bytes::{take_till1, take_while_m_n},
-    combinator::{map, map_opt, map_res, value, verify},
+    combinator::{map, map_opt, map_res, value},
     multi::fold_many0,
     sequence::{delimited, preceded},
     stream::SliceLen,
@@ -110,7 +110,9 @@ impl fmt::Display for DisplayParsedString<'_> {
 fn parse_literal<'i>(input: Span<'i>) -> IResult<'i, &str> {
     trace("parse_literal", |input: Span<'i>| {
         let not_quote_slash = take_till1(",)\\");
-        let res = verify(not_quote_slash, |s: &str| !s.is_empty())(input.clone());
+        let res = not_quote_slash
+            .verify(|s: &str| !s.is_empty())
+            .parse_next(input.clone());
         res
     })
     .parse_next(input)

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -7,8 +7,7 @@ use super::{expect_n, IResult, Span, SpanLength};
 use crate::errors::ParseSingleError;
 use std::fmt;
 use winnow::{
-    combinator::{alt, delimited, preceded},
-    multi::fold_many0,
+    combinator::{alt, delimited, fold_repeat, preceded},
     stream::SliceLen,
     stream::Stream,
     token::{one_of, take_till1, take_while},
@@ -140,7 +139,8 @@ fn parse_fragment(input: Span<'_>) -> IResult<'_, Option<StringFragment<'_>>> {
 pub(super) fn parse_string(input: Span<'_>) -> IResult<'_, Option<String>> {
     trace(
         "parse_string",
-        fold_many0(
+        fold_repeat(
+            0..,
             parse_fragment,
             || Some(String::new()),
             |string, fragment| {

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -25,7 +25,7 @@ futures-sink = { version = "0.3.30", default-features = false, features = ["std"
 getrandom = { version = "0.2.11", default-features = false, features = ["std"] }
 indexmap = { version = "2.1.0", features = ["serde"] }
 log = { version = "0.4.20", default-features = false, features = ["std"] }
-memchr = { version = "2.7.1", features = ["use_std"] }
+memchr = { version = "2.7.1" }
 miette = { version = "5.10.0", features = ["fancy"] }
 num-traits = { version = "0.2.17", default-features = false, features = ["libm", "std"] }
 owo-colors = { version = "4.0.0", default-features = false, features = ["supports-colors"] }


### PR DESCRIPTION
@sunshowers expressed interest in `winnow` and I figured porting an existing project they were familiar with would make it easier when they try it out.

When i first switched from `nom`s pure `Fn(I) -> (I, O)` parser model to `Fn(&mut I) -> O`, I was concerned about it making things worse.  It does have the downside of requiring more lifetime annotations to disambiguate things but I feel like it has been proven time and again to simplify code.  In this case, it removed a lot of bookkeeping from the functions, making the intentional bookkeeping more obvious, and it allowed the removal of `RefCell` for error recovery.

I broke this up into a lot of commits
- Smaller nuggets to review
- Easier to call out the differences
- Easier for me to deal with merge conflicts.

I did put a little too much in the `unpeek`-ectomy commit towards the end.  The main downside is that we can't `git bisect` to one specific bookkeeping change.

I did this as 1 PR though because the decision to commit to this is all-or-nothing.