### PR TITLE
[meta] bump MSRV to Rust 1.73

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,8 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        # 1.70 is the MSRV
-        rust-version: [ "1.70", stable ]
+        # 1.73 is the MSRV
+        rust-version: [ "1.73", stable ]
       fail-fast: false
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ members = [
   "workspace-hack",
 ]
 
+[workspace.package]
+rust-version = "1.73"
+
 [workspace.dependencies]
 bstr = { version = "1.9.0", default-features = false, features = ["std"] }
 globset = "0.4.14"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This repository contains the source code for:
 
 The minimum supported Rust version to *run* nextest with is **Rust 1.38.** Nextest is not tested against versions that are that old, but it should work with any version of Rust released in the past year. (Please report a bug if not!)
 
-The minimum supported Rust version to *build* nextest with is **Rust 1.70.** For building, at least the last 3 versions of stable Rust are supported at any given time.
+The minimum supported Rust version to *build* nextest with is **Rust 1.73.** For building, at least the last 3 versions of stable Rust are supported at any given time.
 
 See the [stability policy](https://nexte.st/book/stability) for more details.
 

--- a/cargo-nextest/Cargo.toml
+++ b/cargo-nextest/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://nexte.st"
 keywords = ["nextest", "test-runner", "flaky-tests", "junit"]
 categories = ["development-tools::cargo-plugins", "development-tools::testing"]
 edition = "2021"
-rust-version = "1.70"
+rust-version.workspace = true
 
 [dependencies]
 camino = "1.1.6"

--- a/fixtures/nextest-tests/Cargo.toml
+++ b/fixtures/nextest-tests/Cargo.toml
@@ -40,10 +40,10 @@ members = [
 dylib-test = { path = "dylib-test" }
 uuid = "1.2.1"
 
-# TODO: Introduce this test (regarding #910) once the MSRV is Rust 1.70.
-# [profile.dev]
-# debug = 1
+# Test that the "line-tables-only" debug setting works.
+[profile.dev]
+debug = 1
 
-# [profile.dev-line-tables-only]
-# inherits = "dev"
-# debug = "line-tables-only"
+[profile.dev-line-tables-only]
+inherits = "dev"
+debug = "line-tables-only"

--- a/nextest-filtering/CHANGELOG.md
+++ b/nextest-filtering/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- MSRV updated to Rust 1.73.
+
 ## [0.7.1] - 2024-01-09
 
 ### Fixed

--- a/nextest-filtering/Cargo.toml
+++ b/nextest-filtering/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/nextest-rs/nextest"
 documentation = "https://docs.rs/nextest-filtering"
 keywords = ["nextest", "test-runner"]
 categories = ["development-tools::testing"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [[bin]]
 name = "generate-expr-corpus"

--- a/nextest-metadata/CHANGELOG.md
+++ b/nextest-metadata/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- MSRV updated to Rust 1.73.
+
 ## [0.10.0] - 2023-12-09
 
 ### Added

--- a/nextest-metadata/Cargo.toml
+++ b/nextest-metadata/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/nextest-rs/nextest"
 documentation = "https://docs.rs/nextest-metadata"
 keywords = ["nextest", "test-runner"]
 categories = ["development-tools::testing"]
-rust-version = "1.70"
+rust-version.workspace = true
 
 [dependencies]
 camino = { version = "1.1.6", features = ["serde1"] }

--- a/nextest-metadata/README.md
+++ b/nextest-metadata/README.md
@@ -32,7 +32,7 @@ println!("{:?}", test_list);
 
 ## Minimum supported Rust version (MSRV)
 
-The minimum supported Rust version is **Rust 1.70.**
+The minimum supported Rust version is **Rust 1.73.**
 
 While this crate is a pre-release (0.x.x) it may have its MSRV bumped in a patch release.
 Once a crate has reached 1.x, any MSRV bump will be accompanied with a new minor version.

--- a/nextest-metadata/src/lib.rs
+++ b/nextest-metadata/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! # Minimum supported Rust version (MSRV)
 //!
-//! The minimum supported Rust version is **Rust 1.70.**
+//! The minimum supported Rust version is **Rust 1.73.**
 //!
 //! While this crate is a pre-release (0.x.x) it may have its MSRV bumped in a patch release.
 //! Once a crate has reached 1.x, any MSRV bump will be accompanied with a new minor version.

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/nextest-rs/nextest"
 documentation = "https://docs.rs/nextest-runner"
 edition = "2021"
-rust-version = "1.70"
+rust-version.workspace = true
 # For an example build script that gates by compiler version, see the history for build.rs in this
 # directory.
 

--- a/quick-junit/CHANGELOG.md
+++ b/quick-junit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- MSRV updated to Rust 1.73.
+
 ## [0.3.5] - 2023-10-27
 
 ### Fixed

--- a/quick-junit/Cargo.toml
+++ b/quick-junit/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/quick-junit"
 keywords = ["junit", "xunit", "xml", "serializer", "flaky-tests"]
 categories = ["encoding", "development-tools"]
 edition = "2021"
-rust-version = "1.70"
+rust-version.workspace = true
 
 [dependencies]
 chrono = { version = "0.4.32", default-features = false, features = ["std"] }

--- a/quick-junit/README.md
+++ b/quick-junit/README.md
@@ -65,7 +65,7 @@ For a more comprehensive example, including reruns and flaky tests, see
 
 ## Minimum supported Rust version (MSRV)
 
-The minimum supported Rust version is **Rust 1.70.**
+The minimum supported Rust version is **Rust 1.73.**
 
 While this crate is a pre-release (0.x.x) it may have its MSRV bumped in a patch release.
 Once a crate has reached 1.x, any MSRV bump will be accompanied with a new minor version.

--- a/quick-junit/src/lib.rs
+++ b/quick-junit/src/lib.rs
@@ -61,7 +61,7 @@
 //!
 //! # Minimum supported Rust version (MSRV)
 //!
-//! The minimum supported Rust version is **Rust 1.70.**
+//! The minimum supported Rust version is **Rust 1.73.**
 //!
 //! While this crate is a pre-release (0.x.x) it may have its MSRV bumped in a patch release.
 //! Once a crate has reached 1.x, any MSRV bump will be accompanied with a new minor version.

--- a/site/src/book/installing-from-source.md
+++ b/site/src/book/installing-from-source.md
@@ -12,7 +12,7 @@ cargo install cargo-nextest --locked
 
 > **Note:** A plain `cargo install cargo-nextest` without `--locked` is **not supported**. If you run into build issues, please try with `--locked` before reporting an issue.
 
-`cargo nextest` must be compiled and installed with **Rust 1.70** or later (see [Stability policy] for more), but it can build and run
+`cargo nextest` must be compiled and installed with **Rust 1.73** or later (see [Stability policy] for more), but it can build and run
 tests against any version of Rust.
 
 [Stability policy]: stability.md#minimum-supported-rust-version-msrv


### PR DESCRIPTION
Some dependencies are starting to require newer versions of Rust, and this matches our stability guarantee.