### PR TITLE
Update to Winnow 0.5.36

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3717,9 +3717,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.35"
+version = "0.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1931d78a9c73861da0134f453bb1f790ce49b2e30eba8410b4b79bac72b46a2d"
+checksum = "818ce546a11a9986bc24f93d0cdf38a8a1a400f1473ea8c82e59f6e0ffab9249"
 dependencies = [
  "memchr",
 ]

--- a/nextest-filtering/Cargo.toml
+++ b/nextest-filtering/Cargo.toml
@@ -38,7 +38,7 @@ proptest = { version = "1.4.0", optional = true }
 test-strategy = { version = "0.3.1", optional = true }
 xxhash-rust = { version = "0.8.8", features = ["xxh3"], optional = true }
 nextest-workspace-hack.workspace = true
-winnow = "0.5.35"
+winnow = "0.5.36"
 
 [dev-dependencies]
 clap = { version = "4.4.18", features = ["derive"] }

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -7,7 +7,7 @@ use super::{expect_n, PResult, Span, SpanLength};
 use crate::errors::ParseSingleError;
 use std::fmt;
 use winnow::{
-    combinator::{alt, delimited, fold_repeat, preceded, trace},
+    combinator::{alt, delimited, preceded, repeat, trace},
     token::{take_till, take_while},
     Parser,
 };
@@ -103,9 +103,7 @@ fn parse_fragment<'i>(input: &mut Span<'i>) -> PResult<Option<StringFragment<'i>
 pub(super) fn parse_string(input: &mut Span<'_>) -> PResult<Option<String>> {
     trace(
         "parse_string",
-        fold_repeat(
-            0..,
-            parse_fragment,
+        repeat(0.., parse_fragment).fold(
             || Some(String::new()),
             |string, fragment| {
                 match (string, fragment) {


### PR DESCRIPTION
This resolves a couple of deprecations.  I'm thinking of doing 0.6 soon and I expect this to be the end of the deprecations that will happen in the lead up.  So for people on 0.5.36 with all deprecations resolved, i expect it to be a trivial version bump to 0.6 for most people.