### PR TITLE
Add archive-include config

### DIFF
--- a/nextest-runner/default-config.toml
+++ b/nextest-runner/default-config.toml
@@ -85,6 +85,20 @@ slow-timeout = { period = "60s" }
 # See <https://nexte.st/book/leaky-tests> for more information.
 leak-timeout = "100ms"
 
+# `nextest archive` automatically includes any build output required by a standard build.
+# However sometimes extra non-standard files are required.
+# To address this "archive-include" specifies additional paths that will be included in the archive.
+archive-include = [
+    # Examples:
+    #
+    # { path = "application-data", relative-to = "target" },
+    # { path = "data-from-some-dependency/file.txt", relative-to = "target" },
+    #
+    # In the above example:
+    # * the directory and its contents at "target/application-data" will be included recursively in the archive.
+    # * the file "target/data-from-some-dependency/file.txt" will be included in the archive.
+]
+
 [profile.default.junit]
 # Output a JUnit report into the given file inside 'store.dir/<profile-name>'.
 # If unspecified, JUnit is not written out.

--- a/nextest-runner/src/config/archive_include.rs
+++ b/nextest-runner/src/config/archive_include.rs
@@ -1,0 +1,199 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use camino::Utf8PathBuf;
+use serde::Deserialize;
+
+/// Type for the archive-include key.
+///
+/// # Notes
+///
+/// This is `deny_unknown_fields` because if we take additional arguments in the future, they're
+/// likely to change semantics in an incompatible way.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct ArchiveInclude {
+    pub(crate) path: Utf8PathBuf,
+    pub(crate) relative_to: ArchiveRelativeTo,
+}
+
+/// Defines the base of the path
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum ArchiveRelativeTo {
+    /// Path starts at the target directory
+    Target,
+    // TODO: add support for profile relative
+    //TargetProfile,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        config::{
+            test_helpers::{build_platforms, temp_workspace},
+            NextestConfig,
+        },
+        errors::ConfigParseErrorKind,
+    };
+    use camino::Utf8Path;
+    use camino_tempfile::tempdir;
+    use config::ConfigError;
+    use indoc::indoc;
+    use test_case::test_case;
+
+    #[test]
+    fn parse_valid() {
+        let config_contents = indoc! {r#"
+            [profile.default]
+            archive-include = [
+                { path = "foo", relative-to = "target" },
+                { path = "bar", relative-to = "target" },
+            ]
+
+            [profile.profile1]
+            archive-include = [
+                { path = "baz", relative-to = "target" },
+            ]
+
+            [profile.profile2]
+            archive-include = []
+
+            [profile.profile3]
+        "#};
+
+        let workspace_dir = tempdir().unwrap();
+
+        let graph = temp_workspace(workspace_dir.path(), config_contents);
+
+        let config = NextestConfig::from_sources(
+            graph.workspace().root(),
+            &graph,
+            None,
+            [],
+            &Default::default(),
+        )
+        .expect("config is valid");
+        assert_eq!(
+            config
+                .profile("default")
+                .expect("default profile exists")
+                .apply_build_platforms(&build_platforms())
+                .archive_include(),
+            &vec![
+                ArchiveInclude {
+                    path: "foo".into(),
+                    relative_to: ArchiveRelativeTo::Target
+                },
+                ArchiveInclude {
+                    path: "bar".into(),
+                    relative_to: ArchiveRelativeTo::Target
+                }
+            ],
+            "default matches"
+        );
+
+        assert_eq!(
+            config
+                .profile("profile1")
+                .expect("profile exists")
+                .apply_build_platforms(&build_platforms())
+                .archive_include(),
+            &vec![ArchiveInclude {
+                path: "baz".into(),
+                relative_to: ArchiveRelativeTo::Target
+            }],
+            "profile1 matches"
+        );
+
+        assert_eq!(
+            config
+                .profile("profile2")
+                .expect("default profile exists")
+                .apply_build_platforms(&build_platforms())
+                .archive_include(),
+            &vec![],
+            "profile2 matches"
+        );
+
+        assert_eq!(
+            config
+                .profile("profile3")
+                .expect("default profile exists")
+                .apply_build_platforms(&build_platforms())
+                .archive_include(),
+            &vec![
+                ArchiveInclude {
+                    path: "foo".into(),
+                    relative_to: ArchiveRelativeTo::Target
+                },
+                ArchiveInclude {
+                    path: "bar".into(),
+                    relative_to: ArchiveRelativeTo::Target
+                }
+            ],
+            "profile3 matches"
+        );
+    }
+
+    #[test_case(
+        indoc!{r#"
+            [profile.default]
+            archive-include = { path = "foo", relative-to = "target" }
+        "#},
+        r#"invalid type: map, expected a sequence"#
+        ; "missing list")]
+    #[test_case(
+        indoc!{r#"
+            [profile.default]
+            archive-include = [
+                { path = "foo" }
+            ]
+        "#},
+        r#"missing field `relative-to`"#
+        ; "missing relative-to")]
+    #[test_case(
+        indoc!{r#"
+            [profile.default]
+            archive-include = [
+                { path = "bar", relative-to = "unknown" }
+            ]
+        "#},
+        r#"enum ArchiveRelativeTo does not have variant constructor unknown"#
+        ; "invalid relative-to")]
+    fn parse_invalid(config_contents: &str, expected_message: &str) {
+        let workspace_dir = tempdir().unwrap();
+        let workspace_path: &Utf8Path = workspace_dir.path();
+
+        let graph = temp_workspace(workspace_path, config_contents);
+
+        let config_err = NextestConfig::from_sources(
+            graph.workspace().root(),
+            &graph,
+            None,
+            [],
+            &Default::default(),
+        )
+        .expect_err("config expected to be invalid");
+
+        let message = match config_err.kind() {
+            ConfigParseErrorKind::DeserializeError(path_error) => match path_error.inner() {
+                ConfigError::Message(message) => message,
+                other => {
+                    panic!("for config error {config_err:?}, expected ConfigError::Message for inner error {other:?}");
+                }
+            },
+            other => {
+                panic!(
+                    "for config error {other:?}, expected ConfigParseErrorKind::DeserializeError"
+                );
+            }
+        };
+
+        assert!(
+            message.contains(expected_message),
+            "expected message: {expected_message}\nactual message: {message}"
+        );
+    }
+}

--- a/nextest-runner/src/config/config_impl.rs
+++ b/nextest-runner/src/config/config_impl.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use super::{
-    CompiledByProfile, CompiledData, ConfigExperimental, CustomTestGroup, DeserializedOverride,
-    DeserializedProfileScriptConfig, NextestVersionDeserialize, RetryPolicy, ScriptConfig,
-    ScriptId, SettingSource, SetupScripts, SlowTimeout, TestGroup, TestGroupConfig, TestSettings,
-    TestThreads, ThreadsRequired, ToolConfigFile,
+    ArchiveInclude, CompiledByProfile, CompiledData, ConfigExperimental, CustomTestGroup,
+    DeserializedOverride, DeserializedProfileScriptConfig, NextestVersionDeserialize, RetryPolicy,
+    ScriptConfig, ScriptId, SettingSource, SetupScripts, SlowTimeout, TestGroup, TestGroupConfig,
+    TestSettings, TestThreads, ThreadsRequired, ToolConfigFile,
 };
 use crate::{
     errors::{
@@ -702,6 +702,13 @@ impl<'cfg> NextestProfile<'cfg, FinalConfig> {
             .unwrap_or(self.default_profile.fail_fast)
     }
 
+    /// Returns the archive-include config for this profile.
+    pub fn archive_include(&self) -> &[ArchiveInclude] {
+        self.custom_profile
+            .and_then(|profile| profile.archive_include.as_ref())
+            .unwrap_or(&self.default_profile.archive_include)
+    }
+
     /// Returns the list of setup scripts.
     pub fn setup_scripts(&self, test_list: &TestList<'_>) -> SetupScripts<'_> {
         SetupScripts::new(self, test_list)
@@ -885,6 +892,7 @@ pub(super) struct DefaultProfileImpl {
     overrides: Vec<DeserializedOverride>,
     scripts: Vec<DeserializedProfileScriptConfig>,
     junit: DefaultJunitImpl,
+    archive_include: Vec<ArchiveInclude>,
 }
 
 impl DefaultProfileImpl {
@@ -933,6 +941,9 @@ impl DefaultProfileImpl {
                     .store_failure_output
                     .expect("junit.store-failure-output present in default profile"),
             },
+            archive_include: p
+                .archive_include
+                .expect("archive_include present in default profile"),
         }
     }
 
@@ -982,6 +993,8 @@ pub(super) struct CustomProfileImpl {
     scripts: Vec<DeserializedProfileScriptConfig>,
     #[serde(default)]
     junit: JunitImpl,
+    #[serde(default)]
+    archive_include: Option<Vec<ArchiveInclude>>,
 }
 
 #[allow(dead_code)]

--- a/nextest-runner/src/config/mod.rs
+++ b/nextest-runner/src/config/mod.rs
@@ -3,6 +3,7 @@
 
 //! Configuration support for nextest.
 
+mod archive_include;
 mod config_impl;
 mod identifier;
 mod nextest_version;
@@ -15,6 +16,7 @@ mod test_threads;
 mod threads_required;
 mod tool_config;
 
+pub use archive_include::*;
 pub use config_impl::*;
 pub use identifier::*;
 pub use nextest_version::*;


### PR DESCRIPTION
Progress towards https://github.com/nextest-rs/nextest/issues/1340

This PR implements the design given by rain in https://github.com/nextest-rs/nextest/issues/1340#issuecomment-1972163611
However it only implements the smallest possible functionality that will the allow the full design to be implemented in a backwards compatible manner in the future.
This is because I would like to land a small part of the design to ensure I am on track and also because I cant afford the time to implement all of these features right now.

The full implementation will look like:
```toml
[profile.ci]
archive-include = [
    { path = "foo", relative-to = "target" },
    { path = "bar/*", relative-to = "target-profile" },
]
```

However this PR's config will only support:
```toml
[profile.ci]
archive-include = [
    { path = "foo", relative-to = "target" },
    { path = "bar", relative-to = "target" },
]
```
This leaves the following features for follow up work:
* `relative-to = "target-profile"`
    + This can easily be introduced later.
    + For now, the user can also set `{ path = "debug/foo", relative-to = "target" }, { path = "release/foo", relative-to = "target" }` for a hacky work around.
* `*` globbing
    + while adding it later would technically be a breaking change since `*` can be included in a valid file name on linux. Using `*` in file names is generally considered a very bad idea, so I'm not worried about breakage here. I am however happy to include globbing support in this PR if such breakage is unacceptable.

## `optional` config

It was also stated that by default the `nextest archive` command should fail when the path to include does not exist.
I considered the positives and negatives of this versus just ignoring missing paths:
* Positives
    + Will give slightly better diagnostics to what went wrong if they enter the wrong path
       + I dont believe this will be a huge improvement, since the user has already diagnosed that there is something missing from their archived target that they need to configure nextest to pick up. So if after configuring nextest to include the path they get the same issue due to missing artifacts, they will naturally inspect the archive and config to find out what is going wrong.
    + Will catch paths that no longer need to be included and can be removed from the config.
* Negatives
   + Will cause archiving to unexpectedly fail in these scenarios:
        - nextest config is workspace wide and only a single crate produces the build artifact
        - When a crate or its dependency is designed to only output the build artifact in only some cases.

Ultimately the negatives are not huge issues since adding `optional = true` is not that hard, its mostly just that it feels `optional = true` is the more reasonable default at which point having it configurable seems less valuable.
In conclusion, I dont know which is better, so I've taken the simpler option of not implementing the `optional` config, but just confirm that you do want fail by default and I'll go ahead and implement it in this PR.

## Questions

* Am I expected to implement custom diagnostics for the ArchiveInclude deserialization
* should append_path_recursive be given an optional recursion depth so it can be used instead of append_dir_one_level?
* Is there any extra documentation I need to add? Or is the automatically generated page at https://nexte.st/book/configuration.html sufficient?