### PR TITLE
Have Miri use all the cores by default

### DIFF
--- a/nextest-runner/default-config.toml
+++ b/nextest-runner/default-config.toml
@@ -109,5 +109,3 @@ store-failure-output = true
 
 # This profile is activated if MIRI_SYSROOT is set.
 [profile.default-miri]
-# Miri tests take up a lot of memory, so only run 1 test at a time by default.
-test-threads = 1


### PR DESCRIPTION
I think this is all that's needed? Quite a slick system if so.
Closes https://github.com/nextest-rs/nextest/issues/1346