### PR TITLE
[nextest-runner] add option hide-progress-bar to configuration file

### DIFF
--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -878,7 +878,10 @@ impl TestReporterOpts {
         if let Some(final_status_level) = self.final_status_level {
             builder.set_final_status_level(final_status_level.into());
         }
-        builder.set_hide_progress_bar(self.hide_progress_bar);
+        match self.hide_progress_bar {
+            true => builder.set_hide_progress_bar(Some(true)),
+            false => builder.set_hide_progress_bar(None),
+        };
         builder
     }
 }

--- a/nextest-runner/default-config.toml
+++ b/nextest-runner/default-config.toml
@@ -67,6 +67,10 @@ success-output = "never"
 # to false.
 fail-fast = true
 
+# Hide the progress bar when running tests. For CI runs, consider setting this
+# to true
+hide-progress-bar = false
+
 # Treat a test that takes longer than the configured 'period' as slow, and print a message.
 # See <https://nexte.st/book/slow-tests> for more information.
 #

--- a/nextest-runner/src/config/config_impl.rs
+++ b/nextest-runner/src/config/config_impl.rs
@@ -702,6 +702,13 @@ impl<'cfg> NextestProfile<'cfg, FinalConfig> {
             .unwrap_or(self.default_profile.fail_fast)
     }
 
+    /// Returns the hide-progress-bar config for this profile.
+    pub fn hide_progress_bar(&self) -> bool {
+        self.custom_profile
+            .and_then(|profile| profile.hide_progress_bar)
+            .unwrap_or(self.default_profile.hide_progress_bar)
+    }
+
     /// Returns the list of setup scripts.
     pub fn setup_scripts(&self, test_list: &TestList<'_>) -> SetupScripts<'_> {
         SetupScripts::new(self, test_list)
@@ -880,6 +887,7 @@ pub(super) struct DefaultProfileImpl {
     failure_output: TestOutputDisplay,
     success_output: TestOutputDisplay,
     fail_fast: bool,
+    hide_progress_bar: bool,
     slow_timeout: SlowTimeout,
     leak_timeout: Duration,
     overrides: Vec<DeserializedOverride>,
@@ -910,6 +918,9 @@ impl DefaultProfileImpl {
                 .success_output
                 .expect("success-output present in default profile"),
             fail_fast: p.fail_fast.expect("fail-fast present in default profile"),
+            hide_progress_bar: p
+                .hide_progress_bar
+                .expect("hide-progress-bar present in default profile"),
             slow_timeout: p
                 .slow_timeout
                 .expect("slow-timeout present in default profile"),
@@ -972,6 +983,8 @@ pub(super) struct CustomProfileImpl {
     success_output: Option<TestOutputDisplay>,
     #[serde(default)]
     fail_fast: Option<bool>,
+    #[serde(default)]
+    hide_progress_bar: Option<bool>,
     #[serde(default, deserialize_with = "super::deserialize_slow_timeout")]
     slow_timeout: Option<SlowTimeout>,
     #[serde(default, with = "humantime_serde::option")]

--- a/nextest-runner/src/reporter.rs
+++ b/nextest-runner/src/reporter.rs
@@ -168,9 +168,8 @@ pub struct TestReporterBuilder {
     success_output: Option<TestOutputDisplay>,
     status_level: Option<StatusLevel>,
     final_status_level: Option<FinalStatusLevel>,
-
     verbose: bool,
-    hide_progress_bar: bool,
+    hide_progress_bar: Option<bool>,
 }
 
 impl TestReporterBuilder {
@@ -215,7 +214,7 @@ impl TestReporterBuilder {
 
     /// Sets visibility of the progress bar.
     /// The progress bar is also hidden if `no_capture` is set.
-    pub fn set_hide_progress_bar(&mut self, hide_progress_bar: bool) -> &mut Self {
+    pub fn set_hide_progress_bar(&mut self, hide_progress_bar: Option<bool>) -> &mut Self {
         self.hide_progress_bar = hide_progress_bar;
         self
     }
@@ -250,6 +249,10 @@ impl TestReporterBuilder {
             .final_status_level
             .unwrap_or_else(|| profile.final_status_level());
 
+        let hide_progress_bar = self
+            .hide_progress_bar
+            .unwrap_or_else(|| profile.hide_progress_bar());
+
         // failure_output and success_output are meaningless if the runner isn't capturing any
         // output.
         let force_success_output = match self.no_capture {
@@ -278,9 +281,7 @@ impl TestReporterBuilder {
                 // in these environments.
                 ReporterStderrImpl::TerminalWithoutBar
             }
-            ReporterStderr::Terminal if self.hide_progress_bar => {
-                ReporterStderrImpl::TerminalWithoutBar
-            }
+            ReporterStderr::Terminal if hide_progress_bar => ReporterStderrImpl::TerminalWithoutBar,
 
             ReporterStderr::Terminal => {
                 let progress_bar = ProgressBar::new(test_list.test_count() as u64);


### PR DESCRIPTION
While configuring nextest for my own projects, I noticed that I couldn't control display of the progress bar from the `.config/nextest.toml` file and I would have to manually run the command with `--hide-progress-bar` every time, which didn't feel very intuitive.

This commit is here to fix this.