### PR TITLE
[nextest-runner] archive and reuse stdlibs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,22 @@ jobs:
           NEXTEST_DOUBLE_SPAWN: 0
         run: cargo local-nt run --profile ci
 
+      - name: Test without rustup wrappers
+        env:
+          CARGO_NEXTEST: target/debug/cargo-nextest
+          RUSTUP_AVAILABLE: 1
+        shell: bash
+        run: ./scripts/nextest-without-rustup.sh run --profile ci
+
+      - name: Upload nextest binary
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: cargo-nextest-${{ matrix.os }}-${{ matrix.rust-version }}
+          path: |
+            target/debug/cargo-nextest
+            target/debug/cargo-nextest.exe
+          if-no-files-found: error
+
   test-archive-target-runner:
     name: Test archives with a target runner
     # gcc-mingw-w64-x86-64-win32 requires Ubuntu 22.04
@@ -128,11 +144,83 @@ jobs:
       - name: Build cargo-nextest
         run: cargo build --package cargo-nextest
       - name: Archive test fixtures
+        env:
+          CARGO_NEXTEST: target/debug/cargo-nextest
+          RUSTUP_AVAILABLE: 1
         run: |
-          cargo local-nt archive --manifest-path fixtures/nextest-tests/Cargo.toml \
+          ./scripts/nextest-without-rustup.sh archive --manifest-path fixtures/nextest-tests/Cargo.toml \
             --target x86_64-pc-windows-gnu --archive-file target/fixture-archive.tar.zst \
             --package cdylib-example --package nextest-derive
+
+      # This ensures that for target binaries, we always use the libdir in the archive, never the
+      # one installed by rustup.
+      - name: Remove x86_64-pc-windows-gnu target from rustup
+        run: rustup target remove x86_64-pc-windows-gnu
+
       - name: Run test fixtures
         env:
           CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUNNER: wine
         run: cargo local-nt run --archive-file target/fixture-archive.tar.zst
+
+      # Completely uninstall rustup -- this is similar to running an archive on a machine without
+      # cargo.
+      - name: Uninstall rustup
+        run: rustup self uninstall -y
+
+      - name: Run test fixtures without rustup wrappers
+        env:
+          CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUNNER: wine
+          CARGO_NEXTEST: target/debug/cargo-nextest
+        run: ./scripts/nextest-without-rustup.sh run --archive-file target/fixture-archive.tar.zst
+
+      # Upload the archive for use in the next job.
+      - name: Upload archive
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: fixture-archive
+          path: target/fixture-archive.tar.zst
+          if-no-files-found: error
+
+  test-archive-runner-dest:
+    name: Test archives with a runner (destination)
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    needs:
+      - test-archive-target-runner
+      - build
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+      - name: Download nextest binary
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          name: cargo-nextest-${{ matrix.os }}-stable
+          path: nextest-bin
+      - name: Download archive
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          name: fixture-archive
+          path: fixture-archive
+      - name: Run test fixtures (host)
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        env:
+          CARGO_NEXTEST: nextest-bin/cargo-nextest
+        run: |
+          chmod +x $CARGO_NEXTEST
+          ./scripts/nextest-without-rustup.sh run \
+            --archive-file fixture-archive/fixture-archive.tar.zst \
+            --workspace-remap $GITHUB_WORKSPACE/fixtures/nextest-tests \
+            -E 'platform(host)'
+      - name: Run test fixtures (target)
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: bash
+        env:
+          CARGO_NEXTEST: nextest-bin/cargo-nextest.exe
+        run: |
+          ./scripts/nextest-without-rustup.sh run \
+            --archive-file fixture-archive/fixture-archive.tar.zst \
+            --workspace-remap $GITHUB_WORKSPACE/fixtures/nextest-tests \
+            -E 'platform(target)'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,9 +1440,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libm"

--- a/cargo-nextest/src/reuse_build.rs
+++ b/cargo-nextest/src/reuse_build.rs
@@ -213,6 +213,7 @@ pub(crate) fn make_path_mapper(
         info.workspace_remap(),
         orig_target_dir,
         info.target_dir_remap(),
+        info.libdir_mapper.clone(),
     )
     .map_err(|err| {
         let arg_name = match err.kind() {

--- a/fixtures/nextest-tests/tests/basic.rs
+++ b/fixtures/nextest-tests/tests/basic.rs
@@ -144,8 +144,11 @@ fn test_cargo_env_vars() {
         Ok("process-per-test"),
         "NEXTEST_EXECUTION_MODE set to process-per-test"
     );
+
     // https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
-    assert_env!("CARGO");
+
+    // Note: we do not test CARGO here because nextest does not set it -- it's set by Cargo when
+    // invoked as `cargo nextest`.
     assert_env!(
         "CARGO_MANIFEST_DIR",
         "__NEXTEST_ORIGINAL_CARGO_MANIFEST_DIR"

--- a/integration-tests/tests/integration/snapshots/integration__archive_includes.snap
+++ b/integration-tests/tests/integration/snapshots/integration__archive_includes.snap
@@ -2,7 +2,7 @@
 source: integration-tests/tests/integration/main.rs
 expression: output.stderr_as_str()
 ---
-   Archiving 17 binaries (including 2 non-test binaries), 2 build script output directories, 2 linked paths, and 7 extra paths to <archive-file>
+   Archiving 17 binaries (including 2 non-test binaries), 2 build script output directories, 2 linked paths, 7 extra paths, and 1 standard library to <archive-file>
      Warning ignoring extra path `<target-dir>/excluded-dir` because it does not exist
      Warning ignoring extra path `<target-dir>/depth-0-dir` specified with depth 0 since it is a directory
      Warning ignoring extra path `<target-dir>/file_that_does_not_exist.txt` because it does not exist

--- a/integration-tests/tests/integration/snapshots/integration__archive_includes_without_uds.snap
+++ b/integration-tests/tests/integration/snapshots/integration__archive_includes_without_uds.snap
@@ -2,7 +2,7 @@
 source: integration-tests/tests/integration/main.rs
 expression: output.stderr_as_str()
 ---
-   Archiving 17 binaries (including 2 non-test binaries), 2 build script output directories, 2 linked paths, and 7 extra paths to <archive-file>
+   Archiving 17 binaries (including 2 non-test binaries), 2 build script output directories, 2 linked paths, 7 extra paths, and 1 standard library to <archive-file>
      Warning ignoring extra path `<target-dir>/excluded-dir` because it does not exist
      Warning ignoring extra path `<target-dir>/depth-0-dir` specified with depth 0 since it is a directory
      Warning ignoring extra path `<target-dir>/file_that_does_not_exist.txt` because it does not exist

--- a/integration-tests/tests/integration/snapshots/integration__archive_missing_includes.snap
+++ b/integration-tests/tests/integration/snapshots/integration__archive_missing_includes.snap
@@ -2,7 +2,7 @@
 source: integration-tests/tests/integration/main.rs
 expression: output.stderr_as_str()
 ---
-   Archiving 17 binaries (including 2 non-test binaries), 2 build script output directories, 2 linked paths, and 1 extra path to <archive-file>
+   Archiving 17 binaries (including 2 non-test binaries), 2 build script output directories, 2 linked paths, 1 extra path, and 1 standard library to <archive-file>
 error: error creating archive `<archive-file>`
 
 Caused by:

--- a/integration-tests/tests/integration/snapshots/integration__archive_no_includes.snap
+++ b/integration-tests/tests/integration/snapshots/integration__archive_no_includes.snap
@@ -2,7 +2,7 @@
 source: integration-tests/tests/integration/main.rs
 expression: output.stderr_as_str()
 ---
-   Archiving 17 binaries (including 2 non-test binaries), 2 build script output directories, and 2 linked paths to <archive-file>
+   Archiving 17 binaries (including 2 non-test binaries), 2 build script output directories, 2 linked paths, and 1 standard library to <archive-file>
      Warning linked path `<target-dir>/debug/build/<cdylib-link-hash>/does-not-exist` not found, requested by: cdylib-link v0.1.0
              (this is a bug in this crate that should be fixed)
     Archived <file-count> files to <archive-file> in <duration>

--- a/nextest-metadata/src/test_list.rs
+++ b/nextest-metadata/src/test_list.rs
@@ -590,6 +590,10 @@ impl PlatformLibdirUnavailable {
     /// version of nextest.
     pub const OLD_SUMMARY: Self = Self::new_const("old-summary");
 
+    /// The libdir is unavailable because a build was reused from an archive, and the libdir was not
+    /// present in the archive
+    pub const NOT_IN_ARCHIVE: Self = Self::new_const("not-in-archive");
+
     /// Converts a static string into Self.
     pub const fn new_const(reason: &'static str) -> Self {
         Self(Cow::Borrowed(reason))

--- a/nextest-runner/src/helpers.rs
+++ b/nextest-runner/src/helpers.rs
@@ -62,6 +62,14 @@ pub(crate) mod plural {
             "these crates"
         }
     }
+
+    pub(crate) fn libraries_str(count: usize) -> &'static str {
+        if count == 1 {
+            "library"
+        } else {
+            "libraries"
+        }
+    }
 }
 
 /// Write out a test name.

--- a/nextest-runner/src/list/test_list.rs
+++ b/nextest-runner/src/list/test_list.rs
@@ -234,6 +234,10 @@ impl<'g> TestList<'g> {
         let stream = futures::stream::iter(test_artifacts).map(|test_binary| {
             async {
                 if filter.should_obtain_test_list_from_binary(&test_binary) {
+                    log::debug!(
+                        "executing test binary to obtain test list: {}",
+                        test_binary.binary_id,
+                    );
                     // Run the binary to obtain the test list.
                     let (non_ignored, ignored) = test_binary.exec(&lctx, ctx.target_runner).await?;
                     let (bin, info) = Self::process_output(
@@ -245,6 +249,10 @@ impl<'g> TestList<'g> {
                     Ok::<_, CreateTestListError>((bin, info))
                 } else {
                     // Skipped means no tests, so test_count doesn't need to be modified.
+                    log::debug!(
+                        "skipping test binary because of filters: {}",
+                        test_binary.binary_id,
+                    );
                     Ok(Self::process_skipped(test_binary))
                 }
             }

--- a/scripts/nextest-without-rustup.sh
+++ b/scripts/nextest-without-rustup.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Run tests without rustup or cargo wrappers.
+#
+# Some scenarios involve running tests without rustup or cargo. We can't run `cargo nextest run`
+# directly because it will use the `cargo` wrapper installed by rustup. Instead, we try our best
+# to not use rustup or cargo.
+#
+# * CARGO is set to $(rustup which cargo) to bypass the rustup wrapper.
+# * Nextest is invoked as "cargo-nextest nextest run" rather than "cargo nextest run".
+
+set -e -o pipefail
+
+if [[ $RUSTUP_AVAILABLE -eq 1 ]]; then
+    CARGO="$(rustup which cargo)"
+    RUSTC="$(rustup which rustc)"
+else
+    # These paths should hopefully make it clear that cargo and rustc are not available -- if we try
+    # to run them then they'll fail.
+    CARGO="cargo-unavailable"
+    RUSTC="rustc-unavailable"
+fi
+
+export CARGO RUSTC
+
+export CARGO_NEXTEST=${CARGO_NEXTEST:-"cargo-nextest"}
+
+echo "[nextest-without-rustup] nextest with CARGO_NEXTEST=$CARGO_NEXTEST" >&2
+$CARGO_NEXTEST nextest "$@"

--- a/site/src/book/env-vars.md
+++ b/site/src/book/env-vars.md
@@ -51,7 +51,7 @@ Nextest delegates to Cargo for the build, which controls the environment variabl
 
 Nextest also sets these environment variables at runtime, matching the behavior of `cargo test`:
 
-- `CARGO` — Path to the `cargo` binary performing the build.
+- `CARGO` — Path to the `cargo` binary performing the build. (This is set by Cargo, not nextest, so if you invoke nextest with `cargo-nextest nextest run` it will not be set.)
 - `CARGO_MANIFEST_DIR` — The directory containing the manifest of your package. If [`--workspace-remap`](reusing-builds.md#specifying-a-new-location-for-the-workspace) is passed in, this is set to the remapped manifest directory. You can obtain the non-remapped directory using the value of this variable at compile-time, e.g. `env!("CARGO_MANIFEST_DIR")`.
 - `CARGO_PKG_VERSION` — The full version of your package.
 - `CARGO_PKG_VERSION_MAJOR` — The major version of your package.

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -43,25 +43,25 @@ syn = { version = "2.0.60", features = ["extra-traits", "full", "visit", "visit-
 [target.x86_64-unknown-linux-gnu.dependencies]
 futures-core = { version = "0.3.30" }
 futures-sink = { version = "0.3.30" }
-libc = { version = "0.2.154", features = ["extra_traits"] }
+libc = { version = "0.2.155", features = ["extra_traits"] }
 linux-raw-sys = { version = "0.4.13", default-features = false, features = ["elf", "errno", "general", "ioctl", "no_std", "std"] }
 miniz_oxide = { version = "0.7.2", default-features = false, features = ["with-alloc"] }
 rustix = { version = "0.38.34", features = ["fs", "termios"] }
 tokio = { version = "1.37.0", default-features = false, features = ["net"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
-libc = { version = "0.2.154", features = ["extra_traits"] }
+libc = { version = "0.2.155", features = ["extra_traits"] }
 
 [target.x86_64-apple-darwin.dependencies]
 futures-core = { version = "0.3.30" }
 futures-sink = { version = "0.3.30" }
-libc = { version = "0.2.154", features = ["extra_traits"] }
+libc = { version = "0.2.155", features = ["extra_traits"] }
 miniz_oxide = { version = "0.7.2", default-features = false, features = ["with-alloc"] }
 rustix = { version = "0.38.34", features = ["fs", "termios"] }
 tokio = { version = "1.37.0", default-features = false, features = ["net"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
-libc = { version = "0.2.154", features = ["extra_traits"] }
+libc = { version = "0.2.155", features = ["extra_traits"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
 futures-core = { version = "0.3.30" }


### PR DESCRIPTION
We need stdlibs in two cases:

1. For proc-macro tests, the host stdlib.
2. For -C prefer-dynamic, the target stdlib.

Archive and reuse them, if available.

Also add tests for running nextest without rustup, including archives. This
should be a pretty comprehensive test.