### PR TITLE
Fix clippy error on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,12 @@ env:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
       - uses: dtolnay/rust-toolchain@stable

--- a/nextest-runner/src/cargo_config/discovery.rs
+++ b/nextest-runner/src/cargo_config/discovery.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::errors::{CargoConfigError, InvalidCargoCliConfigReason};
+use crate::errors::{CargoConfigError, CargoConfigParseError, InvalidCargoCliConfigReason};
 use camino::{Utf8Path, Utf8PathBuf};
 use serde::Deserialize;
 use std::collections::BTreeMap;
@@ -375,11 +375,12 @@ fn load_file(
             path: path.clone(),
             error,
         })?;
-    let config: CargoConfig =
-        toml::from_str(&config_contents).map_err(|error| CargoConfigError::ConfigParseError {
+    let config: CargoConfig = toml::from_str(&config_contents).map_err(|error| {
+        CargoConfigError::from(Box::new(CargoConfigParseError {
             path: path.clone(),
             error,
-        })?;
+        }))
+    })?;
     Ok((CargoConfigSource::File(path), config))
 }
 

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -1159,15 +1159,22 @@ pub enum CargoConfigError {
     },
 
     /// Failed to deserialize config file
-    #[error("failed to parse config at `{path}`")]
-    ConfigParseError {
-        /// The path of the config file
-        path: Utf8PathBuf,
+    #[error(transparent)]
+    ConfigParseError(#[from] Box<CargoConfigParseError>),
+}
 
-        /// The error that occurred trying to deserialize the config file
-        #[source]
-        error: toml::de::Error,
-    },
+/// Failed to deserialize config file
+///
+/// We introduce this extra indirection, because of the `clippy::result_large_err` rule on Windows.
+#[derive(Debug, Error)]
+#[error("failed to parse config at `{path}`")]
+pub struct CargoConfigParseError {
+    /// The path of the config file
+    pub path: Utf8PathBuf,
+
+    /// The error that occurred trying to deserialize the config file
+    #[source]
+    pub error: toml::de::Error,
 }
 
 /// The reason an invalid CLI config failed.

--- a/nextest-runner/src/helpers.rs
+++ b/nextest-runner/src/helpers.rs
@@ -231,7 +231,7 @@ pub(crate) fn extract_abort_status(exit_status: ExitStatus) -> Option<AbortStatu
             exit_status.signal().map(AbortStatus::UnixSignal)
         } else if #[cfg(windows)] {
             exit_status.code().and_then(|code| {
-                (code < 0).then(|| AbortStatus::WindowsNtStatus(code))
+                (code < 0).then_some(AbortStatus::WindowsNtStatus(code))
             })
         } else {
             None
@@ -271,11 +271,11 @@ pub(crate) fn display_nt_status(nt_status: windows_sys::Win32::Foundation::NTSTA
         return format!("{nt_status:#x} ({nt_status})");
     }
 
-    return format!(
+    format!(
         "{:#x}: {}",
         nt_status,
         io::Error::from_raw_os_error(win32_code as i32)
-    );
+    )
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/nextest-runner/src/reporter/aggregator.rs
+++ b/nextest-runner/src/reporter/aggregator.rs
@@ -407,18 +407,15 @@ pub fn heuristic_extract_description<'a>(
         leaked,
     } = exec_result
     {
-        return Some(
-            format!(
-                "Test aborted with code {}{}",
-                crate::helpers::display_nt_status(exception),
-                if leaked {
-                    ", and also leaked handles"
-                } else {
-                    ""
-                }
-            )
-            .into(),
-        );
+        return Some(format!(
+            "Test aborted with code {}{}",
+            crate::helpers::display_nt_status(exception),
+            if leaked {
+                ", and also leaked handles"
+            } else {
+                ""
+            }
+        ));
     }
 
     // Try the heuristic stack trace extraction first as they're the more common kinds of test.

--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -1176,7 +1176,7 @@ fn create_execution_result(exit_status: ExitStatus, leaked: bool) -> ExecutionRe
                 let abort_status = exit_status.signal().map(AbortStatus::UnixSignal);
             } else if #[cfg(windows)] {
                 let abort_status = exit_status.code().and_then(|code| {
-                    (code < 0).then(|| AbortStatus::WindowsNtStatus(code))
+                    (code < 0).then_some(AbortStatus::WindowsNtStatus(code))
                 });
             } else {
                 let abort_status = None;


### PR DESCRIPTION
`cargo clippy --all-features --all-targets` will result the following warnings on windows. This PR:

* fixes those warnings
* runs the lint CI on Windows as well
* fail the CI if clippy results in any warnings

```
PS C:\Users\XXXXXXXX\src\nextest> cargo clippy --all-features --all-targets
    Checking nextest-runner v0.56.1 (C:\Users\XXXXXXXX\src\nextest\nextest-runner)
warning: the `Err`-variant returned from this function is very large
    --> nextest-runner\src\cargo_config\discovery.rs:58:10
     |
58   |       ) -> Result<Self, CargoConfigError> {
     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
    ::: nextest-runner\src\errors.rs:1163:5
     |
1163 | /     ConfigParseError {
1164 | |         /// The path of the config file
1165 | |         path: Utf8PathBuf,
1166 | |
...    |
1169 | |         error: toml::de::Error,
1170 | |     },
     | |_____- the largest variant contains at least 128 bytes
     |
     = help: try reducing the size of `errors::CargoConfigError`, for example by boxing large elements or replacing it with `Box<errors::CargoConfigError>`
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err
     = note: `#[warn(clippy::result_large_err)]` on by default

warning: the `Err`-variant returned from this function is very large
    --> nextest-runner\src\cargo_config\discovery.rs:96:10
     |
96   |       ) -> Result<Self, CargoConfigError> {
     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
    ::: nextest-runner\src\errors.rs:1163:5
     |
1163 | /     ConfigParseError {
1164 | |         /// The path of the config file
1165 | |         path: Utf8PathBuf,
1166 | |
...    |
1169 | |         error: toml::de::Error,
1170 | |     },
     | |_____- the largest variant contains at least 128 bytes
     |
     = help: try reducing the size of `errors::CargoConfigError`, for example by boxing large elements or replacing it with `Box<errors::CargoConfigError>`
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err

warning: the `Err`-variant returned from this function is very large
    --> nextest-runner\src\cargo_config\discovery.rs:167:6
     |
167  |   ) -> Result<Vec<(CargoConfigSource, CargoConfig)>, CargoConfigError> {
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
    ::: nextest-runner\src\errors.rs:1163:5
     |
1163 | /     ConfigParseError {
1164 | |         /// The path of the config file
1165 | |         path: Utf8PathBuf,
1166 | |
...    |
1169 | |         error: toml::de::Error,
1170 | |     },
     | |_____- the largest variant contains at least 128 bytes
     |
     = help: try reducing the size of `errors::CargoConfigError`, for example by boxing large elements or replacing it with `Box<errors::CargoConfigError>`
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err

warning: the `Err`-variant returned from this function is very large
    --> nextest-runner\src\cargo_config\discovery.rs:186:42
     |
186  |   fn parse_cli_config(config_str: &str) -> Result<CargoConfig, CargoConfigError> {
     |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
    ::: nextest-runner\src\errors.rs:1163:5
     |
1163 | /     ConfigParseError {
1164 | |         /// The path of the config file
1165 | |         path: Utf8PathBuf,
1166 | |
...    |
1169 | |         error: toml::de::Error,
1170 | |     },
     | |_____- the largest variant contains at least 128 bytes
     |
     = help: try reducing the size of `errors::CargoConfigError`, for example by boxing large elements or replacing it with `Box<errors::CargoConfigError>`
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err

warning: the `Err`-variant returned from this function is very large
    --> nextest-runner\src\cargo_config\discovery.rs:293:6
     |
293  |   ) -> Result<Vec<(CargoConfigSource, CargoConfig)>, CargoConfigError> {
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
    ::: nextest-runner\src\errors.rs:1163:5
     |
1163 | /     ConfigParseError {
1164 | |         /// The path of the config file
1165 | |         path: Utf8PathBuf,
1166 | |
...    |
1169 | |         error: toml::de::Error,
1170 | |     },
     | |_____- the largest variant contains at least 128 bytes
     |
     = help: try reducing the size of `errors::CargoConfigError`, for example by boxing large elements or replacing it with `Box<errors::CargoConfigError>`
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err

warning: the `Err`-variant returned from this function is very large
    --> nextest-runner\src\cargo_config\discovery.rs:367:6
     |
367  |   ) -> Result<(CargoConfigSource, CargoConfig), CargoConfigError> {
     |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
    ::: nextest-runner\src\errors.rs:1163:5
     |
1163 | /     ConfigParseError {
1164 | |         /// The path of the config file
1165 | |         path: Utf8PathBuf,
1166 | |
...    |
1169 | |         error: toml::de::Error,
1170 | |     },
     | |_____- the largest variant contains at least 128 bytes
     |
     = help: try reducing the size of `errors::CargoConfigError`, for example by boxing large elements or replacing it with `Box<errors::CargoConfigError>`
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err

warning: unnecessary closure used with `bool::then`
   --> nextest-runner\src\helpers.rs:234:17
    |
234 |                 (code < 0).then(|| AbortStatus::WindowsNtStatus(code))
    |                 ^^^^^^^^^^^-------------------------------------------
    |                            |
    |                            help: use `then_some(..)` instead: `then_some(AbortStatus::WindowsNtStatus(code))`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations
    = note: `#[warn(clippy::unnecessary_lazy_evaluations)]` on by default

warning: unneeded `return` statement
   --> nextest-runner\src\helpers.rs:274:5
    |
274 | /     return format!(
275 | |         "{:#x}: {}",
276 | |         nt_status,
277 | |         io::Error::from_raw_os_error(win32_code as i32)
278 | |     );
    | |_____^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_return
    = note: `#[warn(clippy::needless_return)]` on by default
help: remove `return`
    |
274 ~     format!(
275 +         "{:#x}: {}",
276 +         nt_status,
277 +         io::Error::from_raw_os_error(win32_code as i32)
278 ~     )
    |

warning: useless conversion to the same type: `std::string::String`
   --> nextest-runner\src\reporter\aggregator.rs:411:13
    |
411 | /             format!(
412 | |                 "Test aborted with code {}{}",
413 | |                 crate::helpers::display_nt_status(exception),
414 | |                 if leaked {
...   |
419 | |             )
420 | |             .into(),
    | |___________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
    = note: `#[warn(clippy::useless_conversion)]` on by default
help: consider removing `.into()`
    |
411 ~             format!(
412 +                 "Test aborted with code {}{}",
413 +                 crate::helpers::display_nt_status(exception),
414 +                 if leaked {
415 +                     ", and also leaked handles"
416 +                 } else {
417 +                     ""
418 +                 }
419 ~             ),
    |

warning: unnecessary closure used with `bool::then`
    --> nextest-runner\src\runner.rs:1179:21
     |
1179 |                     (code < 0).then(|| AbortStatus::WindowsNtStatus(code))
     |                     ^^^^^^^^^^^-------------------------------------------
     |                                |
     |                                help: use `then_some(..)` instead: `then_some(AbortStatus::WindowsNtStatus(code))`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations

warning: `nextest-runner` (lib) generated 10 warnings (run `cargo clippy --fix --lib -p nextest-runner` to apply 4 suggestions)
    Checking cargo-nextest v0.9.72 (C:\Users\XXXXXXXX\src\nextest\cargo-nextest)
warning: `nextest-runner` (lib test) generated 10 warnings (10 duplicates)
    Checking integration-tests v0.1.0 (C:\Users\XXXXXXXX\src\nextest\integration-tests)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.28s
PS C:\Users\XXXXXXXX\src\nextest> 
```