### PR TITLE
[cargo-nextest] add a new --no-tests option

### DIFF
--- a/cargo-nextest/src/errors.rs
+++ b/cargo-nextest/src/errors.rs
@@ -184,6 +184,12 @@ pub enum ExpectedError {
     SetupScriptFailed,
     #[error("test run failed")]
     TestRunFailed,
+    #[error("no tests to run")]
+    NoTestsRun {
+        /// The no-tests-run error was chosen because it was the default (we show a hint in this
+        /// case)
+        is_default: bool,
+    },
     #[cfg(feature = "self-update")]
     #[error("failed to parse --version")]
     UpdateVersionParseError {
@@ -406,6 +412,7 @@ impl ExpectedError {
             }
             Self::SetupScriptFailed => NextestExitCode::SETUP_SCRIPT_FAILED,
             Self::TestRunFailed => NextestExitCode::TEST_RUN_FAILED,
+            Self::NoTestsRun { .. } => NextestExitCode::NO_TESTS_RUN,
             Self::ArchiveCreateError { .. } => NextestExitCode::ARCHIVE_CREATION_FAILED,
             Self::WriteTestListError { .. } | Self::WriteEventError { .. } => {
                 NextestExitCode::WRITE_OUTPUT_ERROR
@@ -729,6 +736,15 @@ impl ExpectedError {
             }
             Self::TestRunFailed => {
                 log::error!("test run failed");
+                None
+            }
+            Self::NoTestsRun { is_default } => {
+                let hint_str = if *is_default {
+                    "\n(hint: use `--no-tests` to customize)"
+                } else {
+                    ""
+                };
+                log::error!("no tests to run{hint_str}");
                 None
             }
             Self::ShowTestGroupsError { err } => {

--- a/integration-tests/tests/integration/main.rs
+++ b/integration-tests/tests/integration/main.rs
@@ -229,6 +229,87 @@ fn test_list_target_after_build() {
 }
 
 #[test]
+fn test_run_no_tests() {
+    set_env_vars();
+
+    let p = TempProject::new().unwrap();
+    build_tests(&p);
+
+    let output = CargoNextestCli::new()
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "run",
+            "-E",
+            "none()",
+        ])
+        .output();
+
+    let stderr = output.stderr_as_str();
+    assert!(
+        stderr.contains("warning: no tests to run -- this will become an error in the future"),
+        "stderr contains no tests message"
+    );
+
+    let output = CargoNextestCli::new()
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "run",
+            "-E",
+            "none()",
+            "--no-tests=warn",
+        ])
+        .output();
+
+    let stderr = output.stderr_as_str();
+    assert!(
+        stderr.contains("warning: no tests to run"),
+        "stderr contains no tests message"
+    );
+
+    let output = CargoNextestCli::new()
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "run",
+            "-E",
+            "none()",
+            "--no-tests=fail",
+        ])
+        .unchecked(true)
+        .output();
+    assert_eq!(
+        output.exit_status.code(),
+        Some(NextestExitCode::NO_TESTS_RUN),
+        "correct exit code for command\n{output}"
+    );
+
+    let stderr = output.stderr_as_str();
+    assert!(
+        stderr.contains("error: no tests to run"),
+        "stderr contains no tests message: {output}"
+    );
+
+    let output = CargoNextestCli::new()
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "run",
+            "-E",
+            "none()",
+            "--no-tests=pass",
+        ])
+        .output();
+
+    let stderr = output.stderr_as_str();
+    assert!(
+        !stderr.contains("no tests to run"),
+        "no tests message does not error out"
+    );
+}
+
+#[test]
 fn test_run() {
     set_env_vars();
 

--- a/nextest-metadata/src/exit_codes.rs
+++ b/nextest-metadata/src/exit_codes.rs
@@ -19,6 +19,14 @@ impl NextestExitCode {
     /// An error was encountered while attempting to double-spawn a nextest process.
     pub const DOUBLE_SPAWN_ERROR: i32 = 70;
 
+    /// No tests were selected to run, but no other errors occurred.
+    ///
+    /// This is an advisory exit code generated if nextest is run with `--no-tests=fail` (soon to
+    /// become the default). See [discussion #1646] for more.
+    ///
+    /// [discussion #1646]: https://github.com/nextest-rs/nextest/discussions/1646
+    pub const NO_TESTS_RUN: i32 = 4;
+
     /// One or more tests failed.
     pub const TEST_RUN_FAILED: i32 = 100;
 

--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -1649,7 +1649,7 @@ pub enum FinalRunStats {
     /// The test run was successful, or is successful so far.
     Success,
 
-    /// The test run was successful, or is successful so far, but no tests were run.
+    /// The test run was successful, or is successful so far, but no tests were selected to run.
     NoTestsRun,
 
     /// The test run was canceled.


### PR DESCRIPTION
Default to `warn` currently, but can also be `fail` or `pass`. The plan is to default to `fail` in the future (see #1646).