### PR TITLE
WIP: Add support for --skip and --exact test binary arguments

### DIFF
--- a/fixture-data/src/models.rs
+++ b/fixture-data/src/models.rs
@@ -105,4 +105,6 @@ impl TestCaseFixtureStatus {
 pub enum TestCaseFixtureProperty {
     NeedsSameCwd = 1,
     NotInDefaultSet = 2,
+    MatchesCdylib = 4,
+    MatchesTestMultiplyTwo = 8,
 }

--- a/fixture-data/src/nextest_tests.rs
+++ b/fixture-data/src/nextest_tests.rs
@@ -139,7 +139,8 @@ pub static EXPECTED_TEST_SUITES: Lazy<BTreeMap<RustBinaryId, TestSuiteFixture>> 
             "cdylib-link",
             BuildPlatform::Target,
             vec![
-                TestCaseFixture::new("test_multiply_two", TestCaseFixtureStatus::Pass),
+                TestCaseFixture::new("test_multiply_two", TestCaseFixtureStatus::Pass)
+                    .with_property(TestCaseFixtureProperty::MatchesTestMultiplyTwo),
             ],
         ),
         "dylib-test".into() => TestSuiteFixture::new(
@@ -153,7 +154,9 @@ pub static EXPECTED_TEST_SUITES: Lazy<BTreeMap<RustBinaryId, TestSuiteFixture>> 
             "cdylib-example",
             BuildPlatform::Target,
             vec![
-                TestCaseFixture::new("tests::test_multiply_two_cdylib", TestCaseFixtureStatus::Pass),
+                TestCaseFixture::new("tests::test_multiply_two_cdylib", TestCaseFixtureStatus::Pass)
+                    .with_property(TestCaseFixtureProperty::MatchesCdylib)
+                    .with_property(TestCaseFixtureProperty::MatchesTestMultiplyTwo),
             ],
         )
         .with_property(TestSuiteFixtureProperty::NotInDefaultSet),

--- a/nextest-runner/src/list/test_list.rs
+++ b/nextest-runner/src/list/test_list.rs
@@ -1068,7 +1068,7 @@ mod tests {
         cargo_config::{TargetDefinitionLocation, TargetTriple, TargetTripleSource},
         list::SerializableFormat,
         platform::{BuildPlatforms, HostPlatform, PlatformLibdir, TargetPlatform},
-        test_filter::RunIgnored,
+        test_filter::{RunIgnored, TestFilterPatterns},
     };
     use guppy::CargoMetadata;
     use indoc::indoc;
@@ -1077,7 +1077,6 @@ mod tests {
     use nextest_metadata::{FilterMatch, MismatchReason, PlatformLibdirUnavailable};
     use once_cell::sync::Lazy;
     use pretty_assertions::assert_eq;
-    use std::iter;
     use target_spec::Platform;
 
     #[test]
@@ -1102,7 +1101,7 @@ mod tests {
         let test_filter = TestFilterBuilder::new(
             RunIgnored::Default,
             None,
-            iter::empty::<String>(),
+            TestFilterPatterns::default(),
             // Test against the platform() predicate because this is the most important one here.
             vec![Filterset::parse("platform(target)".to_owned(), &cx).unwrap()],
         )

--- a/nextest-runner/tests/integration/basic.rs
+++ b/nextest-runner/tests/integration/basic.rs
@@ -22,7 +22,7 @@ use nextest_runner::{
     },
     signal::SignalHandlerKind,
     target_runner::TargetRunner,
-    test_filter::{RunIgnored, TestFilterBuilder},
+    test_filter::{RunIgnored, TestFilterBuilder, TestFilterPatterns},
     test_output::{TestExecutionOutput, TestOutput},
 };
 use pretty_assertions::assert_eq;
@@ -230,8 +230,13 @@ fn test_run_ignored() -> Result<()> {
     };
     let expr = Filterset::parse("not test(test_slow_timeout)".to_owned(), &pcx).unwrap();
 
-    let test_filter =
-        TestFilterBuilder::new(RunIgnored::Only, None, Vec::<String>::new(), vec![expr]).unwrap();
+    let test_filter = TestFilterBuilder::new(
+        RunIgnored::Only,
+        None,
+        TestFilterPatterns::default(),
+        vec![expr],
+    )
+    .unwrap();
     let test_list = FIXTURE_TARGETS.make_test_list(&test_filter, &TargetRunner::empty())?;
     let config = load_config();
     let profile = config
@@ -319,7 +324,10 @@ fn test_filter_expr_with_string_filters() -> Result<()> {
     let test_filter = TestFilterBuilder::new(
         RunIgnored::Default,
         None,
-        ["call_dylib_add_two", "test_flaky_mod_4"],
+        TestFilterPatterns::new(vec![
+            "call_dylib_add_two".to_owned(),
+            "test_flaky_mod_4".to_owned(),
+        ]),
         vec![expr],
     )
     .unwrap();
@@ -383,9 +391,13 @@ fn test_filter_expr_without_string_filters() -> Result<()> {
     )
     .expect("filterset is valid");
 
-    let test_filter =
-        TestFilterBuilder::new(RunIgnored::Default, None, Vec::<String>::new(), vec![expr])
-            .unwrap();
+    let test_filter = TestFilterBuilder::new(
+        RunIgnored::Default,
+        None,
+        TestFilterPatterns::default(),
+        vec![expr],
+    )
+    .unwrap();
     let test_list = FIXTURE_TARGETS.make_test_list(&test_filter, &TargetRunner::empty())?;
     for test in test_list.iter_tests() {
         if test.name.contains("test_multiply_two") || test.name == "tests::call_dylib_add_two" {
@@ -411,7 +423,10 @@ fn test_string_filters_without_filter_expr() -> Result<()> {
     let test_filter = TestFilterBuilder::new(
         RunIgnored::Default,
         None,
-        vec!["test_multiply_two", "tests::call_dylib_add_two"],
+        TestFilterPatterns::new(vec![
+            "test_multiply_two".to_owned(),
+            "tests::call_dylib_add_two".to_owned(),
+        ]),
         vec![],
     )
     .unwrap();
@@ -601,8 +616,13 @@ fn test_termination() -> Result<()> {
         kind: FiltersetKind::Test,
     };
     let expr = Filterset::parse("test(/^test_slow_timeout/)".to_owned(), &pcx).unwrap();
-    let test_filter =
-        TestFilterBuilder::new(RunIgnored::Only, None, Vec::<String>::new(), vec![expr]).unwrap();
+    let test_filter = TestFilterBuilder::new(
+        RunIgnored::Only,
+        None,
+        TestFilterPatterns::default(),
+        vec![expr],
+    )
+    .unwrap();
 
     let test_list = FIXTURE_TARGETS.make_test_list(&test_filter, &TargetRunner::empty())?;
     let config = load_config();


### PR DESCRIPTION
My half-finished attempt at #1483. It works, but clearly is not acceptable as-is because it adds a `todo!()` to one test, and doesn't add any tests for the new behavior.

Any hints as to how to get this into a mergable shape would be appreciated.