### PR TITLE
highlight interesting parts of the output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,6 +375,7 @@ dependencies = [
  "once_cell",
  "owo-colors 4.0.0",
  "pathdiff",
+ "quick-junit",
  "semver",
  "serde_json",
  "shell-words",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,14 +2104,14 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-junit"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc1a6a5406a114913df2df8507998c755311b55b78584bed5f6e88f6417c4d4"
+checksum = "62ffd2f9a162cfae131bed6d9d1ed60adced33be340a94f96952897d7cb0c240"
 dependencies = [
  "chrono",
  "indexmap 2.4.0",
  "newtype-uuid",
- "quick-xml 0.31.0",
+ "quick-xml 0.36.1",
  "strip-ansi-escapes",
  "thiserror",
  "uuid",
@@ -2128,9 +2128,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.31.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+checksum = "96a05e2e8efddfa51a84ca47cec303fac86c8541b686d37cac5efc0e094417bc"
 dependencies = [
  "memchr",
 ]
@@ -3315,9 +3315,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ owo-colors = { version = "4.0.0", features = ["supports-colors"] }
 newtype-uuid = { version = "1.1.0", features = ["v4"] }
 nextest-metadata = { version = "0.12.0", path = "nextest-metadata" }
 nextest-workspace-hack = "0.1.0"
-quick-junit = "0.4.0"
+quick-junit = "0.5.0"
 swrite = "0.1.0"
 target-spec = { version = "3.2.1", features = ["custom", "summaries"] }
 target-spec-miette = "0.4.0"

--- a/cargo-nextest/Cargo.toml
+++ b/cargo-nextest/Cargo.toml
@@ -32,6 +32,7 @@ nextest-metadata = { version = "=0.12.0", path = "../nextest-metadata" }
 once_cell = "1.19.0"
 owo-colors.workspace = true
 pathdiff = { version = "0.2.1", features = ["camino"] }
+quick-junit.workspace = true
 semver = "1.0.23"
 shell-words = "1.1.0"
 supports-color = "2.1.0"

--- a/nextest-runner/src/reporter/aggregator.rs
+++ b/nextest-runner/src/reporter/aggregator.rs
@@ -3,9 +3,7 @@
 
 //! Metadata management.
 
-use super::TestEvent;
-#[cfg(any(unix, windows))]
-use crate::runner::AbortStatus;
+use super::{heuristic_extract_description, TestEvent};
 use crate::{
     config::{NextestJunitConfig, NextestProfile},
     errors::WriteEventError,
@@ -16,9 +14,7 @@ use crate::{
 };
 use camino::Utf8PathBuf;
 use debug_ignore::DebugIgnore;
-use once_cell::sync::Lazy;
-use quick_junit::{NonSuccessKind, Output, Report, TestCase, TestCaseStatus, TestRerun, TestSuite};
-use regex::{Regex, RegexBuilder};
+use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestRerun, TestSuite};
 use std::{borrow::Cow, collections::HashMap, fs::File};
 
 #[derive(Clone, Debug)]
@@ -352,184 +348,6 @@ fn set_execute_status_props(
         }
         None => {
             out.set_message("Test failed, but output was not captured");
-        }
-    }
-}
-
-// This regex works for the default panic handler for Rust -- other panic handlers may not work,
-// which is why this is heuristic.
-static PANICKED_AT_REGEX_STR: &str = "^thread '([^']+)' panicked at ";
-static PANICKED_AT_REGEX: Lazy<Regex> = Lazy::new(|| {
-    let mut builder = RegexBuilder::new(PANICKED_AT_REGEX_STR);
-    builder.multi_line(true);
-    builder.build().unwrap()
-});
-
-static ERROR_REGEX_STR: &str = "^Error: ";
-static ERROR_REGEX: Lazy<Regex> = Lazy::new(|| {
-    let mut builder = RegexBuilder::new(ERROR_REGEX_STR);
-    builder.multi_line(true);
-    builder.build().unwrap()
-});
-
-#[allow(unused_variables)]
-/// Not part of the public API: only used for testing.
-#[doc(hidden)]
-pub fn heuristic_extract_description<'a>(
-    exec_result: ExecutionResult,
-    stdout: &'a str,
-    stderr: &'a str,
-) -> Option<String> {
-    // If the test crashed with a signal, use that.
-    #[cfg(unix)]
-    if let ExecutionResult::Fail {
-        abort_status: Some(AbortStatus::UnixSignal(sig)),
-        leaked,
-    } = exec_result
-    {
-        let signal_str = match crate::helpers::signal_str(sig) {
-            Some(signal_str) => format!(" SIG{signal_str}"),
-            None => String::new(),
-        };
-        return Some(format!(
-            "Test aborted with signal{signal_str} (code {sig}){}",
-            if leaked {
-                ", and also leaked handles"
-            } else {
-                ""
-            }
-        ));
-    }
-
-    #[cfg(windows)]
-    if let ExecutionResult::Fail {
-        abort_status: Some(AbortStatus::WindowsNtStatus(exception)),
-        leaked,
-    } = exec_result
-    {
-        return Some(format!(
-            "Test aborted with code {}{}",
-            crate::helpers::display_nt_status(exception),
-            if leaked {
-                ", and also leaked handles"
-            } else {
-                ""
-            }
-        ));
-    }
-
-    // Try the heuristic stack trace extraction first as they're the more common kinds of test.
-    if let Some(description) = heuristic_stack_trace(stderr) {
-        return Some(description);
-    }
-    if let Some(description) = heuristic_error_str(stderr) {
-        return Some(description);
-    }
-    heuristic_should_panic(stdout)
-}
-
-fn heuristic_should_panic(stdout: &str) -> Option<String> {
-    for line in stdout.lines() {
-        if line.contains("note: test did not panic as expected") {
-            // Strip invalid XML characters (e.g. ANSI escapes) if they're around.
-            return Some(Output::new(line).into_string());
-        }
-    }
-    None
-}
-
-fn heuristic_stack_trace(stderr: &str) -> Option<String> {
-    let panicked_at_match = PANICKED_AT_REGEX.find(stderr)?;
-    // If the previous line starts with "Error: ", grab it as well -- it contains the error with
-    // result-based test failures.
-    let mut start = panicked_at_match.start();
-    let prefix = stderr[..start].trim_end_matches('\n');
-    if let Some(prev_line_start) = prefix.rfind('\n') {
-        if prefix[prev_line_start..].starts_with("\nError:") {
-            start = prev_line_start + 1;
-        }
-    }
-
-    Some(Output::new(stderr[start..].trim_end()).into_string())
-}
-
-fn heuristic_error_str(stderr: &str) -> Option<String> {
-    // Starting Rust 1.66, Result-based errors simply print out "Error: ".
-    let error_match = ERROR_REGEX.find(stderr)?;
-    let start = error_match.start();
-    Some(Output::new(stderr[start..].trim_end()).into_string())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_heuristic_extract_description() {
-        let tests: &[(&str, &str)] = &[(
-            "running 1 test
-test test_failure_should_panic - should panic ... FAILED
-
-failures:
-
----- test_failure_should_panic stdout ----
-note: test did not panic as expected
-
-failures:
-    test_failure_should_panic
-
-test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 13 filtered out; finished in 0.00s",
-            "note: test did not panic as expected",
-        )];
-
-        for (input, output) in tests {
-            assert_eq!(heuristic_should_panic(input).as_deref(), Some(*output));
-        }
-    }
-
-    #[test]
-    fn test_heuristic_stack_trace() {
-        let tests: &[(&str, &str)] = &[
-            (
-                "thread 'main' panicked at 'foo', src/lib.rs:1\n",
-                "thread 'main' panicked at 'foo', src/lib.rs:1",
-            ),
-            (
-                "foobar\n\
-            thread 'main' panicked at 'foo', src/lib.rs:1\n\n",
-                "thread 'main' panicked at 'foo', src/lib.rs:1",
-            ),
-            (
-                r#"
-text: foo
-Error: Custom { kind: InvalidData, error: "this is an error" }
-thread 'test_result_failure' panicked at 'assertion failed: `(left == right)`
-  left: `1`,
- right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/test/src/lib.rs:186:5
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-            "#,
-                r#"Error: Custom { kind: InvalidData, error: "this is an error" }
-thread 'test_result_failure' panicked at 'assertion failed: `(left == right)`
-  left: `1`,
- right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/test/src/lib.rs:186:5
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace"#,
-            ),
-        ];
-
-        for (input, output) in tests {
-            assert_eq!(heuristic_stack_trace(input).as_deref(), Some(*output));
-        }
-    }
-
-    #[test]
-    fn test_heuristic_error_str() {
-        let tests: &[(&str, &str)] = &[(
-            "foobar\nError: \"this is an error\"\n",
-            "Error: \"this is an error\"",
-        )];
-
-        for (input, output) in tests {
-            assert_eq!(heuristic_error_str(input).as_deref(), Some(*output));
         }
     }
 }

--- a/nextest-runner/src/reporter/aggregator.rs
+++ b/nextest-runner/src/reporter/aggregator.rs
@@ -302,13 +302,13 @@ fn set_execute_status_props(
 ) {
     match &execute_status.output {
         Some(TestOutput::Split { stdout, stderr }) => {
-            let stdout_lossy = stdout.to_str_lossy();
-            let stderr_lossy = stderr.to_str_lossy();
+            let stdout_lossy = stdout.as_str_lossy();
+            let stderr_lossy = stderr.as_str_lossy();
             if !is_success {
                 let description = heuristic_extract_description(
                     execute_status.result,
-                    &stdout_lossy,
-                    &stderr_lossy,
+                    stdout_lossy,
+                    stderr_lossy,
                 );
                 if let Some(description) = description {
                     out.set_description(description.display_human().to_junit_output());
@@ -321,13 +321,13 @@ fn set_execute_status_props(
             }
         }
         Some(TestOutput::Combined { output }) => {
-            let output_lossy = output.to_str_lossy();
+            let output_lossy = output.as_str_lossy();
             if !is_success {
                 let description = heuristic_extract_description(
                     execute_status.result,
                     // The output is combined so we just track all of it.
-                    &output_lossy,
-                    &output_lossy,
+                    output_lossy,
+                    output_lossy,
                 );
                 if let Some(description) = description {
                     out.set_description(description.display_human().to_junit_output());

--- a/nextest-runner/src/reporter/aggregator.rs
+++ b/nextest-runner/src/reporter/aggregator.rs
@@ -311,7 +311,7 @@ fn set_execute_status_props(
                     &stderr_lossy,
                 );
                 if let Some(description) = description {
-                    out.set_description(description);
+                    out.set_description(description.display_human().to_junit_output());
                 }
             }
 
@@ -330,7 +330,7 @@ fn set_execute_status_props(
                     &output_lossy,
                 );
                 if let Some(description) = description {
-                    out.set_description(description);
+                    out.set_description(description.display_human().to_junit_output());
                 }
             }
 

--- a/nextest-runner/src/reporter/aggregator.rs
+++ b/nextest-runner/src/reporter/aggregator.rs
@@ -14,7 +14,9 @@ use crate::{
 };
 use camino::Utf8PathBuf;
 use debug_ignore::DebugIgnore;
-use quick_junit::{NonSuccessKind, Report, TestCase, TestCaseStatus, TestRerun, TestSuite};
+use quick_junit::{
+    NonSuccessKind, Report, TestCase, TestCaseStatus, TestRerun, TestSuite, XmlString,
+};
 use std::{borrow::Cow, collections::HashMap, fs::File};
 
 #[derive(Clone, Debug)]
@@ -245,7 +247,7 @@ enum TestcaseOrRerun<'a> {
 }
 
 impl TestcaseOrRerun<'_> {
-    fn set_message(&mut self, message: impl Into<String>) -> &mut Self {
+    fn set_message(&mut self, message: impl Into<XmlString>) -> &mut Self {
         match self {
             TestcaseOrRerun::Testcase(testcase) => {
                 testcase.status.set_message(message.into());
@@ -257,7 +259,7 @@ impl TestcaseOrRerun<'_> {
         self
     }
 
-    fn set_description(&mut self, description: impl Into<String>) -> &mut Self {
+    fn set_description(&mut self, description: impl Into<XmlString>) -> &mut Self {
         match self {
             TestcaseOrRerun::Testcase(testcase) => {
                 testcase.status.set_description(description.into());
@@ -269,7 +271,7 @@ impl TestcaseOrRerun<'_> {
         self
     }
 
-    fn set_system_out(&mut self, system_out: impl Into<String>) -> &mut Self {
+    fn set_system_out(&mut self, system_out: impl Into<XmlString>) -> &mut Self {
         match self {
             TestcaseOrRerun::Testcase(testcase) => {
                 testcase.set_system_out(system_out.into());
@@ -281,7 +283,7 @@ impl TestcaseOrRerun<'_> {
         self
     }
 
-    fn set_system_err(&mut self, system_err: impl Into<String>) -> &mut Self {
+    fn set_system_err(&mut self, system_err: impl Into<XmlString>) -> &mut Self {
         match self {
             TestcaseOrRerun::Testcase(testcase) => {
                 testcase.set_system_err(system_err.into());
@@ -305,7 +307,7 @@ fn set_execute_status_props(
             if !is_success {
                 let description = output.heuristic_extract_description(execute_status.result);
                 if let Some(description) = description {
-                    out.set_description(description.display_human().to_junit_output());
+                    out.set_description(description.display_human().to_string());
                 }
             }
 

--- a/nextest-runner/src/reporter/displayer.rs
+++ b/nextest-runner/src/reporter/displayer.rs
@@ -16,7 +16,7 @@ use crate::{
         AbortStatus, ExecuteStatus, ExecutionDescription, ExecutionResult, ExecutionStatuses,
         FinalRunStats, RetryData, RunStats, RunStatsFailureKind, SetupScriptExecuteStatus,
     },
-    test_output::{TestOutput, TestSingleOutput},
+    test_output::{TestExecutionOutput, TestOutput, TestSingleOutput},
 };
 use chrono::{DateTime, FixedOffset};
 use debug_ignore::DebugIgnore;
@@ -1354,7 +1354,7 @@ impl<'a> TestReporterImpl<'a> {
         };
 
         match &run_status.output {
-            Some(TestOutput::Split { stdout, stderr }) => {
+            Some(TestExecutionOutput::Output(TestOutput::Split { stdout, stderr })) => {
                 if !stdout.is_empty() {
                     write!(writer, "\n{}", "--- ".style(header_style))?;
                     let out_len = self.write_attempt(run_status, header_style, writer)?;
@@ -1388,7 +1388,7 @@ impl<'a> TestReporterImpl<'a> {
                 }
             }
 
-            Some(TestOutput::Combined { output }) => {
+            Some(TestExecutionOutput::Output(TestOutput::Combined { output })) => {
                 if !output.is_empty() {
                     write!(writer, "\n{}", "--- ".style(header_style))?;
                     let out_len = self.write_attempt(run_status, header_style, writer)?;
@@ -1406,7 +1406,7 @@ impl<'a> TestReporterImpl<'a> {
                 }
             }
 
-            Some(TestOutput::ExecFail { description, .. }) => {
+            Some(TestExecutionOutput::ExecFail { description, .. }) => {
                 write!(writer, "\n{}", "--- ".style(header_style))?;
                 let out_len = self.write_attempt(run_status, header_style, writer)?;
                 // The width is to align test instances.

--- a/nextest-runner/src/reporter/displayer.rs
+++ b/nextest-runner/src/reporter/displayer.rs
@@ -5,9 +5,7 @@
 //!
 //! The main structure in this module is [`TestReporter`].
 
-mod aggregator;
-pub mod structured;
-
+use super::structured::StructuredReporter;
 use crate::{
     config::{NextestProfile, ScriptId},
     errors::WriteEventError,
@@ -20,7 +18,6 @@ use crate::{
     },
     test_output::{TestOutput, TestSingleOutput},
 };
-pub use aggregator::heuristic_extract_description;
 use chrono::{DateTime, FixedOffset};
 use debug_ignore::DebugIgnore;
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
@@ -228,7 +225,7 @@ impl TestReporterBuilder {
         test_list: &TestList,
         profile: &NextestProfile<'a>,
         output: ReporterStderr<'a>,
-        structured_reporter: structured::StructuredReporter<'a>,
+        structured_reporter: StructuredReporter<'a>,
     ) -> TestReporter<'a> {
         let styles = Box::default();
         let binary_id_width = test_list
@@ -362,7 +359,7 @@ pub struct TestReporter<'a> {
     /// Used to aggregate events for JUnit reports written to disk
     metadata_reporter: EventAggregator<'a>,
     /// Used to emit test events in machine-readable format(s) to stdout
-    structured_reporter: structured::StructuredReporter<'a>,
+    structured_reporter: StructuredReporter<'a>,
 }
 
 impl<'a> TestReporter<'a> {

--- a/nextest-runner/src/reporter/helpers.rs
+++ b/nextest-runner/src/reporter/helpers.rs
@@ -1,0 +1,184 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::runner::{AbortStatus, ExecutionResult};
+use once_cell::sync::Lazy;
+use quick_junit::Output;
+use regex::{Regex, RegexBuilder};
+
+// This regex works for the default panic handler for Rust -- other panic handlers may not work,
+// which is why this is heuristic.
+static PANICKED_AT_REGEX_STR: &str = "^thread '([^']+)' panicked at ";
+static PANICKED_AT_REGEX: Lazy<Regex> = Lazy::new(|| {
+    let mut builder = RegexBuilder::new(PANICKED_AT_REGEX_STR);
+    builder.multi_line(true);
+    builder.build().unwrap()
+});
+
+static ERROR_REGEX_STR: &str = "^Error: ";
+static ERROR_REGEX: Lazy<Regex> = Lazy::new(|| {
+    let mut builder = RegexBuilder::new(ERROR_REGEX_STR);
+    builder.multi_line(true);
+    builder.build().unwrap()
+});
+
+#[allow(unused_variables)]
+/// Not part of the public API: only used for testing.
+#[doc(hidden)]
+pub fn heuristic_extract_description<'a>(
+    exec_result: ExecutionResult,
+    stdout: &'a str,
+    stderr: &'a str,
+) -> Option<String> {
+    // If the test crashed with a signal, use that.
+    #[cfg(unix)]
+    if let ExecutionResult::Fail {
+        abort_status: Some(AbortStatus::UnixSignal(sig)),
+        leaked,
+    } = exec_result
+    {
+        let signal_str = match crate::helpers::signal_str(sig) {
+            Some(signal_str) => format!(" SIG{signal_str}"),
+            None => String::new(),
+        };
+        return Some(format!(
+            "Test aborted with signal{signal_str} (code {sig}){}",
+            if leaked {
+                ", and also leaked handles"
+            } else {
+                ""
+            }
+        ));
+    }
+
+    #[cfg(windows)]
+    if let ExecutionResult::Fail {
+        abort_status: Some(AbortStatus::WindowsNtStatus(exception)),
+        leaked,
+    } = exec_result
+    {
+        return Some(format!(
+            "Test aborted with code {}{}",
+            crate::helpers::display_nt_status(exception),
+            if leaked {
+                ", and also leaked handles"
+            } else {
+                ""
+            }
+        ));
+    }
+
+    // Try the heuristic stack trace extraction first as they're the more common kinds of test.
+    if let Some(description) = heuristic_stack_trace(stderr) {
+        return Some(description);
+    }
+    if let Some(description) = heuristic_error_str(stderr) {
+        return Some(description);
+    }
+    heuristic_should_panic(stdout)
+}
+
+fn heuristic_should_panic(stdout: &str) -> Option<String> {
+    for line in stdout.lines() {
+        if line.contains("note: test did not panic as expected") {
+            return Some(Output::new(line).into_string());
+        }
+    }
+    None
+}
+
+fn heuristic_stack_trace(stderr: &str) -> Option<String> {
+    let panicked_at_match = PANICKED_AT_REGEX.find(stderr)?;
+    // If the previous line starts with "Error: ", grab it as well -- it contains the error with
+    // result-based test failures.
+    let mut start = panicked_at_match.start();
+    let prefix = stderr[..start].trim_end_matches('\n');
+    if let Some(prev_line_start) = prefix.rfind('\n') {
+        if prefix[prev_line_start..].starts_with("\nError:") {
+            start = prev_line_start + 1;
+        }
+    }
+
+    Some(Output::new(stderr[start..].trim_end()).into_string())
+}
+
+fn heuristic_error_str(stderr: &str) -> Option<String> {
+    // Starting Rust 1.66, Result-based errors simply print out "Error: ".
+    let error_match = ERROR_REGEX.find(stderr)?;
+    let start = error_match.start();
+    Some(Output::new(stderr[start..].trim_end()).into_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_heuristic_extract_description() {
+        let tests: &[(&str, &str)] = &[(
+            "running 1 test
+test test_failure_should_panic - should panic ... FAILED
+
+failures:
+
+---- test_failure_should_panic stdout ----
+note: test did not panic as expected
+
+failures:
+    test_failure_should_panic
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 13 filtered out; finished in 0.00s",
+            "note: test did not panic as expected",
+        )];
+
+        for (input, output) in tests {
+            assert_eq!(heuristic_should_panic(input).as_deref(), Some(*output));
+        }
+    }
+
+    #[test]
+    fn test_heuristic_stack_trace() {
+        let tests: &[(&str, &str)] = &[
+            (
+                "thread 'main' panicked at 'foo', src/lib.rs:1\n",
+                "thread 'main' panicked at 'foo', src/lib.rs:1",
+            ),
+            (
+                "foobar\n\
+            thread 'main' panicked at 'foo', src/lib.rs:1\n\n",
+                "thread 'main' panicked at 'foo', src/lib.rs:1",
+            ),
+            (
+                r#"
+text: foo
+Error: Custom { kind: InvalidData, error: "this is an error" }
+thread 'test_result_failure' panicked at 'assertion failed: `(left == right)`
+  left: `1`,
+ right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/test/src/lib.rs:186:5
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+            "#,
+                r#"Error: Custom { kind: InvalidData, error: "this is an error" }
+thread 'test_result_failure' panicked at 'assertion failed: `(left == right)`
+  left: `1`,
+ right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/test/src/lib.rs:186:5
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace"#,
+            ),
+        ];
+
+        for (input, output) in tests {
+            assert_eq!(heuristic_stack_trace(input).as_deref(), Some(*output));
+        }
+    }
+
+    #[test]
+    fn test_heuristic_error_str() {
+        let tests: &[(&str, &str)] = &[(
+            "foobar\nError: \"this is an error\"\n",
+            "Error: \"this is an error\"",
+        )];
+
+        for (input, output) in tests {
+            assert_eq!(heuristic_error_str(input).as_deref(), Some(*output));
+        }
+    }
+}

--- a/nextest-runner/src/reporter/helpers.rs
+++ b/nextest-runner/src/reporter/helpers.rs
@@ -4,7 +4,6 @@
 use crate::runner::{AbortStatus, ExecutionResult};
 use bstr::ByteSlice;
 use once_cell::sync::Lazy;
-use quick_junit::Output;
 use regex::bytes::{Regex, RegexBuilder};
 use std::fmt;
 
@@ -120,15 +119,6 @@ pub struct ByteSubslice<'a> {
 /// A display wrapper for [`DescriptionKind`].
 #[derive(Clone, Copy, Debug)]
 pub struct DescriptionKindDisplay<'a>(DescriptionKind<'a>);
-
-impl<'a> DescriptionKindDisplay<'a> {
-    /// Returns the displayer in a JUnit-compatible format.
-    ///
-    /// This format filters out invalid XML characters.
-    pub fn to_junit_output(self) -> Output {
-        Output::new(self.to_string())
-    }
-}
 
 impl fmt::Display for DescriptionKindDisplay<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/nextest-runner/src/reporter/mod.rs
+++ b/nextest-runner/src/reporter/mod.rs
@@ -11,4 +11,4 @@ mod helpers;
 pub mod structured;
 
 pub use displayer::*;
-pub use helpers::{heuristic_extract_description, DescriptionKind};
+pub use helpers::{heuristic_extract_description, highlight_end, DescriptionKind};

--- a/nextest-runner/src/reporter/mod.rs
+++ b/nextest-runner/src/reporter/mod.rs
@@ -11,4 +11,4 @@ mod helpers;
 pub mod structured;
 
 pub use displayer::*;
-pub use helpers::heuristic_extract_description;
+pub use helpers::{heuristic_extract_description, DescriptionKind};

--- a/nextest-runner/src/reporter/mod.rs
+++ b/nextest-runner/src/reporter/mod.rs
@@ -1,0 +1,14 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Report the results of a test run in human and machine-readable formats.
+//!
+//! The main type here is [`TestReporter`], which is constructed via a [`TestReporterBuilder`].
+
+mod aggregator;
+mod displayer;
+mod helpers;
+pub mod structured;
+
+pub use displayer::*;
+pub use helpers::heuristic_extract_description;

--- a/nextest-runner/src/reporter/structured.rs
+++ b/nextest-runner/src/reporter/structured.rs
@@ -3,7 +3,8 @@
 
 mod libtest;
 
-use super::*;
+use super::TestEvent;
+use crate::errors::WriteEventError;
 pub use libtest::{EmitNextestObject, LibtestReporter};
 
 /// Error returned when a user-supplied format version fails to be parsed to a

--- a/nextest-runner/src/reporter/structured/libtest.rs
+++ b/nextest-runner/src/reporter/structured/libtest.rs
@@ -22,11 +22,10 @@
 //! users to move to the new format or stick to the format version(s) they were
 //! using before
 
-use super::{
-    FormatVersionError, FormatVersionErrorInner, TestEvent, TestEventKind, WriteEventError,
-};
+use super::{FormatVersionError, FormatVersionErrorInner, TestEvent, WriteEventError};
 use crate::{
     list::RustTestSuite,
+    reporter::TestEventKind,
     runner::ExecutionResult,
     test_output::{TestOutput, TestSingleOutput},
 };

--- a/nextest-runner/src/reporter/structured/libtest.rs
+++ b/nextest-runner/src/reporter/structured/libtest.rs
@@ -509,7 +509,7 @@ fn strip_human_output_from_failed_test(
             // If stderr is not empty, just write all of it in.
             if !stderr.is_empty() {
                 write!(out, "\\n--- STDERR ---\\n").map_err(fmt_err)?;
-                write!(out, "{}", EscapedString(&stderr.to_str_lossy())).map_err(fmt_err)?;
+                write!(out, "{}", EscapedString(stderr.as_str_lossy())).map_err(fmt_err)?;
             }
         }
         Some(TestOutput::ExecFail { description, .. }) => {
@@ -555,7 +555,7 @@ fn strip_human_stdout_or_combined(
     } else {
         // This is most likely a custom test harness. Just write out the entire
         // output.
-        write!(out, "{}", EscapedString(&output.to_str_lossy())).map_err(fmt_err)?;
+        write!(out, "{}", EscapedString(output.as_str_lossy())).map_err(fmt_err)?;
     }
 
     Ok(())

--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     signal::{JobControlEvent, ShutdownEvent, SignalEvent, SignalHandler, SignalHandlerKind},
     target_runner::TargetRunner,
-    test_output::{CaptureStrategy, TestOutput, TestSingleOutput},
+    test_output::{CaptureStrategy, TestExecutionOutput, TestSingleOutput},
     time::{PausableSleep, StopwatchSnapshot, StopwatchStart},
 };
 use async_scoped::TokioScope;
@@ -924,7 +924,7 @@ impl<'a> TestRunnerInner<'a> {
                 let message = error.to_string();
                 let description = DisplayErrorChain::new(error).to_string();
                 InternalExecuteStatus {
-                    output: Some(TestOutput::ExecFail {
+                    output: Some(TestExecutionOutput::ExecFail {
                         message,
                         description,
                     }),
@@ -1088,7 +1088,7 @@ impl<'a> TestRunnerInner<'a> {
         let status = status.unwrap_or_else(|| create_execution_result(exit_status, leaked));
 
         Ok(InternalExecuteStatus {
-            output: test_output,
+            output: test_output.map(TestExecutionOutput::Output),
             result: status,
             stopwatch_end: stopwatch.snapshot(),
             is_slow,
@@ -1409,7 +1409,7 @@ pub struct ExecuteStatus {
     /// The stdout and stderr output for this test.
     ///
     /// This is None if the output wasn't caught.
-    pub output: Option<TestOutput>,
+    pub output: Option<TestExecutionOutput>,
     /// The execution result for this test: pass, fail or execution error.
     pub result: ExecutionResult,
     /// The time at which the test started.
@@ -1424,7 +1424,7 @@ pub struct ExecuteStatus {
 
 struct InternalExecuteStatus {
     // This is None if output wasn't captured.
-    output: Option<TestOutput>,
+    output: Option<TestExecutionOutput>,
     result: ExecutionResult,
     stopwatch_end: StopwatchSnapshot,
     is_slow: bool,

--- a/nextest-runner/tests/integration/basic.rs
+++ b/nextest-runner/tests/integration/basic.rs
@@ -176,11 +176,11 @@ fn test_run() -> Result<()> {
                             else {
                                 panic!("this test should always use split output")
                             };
-                            let stdout = stdout.to_str_lossy();
-                            let stderr = stderr.to_str_lossy();
+                            let stdout = stdout.as_str_lossy();
+                            let stderr = stderr.as_str_lossy();
                             println!("stderr: {stderr}");
                             let description =
-                                heuristic_extract_description(run_status.result, &stdout, &stderr);
+                                heuristic_extract_description(run_status.result, stdout, stderr);
                             assert!(
                                 description.is_some(),
                                 "failed to extract description from {}\n*** stdout:\n{stdout}\n*** stderr:\n{stderr}\n",

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -300,8 +300,8 @@ impl fmt::Debug for InstanceStatus {
                         run_status.retry_data.attempt,
                         run_status.retry_data.total_attempts,
                         run_status.result,
-                        stdout.to_str_lossy(),
-                        stderr.to_str_lossy(),
+                        stdout.as_str_lossy(),
+                        stderr.as_str_lossy(),
                     )?;
                 }
                 Ok(())

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -25,7 +25,7 @@ use nextest_runner::{
     },
     target_runner::TargetRunner,
     test_filter::{FilterBound, TestFilterBuilder},
-    test_output::TestOutput,
+    test_output::{TestExecutionOutput, TestOutput},
 };
 use once_cell::sync::Lazy;
 use std::{
@@ -291,7 +291,9 @@ impl fmt::Debug for InstanceStatus {
             InstanceStatus::Skipped(reason) => write!(f, "skipped: {reason}"),
             InstanceStatus::Finished(run_statuses) => {
                 for run_status in run_statuses.iter() {
-                    let Some(TestOutput::Split { stdout, stderr }) = &run_status.output else {
+                    let Some(TestExecutionOutput::Output(TestOutput::Split { stdout, stderr })) =
+                        &run_status.output
+                    else {
                         panic!("this test should always use split output")
                     };
                     write!(


### PR DESCRIPTION
With very long outputs, it can often be hard to tell which parts correspond immediately to the failure. Highlight those parts so users can easily tell.