### PR TITLE
Add support for silencing only one of the outputs of a test

### DIFF
--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -32,7 +32,8 @@ use nextest_runner::{
     redact::Redactor,
     reporter::{
         heuristic_extract_description, highlight_end, structured, DescriptionKind,
-        FinalStatusLevel, StatusLevel, TestOutputDisplay, TestReporterBuilder,
+        FinalStatusLevel, StatusLevel, TestOutputDisplay, TestOutputDisplayStreams,
+        TestReporterBuilder,
     },
     reuse_build::{archive_to_file, ArchiveReporter, PathMapper, ReuseBuildInfo},
     runner::{
@@ -55,6 +56,7 @@ use std::{
     env::VarError,
     fmt,
     io::{Cursor, Write},
+    str::FromStr,
     sync::Arc,
 };
 use swrite::{swrite, SWrite};
@@ -871,7 +873,10 @@ enum MessageFormat {
 #[derive(Debug, Default, Args)]
 #[command(next_help_heading = "Reporter options")]
 struct TestReporterOpts {
-    /// Output stdout and stderr on failure
+    /// Output stdout and/or stderr on failure
+    ///
+    /// Takes the form of: '{value}' or 'stdout={value}' or 'stdout={value},stderr={value}'
+    /// where {value} is one of: 'immediate', 'immediate-final', 'final', 'never'
     #[arg(
         long,
         value_enum,
@@ -879,9 +884,12 @@ struct TestReporterOpts {
         value_name = "WHEN",
         env = "NEXTEST_FAILURE_OUTPUT",
     )]
-    failure_output: Option<TestOutputDisplayOpt>,
+    failure_output: Option<TestOutputDisplayStreamsOpt>,
 
-    /// Output stdout and stderr on success
+    /// Output stdout and/or stderr on success
+    ///
+    /// Takes the form of: '{value}' or 'stdout={value}' or 'stdout={value},stderr={value}'
+    /// where {value} is one of: 'immediate', 'immediate-final', 'final', 'never'
     #[arg(
         long,
         value_enum,
@@ -889,7 +897,7 @@ struct TestReporterOpts {
         value_name = "WHEN",
         env = "NEXTEST_SUCCESS_OUTPUT",
     )]
-    success_output: Option<TestOutputDisplayOpt>,
+    success_output: Option<TestOutputDisplayStreamsOpt>,
 
     // status_level does not conflict with --no-capture because pass vs skip still makes sense.
     /// Test statuses to output
@@ -960,6 +968,68 @@ impl TestReporterOpts {
         }
         builder.set_hide_progress_bar(self.hide_progress_bar);
         builder
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TestOutputDisplayStreamsOpt {
+    stdout: Option<TestOutputDisplayOpt>,
+    stderr: Option<TestOutputDisplayOpt>,
+}
+
+impl FromStr for TestOutputDisplayStreamsOpt {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // expected input has three forms
+        // - "{value}":                         where value is one of [immediate, immediate-final, final, never]
+        // - "{stream}={value}":                where {stream} is one of [stdout, stderr]
+        // - "{stream}={value},{stream=value}": where the two {stream} keys cannot be the same
+        let (stdout, stderr) = if let Some((left, right)) = s.split_once(',') {
+            // the "{stream}={value},{stream=value}" case
+            let left = left
+                .split_once('=')
+                .map(|l| (l.0, TestOutputDisplayOpt::from_str(l.1, false)));
+            let right = right
+                .split_once('=')
+                .map(|r| (r.0, TestOutputDisplayOpt::from_str(r.1, false)));
+            match (left, right) {
+                (Some(("stderr", Ok(stderr))), Some(("stdout", Ok(stdout)))) => (Some(stdout), Some(stderr)),
+                (Some(("stdout", Ok(stdout))), Some(("stderr", Ok(stderr)))) => (Some(stdout), Some(stderr)),
+                (Some((stream @ "stdout" | stream @ "stderr", Err(_))), _) => return Err(format!("\n  unrecognized setting for {stream}: [possible values: immediate, immediate-final, final, never]")),
+                (_, Some((stream @ "stdout" | stream @ "stderr", Err(_)))) => return Err(format!("\n  unrecognized setting for {stream}: [possible values: immediate, immediate-final, final, never]")),
+                (Some(("stdout", _)), Some(("stdout", _))) => return Err("\n  stdout specified twice".to_string()),
+                (Some(("stderr", _)), Some(("stderr", _))) => return Err("\n  stderr specified twice".to_string()),
+                (Some((stream, _)), Some(("stdout" | "stderr", _))) => return Err(format!("\n  unrecognized output stream '{stream}': [possible values: stdout, stderr]")),
+                (Some(("stdout" | "stderr", _)), Some((stream, _))) => return Err(format!("\n  unrecognized output stream '{stream}': [possible values: stdout, stderr]")),
+                (_, _) => return Err("\n  [possible values: immediate, immediate-final, final, never], or specify one or both output streams: stdout={}, stderr={}, stdout={},stderr={}".to_string()),
+            }
+        } else if let Some((stream, right)) = s.split_once('=') {
+            // the "{stream}={value}" case
+            let value = TestOutputDisplayOpt::from_str(right, false);
+            match (stream, value) {
+                ("stderr", Ok(stderr)) => (None, Some(stderr)),
+                ("stdout", Ok(stdout)) => (Some(stdout), None),
+                ("stdout" | "stderr", Err(_)) => return Err(format!("\n  unrecognized setting for {stream}: [possible values: immediate, immediate-final, final, never]")),
+                (_, _) => return Err("\n  unrecognized output stream, possible values: [stdout={}, stderr={}, stdout={},stderr={}]".to_string())
+            }
+        } else if let Ok(value) = TestOutputDisplayOpt::from_str(s, false) {
+            // the "{value}" case
+            (Some(value), Some(value))
+        } else {
+            // did not recognize one of the three cases
+            return Err("\n  [possible values: immediate, immediate-final, final, never], or specify one or both output streams: stdout={}, stderr={}, stdout={},stderr={}".to_string());
+        };
+        Ok(Self { stdout, stderr })
+    }
+}
+
+impl From<TestOutputDisplayStreamsOpt> for TestOutputDisplayStreams {
+    fn from(value: TestOutputDisplayStreamsOpt) -> Self {
+        Self {
+            stdout: value.stdout.map(TestOutputDisplay::from),
+            stderr: value.stderr.map(TestOutputDisplay::from),
+        }
     }
 }
 

--- a/nextest-runner/src/config/config_impl.rs
+++ b/nextest-runner/src/config/config_impl.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     list::TestList,
     platform::BuildPlatforms,
-    reporter::{FinalStatusLevel, StatusLevel, TestOutputDisplay},
+    reporter::{FinalStatusLevel, StatusLevel, TestOutputDisplayStreams},
 };
 use camino::{Utf8Path, Utf8PathBuf};
 use config::{builder::DefaultState, Config, ConfigBuilder, File, FileFormat, FileSourceFile};
@@ -702,14 +702,14 @@ impl<'cfg> NextestProfile<'cfg, FinalConfig> {
     }
 
     /// Returns the failure output config for this profile.
-    pub fn failure_output(&self) -> TestOutputDisplay {
+    pub fn failure_output(&self) -> TestOutputDisplayStreams {
         self.custom_profile
             .and_then(|profile| profile.failure_output)
             .unwrap_or(self.default_profile.failure_output)
     }
 
     /// Returns the failure output config for this profile.
-    pub fn success_output(&self) -> TestOutputDisplay {
+    pub fn success_output(&self) -> TestOutputDisplayStreams {
         self.custom_profile
             .and_then(|profile| profile.success_output)
             .unwrap_or(self.default_profile.success_output)
@@ -905,8 +905,8 @@ pub(super) struct DefaultProfileImpl {
     retries: RetryPolicy,
     status_level: StatusLevel,
     final_status_level: FinalStatusLevel,
-    failure_output: TestOutputDisplay,
-    success_output: TestOutputDisplay,
+    failure_output: TestOutputDisplayStreams,
+    success_output: TestOutputDisplayStreams,
     fail_fast: bool,
     slow_timeout: SlowTimeout,
     leak_timeout: Duration,
@@ -1007,9 +1007,9 @@ pub(super) struct CustomProfileImpl {
     #[serde(default)]
     final_status_level: Option<FinalStatusLevel>,
     #[serde(default)]
-    failure_output: Option<TestOutputDisplay>,
+    failure_output: Option<TestOutputDisplayStreams>,
     #[serde(default)]
-    success_output: Option<TestOutputDisplay>,
+    success_output: Option<TestOutputDisplayStreams>,
     #[serde(default)]
     fail_fast: Option<bool>,
     #[serde(default, deserialize_with = "super::deserialize_slow_timeout")]

--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -17,7 +17,8 @@ use crate::{
     },
     list::{TestExecuteContext, TestInstance, TestList},
     reporter::{
-        CancelReason, FinalStatusLevel, StatusLevel, TestEvent, TestEventKind, TestOutputDisplay,
+        CancelReason, FinalStatusLevel, StatusLevel, TestEvent, TestEventKind,
+        TestOutputDisplayStreams,
     },
     signal::{JobControlEvent, ShutdownEvent, SignalEvent, SignalHandler, SignalHandlerKind},
     target_runner::TargetRunner,
@@ -2056,7 +2057,7 @@ enum InternalTestEvent<'a> {
     },
     AttemptFailedWillRetry {
         test_instance: TestInstance<'a>,
-        failure_output: TestOutputDisplay,
+        failure_output: TestOutputDisplayStreams,
         run_status: ExecuteStatus,
         delay_before_next_attempt: Duration,
     },
@@ -2066,8 +2067,8 @@ enum InternalTestEvent<'a> {
     },
     Finished {
         test_instance: TestInstance<'a>,
-        success_output: TestOutputDisplay,
-        failure_output: TestOutputDisplay,
+        success_output: TestOutputDisplayStreams,
+        failure_output: TestOutputDisplayStreams,
         junit_store_success_output: bool,
         junit_store_failure_output: bool,
         run_statuses: ExecutionStatuses,


### PR DESCRIPTION
The old syntax is still supported, the new complete syntax is:
 - "{value}":                         where value is one of [immediate, immediate-final, final, never]
 - "{stream}={value}":                where {stream} is one of [stdout, stderr]
 - "{stream}={value},{stream=value}": where the two {stream} keys cannot be the same

For tests where the output is combined (currently only used for libtest-json output), only the stdout value is used.

There is a small regression where the CLI won't suggest values that are close to the incorrect input, i.e. if you input 'imediate' it won't suggest 'immediate'.

I've not added tests yet, I first wanted to make sure that the implementation is acceptable for inclusion into nextest.

Closes #1688 