### PR TITLE
[cargo-nextest] also fix --skip with --exact

### DIFF
--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -715,7 +715,11 @@ impl TestBuildFilter {
                     )
                 })?;
 
-                patterns.add_skip_pattern(skip_arg.clone());
+                if is_exact {
+                    patterns.add_skip_exact_pattern(skip_arg.clone());
+                } else {
+                    patterns.add_skip_pattern(skip_arg.clone());
+                }
             } else if arg == "--exact" {
                 // Already handled above.
             } else {
@@ -2617,14 +2621,30 @@ mod tests {
         ];
         let skip_exact = &[
             // ---
+            // skip
+            // ---
+            ("foo -- --skip my-pattern --skip your-pattern", {
+                let mut patterns = TestFilterPatterns::default();
+                patterns.add_skip_pattern("my-pattern".to_owned());
+                patterns.add_skip_pattern("your-pattern".to_owned());
+                patterns
+            }),
+            ("foo -- pattern1 --skip my-pattern --skip your-pattern", {
+                let mut patterns = TestFilterPatterns::default();
+                patterns.add_substring_pattern("pattern1".to_owned());
+                patterns.add_skip_pattern("my-pattern".to_owned());
+                patterns.add_skip_pattern("your-pattern".to_owned());
+                patterns
+            }),
+            // ---
             // skip and exact
             // ---
             (
                 "foo -- --skip my-pattern --skip your-pattern exact1 --exact pattern2",
                 {
                     let mut patterns = TestFilterPatterns::default();
-                    patterns.add_skip_pattern("my-pattern".to_owned());
-                    patterns.add_skip_pattern("your-pattern".to_owned());
+                    patterns.add_skip_exact_pattern("my-pattern".to_owned());
+                    patterns.add_skip_exact_pattern("your-pattern".to_owned());
                     patterns.add_exact_pattern("exact1".to_owned());
                     patterns.add_exact_pattern("pattern2".to_owned());
                     patterns

--- a/integration-tests/tests/integration/main.rs
+++ b/integration-tests/tests/integration/main.rs
@@ -510,9 +510,9 @@ fn test_run() {
             "--exact",
             "tests::test_multiply_two_cdylib",
             "--skip",
-            "cdylib",
+            "tests::test_multiply_two_cdylib",
         ])
-        // This should only select the two test_multiply_two tests, which pass. So don't pass in
+        // This should only select the one test_multiply_two test, which pass. So don't pass in
         // unchecked(true) here.
         .output();
     check_run_output(
@@ -529,7 +529,7 @@ fn test_run() {
             "--workspace",
             "--all-targets",
             "-E",
-            "(test(=test_multiply_two) | test(=tests::test_multiply_two_cdylib)) & not test(cdylib)",
+            "(test(=test_multiply_two) | test(=tests::test_multiply_two_cdylib)) & not test(=tests::test_multiply_two_cdylib)",
         ])
         // This should only select the test_multiply_two test, which passes. So don't pass in
         // unchecked(true) here.
@@ -576,7 +576,7 @@ fn test_run() {
             "--exact",
             "tests::test_multiply_two_cdylib",
         ])
-        // This should only select the two test_multiply_two tests, which pass. So don't pass in
+        // This should only select the test_multiply_two test, which passes. So don't pass in
         // unchecked(true) here.
         .output();
     check_run_output(


### PR DESCRIPTION
If both `--skip` and `--exact` are passed in at the same time, then `--skip` also matches filters exactly.