### PR TITLE
Set environment variables specified via `cargo::rustc-env` in the build script

### DIFF
--- a/fixture-data/src/nextest_tests.rs
+++ b/fixture-data/src/nextest_tests.rs
@@ -166,6 +166,7 @@ pub static EXPECTED_TEST_SUITES: Lazy<BTreeMap<RustBinaryId, TestSuiteFixture>> 
             "with-build-script",
             BuildPlatform::Target,
             vec![
+                TestCaseFixture::new("tests::test_build_script_vars_set", TestCaseFixtureStatus::Pass),
                 TestCaseFixture::new("tests::test_out_dir_present", TestCaseFixtureStatus::Pass),
             ],
         ),

--- a/fixtures/nextest-tests/with-build-script/build.rs
+++ b/fixtures/nextest-tests/with-build-script/build.rs
@@ -9,4 +9,28 @@ fn main() {
 
     // The presence of this file is checked by a test.
     std::fs::write(out_dir.join("this-is-a-test-file"), "test-contents").unwrap();
+
+    // Needed for 1.79+
+    println!("cargo:rustc-check-cfg=cfg(new_format)");
+
+    // The presence of these environment variables is checked by a test.
+    if rustc_minor_version().is_some_and(|minor| minor >= 77) {
+        println!("cargo::rustc-cfg=new_format");
+        println!("cargo::rustc-env=BUILD_SCRIPT_NEW_FMT=new_val");
+    }
+    println!("cargo:rustc-env=BUILD_SCRIPT_OLD_FMT=old_val");
+}
+
+fn rustc_minor_version() -> Option<u32> {
+    let rustc = std::env::var_os("RUSTC")?;
+    let output = std::process::Command::new(rustc)
+        .arg("--version")
+        .output()
+        .ok()?;
+    let version = std::str::from_utf8(&output.stdout).ok()?;
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+    pieces.next()?.parse().ok()
 }

--- a/fixtures/nextest-tests/with-build-script/src/lib.rs
+++ b/fixtures/nextest-tests/with-build-script/src/lib.rs
@@ -12,4 +12,17 @@ mod tests {
         let contents = std::fs::read(&path).expect("test file exists in OUT_DIR");
         assert_eq!(contents, b"test-contents");
     }
+
+    #[test]
+    fn test_build_script_vars_set() {
+        // Since the build script wrote `cargo::rustc-env` instructions, these variables are
+        // expected to be set by nextest
+        #[cfg(new_format)]
+        {
+            let val = std::env::var("BUILD_SCRIPT_NEW_FMT").expect("BUILD_SCRIPT_NEW_FMT is valid");
+            assert_eq!(val, "new_val");
+        }
+        let val = std::env::var("BUILD_SCRIPT_OLD_FMT").expect("BUILD_SCRIPT_OLD_FMT is valid");
+        assert_eq!(val, "old_val");
+    }
 }

--- a/integration-tests/tests/integration/snapshots/integration__list_with_default_set_basic.snap
+++ b/integration-tests/tests/integration/snapshots/integration__list_with_default_set_basic.snap
@@ -37,4 +37,5 @@ nextest-tests::example/nextest-tests:
 nextest-tests::example/other:
     tests::other_example_success
 with-build-script:
+    tests::test_build_script_vars_set
     tests::test_out_dir_present

--- a/integration-tests/tests/integration/snapshots/integration__list_with_default_set_bound_all.snap
+++ b/integration-tests/tests/integration/snapshots/integration__list_with_default_set_bound_all.snap
@@ -41,4 +41,5 @@ nextest-tests::example/nextest-tests:
 nextest-tests::example/other:
     tests::other_example_success
 with-build-script:
+    tests::test_build_script_vars_set
     tests::test_out_dir_present

--- a/integration-tests/tests/integration/snapshots/integration__list_with_default_set_expr_all.snap
+++ b/integration-tests/tests/integration/snapshots/integration__list_with_default_set_expr_all.snap
@@ -37,4 +37,5 @@ nextest-tests::example/nextest-tests:
 nextest-tests::example/other:
     tests::other_example_success
 with-build-script:
+    tests::test_build_script_vars_set
     tests::test_out_dir_present

--- a/integration-tests/tests/integration/snapshots/integration__list_with_default_set_expr_default.snap
+++ b/integration-tests/tests/integration/snapshots/integration__list_with_default_set_expr_default.snap
@@ -37,4 +37,5 @@ nextest-tests::example/nextest-tests:
 nextest-tests::example/other:
     tests::other_example_success
 with-build-script:
+    tests::test_build_script_vars_set
     tests::test_out_dir_present

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-2.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-2.snap
@@ -47,5 +47,6 @@ group: @global
       nextest-tests::example/other:
           tests::other_example_success
       with-build-script:
+          tests::test_build_script_vars_set
           tests::test_out_dir_present
 

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-4.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-4.snap
@@ -48,5 +48,6 @@ group: @global
       nextest-tests::example/other:
           tests::other_example_success
       with-build-script:
+          tests::test_build_script_vars_set
           tests::test_out_dir_present
 

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-6.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-6.snap
@@ -49,5 +49,6 @@ group: @global
       nextest-tests::example/other:
           tests::other_example_success
       with-build-script:
+          tests::test_build_script_vars_set
           tests::test_out_dir_present
 

--- a/site/src/docs/configuration/env-vars.md
+++ b/site/src/docs/configuration/env-vars.md
@@ -152,6 +152,9 @@ Nextest also sets these environment variables at runtime, matching the behavior 
 
 Additionally, environment variables specified in [the `[env]` section of `.cargo/config.toml`](https://doc.rust-lang.org/cargo/reference/config.html#env) are also set.
 
+Since `cargo test` also sets variables specified in the build script via [`cargo::rustc-env`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-env) at test runtime, `nextest` does the same.
+However, note that [`cargo` discourages using these variables at runtime](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-env).
+
 ### Dynamic library paths
 
 Nextest sets the dynamic library path at runtime, similar to [what Cargo does](https://doc.rust-lang.org/cargo/reference/environment-variables.html#dynamic-library-paths). This helps with locating shared libraries that are part of the build process. The variable name depends on the platform:


### PR DESCRIPTION
As discussed in #1787, `cargo test` does this, so `nextest` should too.

I added warnings in case the build script output file is not found, this should usually have been created when cargo executes the build script.
I also decided to package the build script output _file_ in the same step as the build script output _directory_.
Let me know if you prefer creating a separate step for this.

I tried to approach this with minimal changes, maybe it would be nicer to store the path to the `$OUT_DIR` _parent_, so that getting the path of the output file is a tad simpler, but that would have required me touching more code.
Let me know if you have suggestions for implementing any of this differently.

Side note: trying to run tests with `cargo run -p cargo-nextest -- nextest run --all-features` failed with tracing complaining that it failed to set a global subscriber since one is already set, so I ran tests without the `--all-features` flag.