### PR TITLE
[ci] try using Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,8 +130,9 @@ jobs:
 
   test-archive-target-runner:
     name: Test archives with a target runner
-    # gcc-mingw-w64-x86-64-win32 requires Ubuntu 22.04
-    runs-on: ubuntu-22.04
+    # We need at least 24.04 for updated wine and mingw. 22.04 has a wine that's too old (and the
+    # official WineHQ PPA breaks every so often).
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
       - name: Install Rust toolchain
@@ -140,20 +141,10 @@ jobs:
           toolchain: stable
           targets: x86_64-pc-windows-gnu
       - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # v2
-
-      # The version of wine that comes with Ubuntu 22.04 is too old: it doesn't contain
-      # bcryptprimitives.dll, which is required to run binaries built with Rust 1.78+. We use the
-      # WineHQ PPA to get a newer version.
-      - name: Add Wine PPA
-        run: |
-          sudo dpkg --add-architecture i386
-          wget -nc https://dl.winehq.org/wine-builds/winehq.key
-          sudo apt-key add winehq.key
-          sudo add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ jammy main'
       - name: Install wine and gcc-mingw-w64-x86-64-win32
         run: |
           sudo apt-get update
-          sudo apt-get install winehq-stable gcc-mingw-w64-x86-64-win32
+          sudo apt-get install wine gcc-mingw-w64-x86-64-win32
       - name: Build cargo-nextest
         run: cargo build --package cargo-nextest
       - name: Archive test fixtures


### PR DESCRIPTION
The Wine PPA for Ubuntu 22.04 seems to currently be broken, returning a `Packages.xz` that doesn't match the `InRelease` manifest. Try out Ubuntu 24.04 and the shipped version of Wine.