### PR TITLE
[nextest-runner] demo of a hang

### DIFF
--- a/nextest-runner/src/runner.rs
+++ b/nextest-runner/src/runner.rs
@@ -1082,6 +1082,9 @@ impl<'a> TestRunnerInner<'a> {
                     () = sleep, if !child_fds.is_done() => {
                         break true;
                     }
+                    _ = forward_receiver.recv() => {
+                        // XXX: Why does this hang here?
+                    }
                     else => {
                         break false;
                     }


### PR DESCRIPTION
Repro (just to keep it as minimal as possible + allow attaching a Tokio console)

```
cargo run -p cargo-nextest --all-features -- nextest run -p nextest-filtering -j1
```