### PR TITLE
[nextest-runner] simplify reporter error handling

### DIFF
--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -1821,11 +1821,11 @@ impl App {
                     }
                 }
             }
-            FinalRunStats::Canceled(RunStatsFailureKind::SetupScript)
+            FinalRunStats::Cancelled(RunStatsFailureKind::SetupScript)
             | FinalRunStats::Failed(RunStatsFailureKind::SetupScript) => {
                 Err(ExpectedError::setup_script_failed())
             }
-            FinalRunStats::Canceled(RunStatsFailureKind::Test { .. })
+            FinalRunStats::Cancelled(RunStatsFailureKind::Test { .. })
             | FinalRunStats::Failed(RunStatsFailureKind::Test { .. }) => {
                 Err(ExpectedError::test_run_failed())
             }

--- a/nextest-runner/src/reporter/displayer.rs
+++ b/nextest-runner/src/reporter/displayer.rs
@@ -965,7 +965,7 @@ impl<'a> TestReporterImpl<'a> {
                 let summary_style = match stats_summary {
                     FinalRunStats::Success => self.styles.pass,
                     FinalRunStats::NoTestsRun => self.styles.skip,
-                    FinalRunStats::Failed(_) | FinalRunStats::Canceled(_) => self.styles.fail,
+                    FinalRunStats::Failed(_) | FinalRunStats::Cancelled(_) => self.styles.fail,
                 };
                 write!(
                     writer,
@@ -1843,7 +1843,7 @@ fn write_final_warnings(
             initial_run_count,
             not_run,
         })
-        | FinalRunStats::Canceled(RunStatsFailureKind::Test {
+        | FinalRunStats::Cancelled(RunStatsFailureKind::Test {
             initial_run_count,
             not_run,
         }) if not_run > 0 => {
@@ -2091,7 +2091,7 @@ pub enum TestEventKind<'a> {
         /// The number of tests still running.
         running: usize,
 
-        /// The reason this run was canceled.
+        /// The reason this run was cancelled.
         reason: CancelReason,
     },
 
@@ -2771,7 +2771,7 @@ mod tests {
         assert_eq!(warnings, "warning: 5/8 tests were not run due to signal\n");
 
         let warnings = final_warnings_for(
-            FinalRunStats::Canceled(RunStatsFailureKind::Test {
+            FinalRunStats::Cancelled(RunStatsFailureKind::Test {
                 initial_run_count: 1,
                 not_run: 1,
             }),
@@ -2798,7 +2798,7 @@ mod tests {
 
         // No warnings for setup script cancellation.
         let warnings = final_warnings_for(
-            FinalRunStats::Canceled(RunStatsFailureKind::SetupScript),
+            FinalRunStats::Cancelled(RunStatsFailureKind::SetupScript),
             Some(CancelReason::Interrupt),
         );
         assert_eq!(warnings, "");


### PR DESCRIPTION
Trying to handle reporter errors in the main runner loop is a bit of a mess. Instead, handle them at a higher level and use a oneshot channel to indicate that an error has occurred. This fits in quite naturally with the rest of the event-driven system.

Also change "canceled" to "cancelled" for consistency.