### PR TITLE
[nextest-runner] move FormatVersionError to errors.rs

### DIFF
--- a/nextest-runner/src/reporter/structured.rs
+++ b/nextest-runner/src/reporter/structured.rs
@@ -7,48 +7,6 @@ use super::TestEvent;
 use crate::errors::WriteEventError;
 pub use libtest::{EmitNextestObject, LibtestReporter};
 
-/// Error returned when a user-supplied format version fails to be parsed to a
-/// valid and supported version
-#[derive(Clone, Debug, thiserror::Error)]
-#[error("invalid format version: {input}")]
-pub struct FormatVersionError {
-    /// The input that failed to parse.
-    pub input: String,
-    /// The underlying error
-    #[source]
-    pub err: FormatVersionErrorInner,
-}
-
-/// The different errors that can occur when parsing and validating a format version
-#[derive(Clone, Debug, thiserror::Error)]
-pub enum FormatVersionErrorInner {
-    /// The input did not have a valid syntax
-    #[error("expected format version in form of `{expected}`")]
-    InvalidFormat {
-        /// The expected pseudo format
-        expected: &'static str,
-    },
-    /// A decimal integer was expected but could not be parsed
-    #[error("version component `{which}` could not be parsed as an integer")]
-    InvalidInteger {
-        /// Which component was invalid
-        which: &'static str,
-        /// The parse failure
-        #[source]
-        err: std::num::ParseIntError,
-    },
-    /// The version component was not within th expected range
-    #[error("version component `{which}` value {value} is out of range {range:?}")]
-    InvalidValue {
-        /// The component which was out of range
-        which: &'static str,
-        /// The value that was parsed
-        value: u8,
-        /// The range of valid values for the component
-        range: std::ops::Range<u8>,
-    },
-}
-
 /// A reporter for structured, machine-readable formats.
 #[derive(Default)]
 pub struct StructuredReporter<'a> {

--- a/nextest-runner/src/reporter/structured/libtest.rs
+++ b/nextest-runner/src/reporter/structured/libtest.rs
@@ -22,8 +22,9 @@
 //! users to move to the new format or stick to the format version(s) they were
 //! using before
 
-use super::{FormatVersionError, FormatVersionErrorInner, TestEvent, WriteEventError};
+use super::{TestEvent, WriteEventError};
 use crate::{
+    errors::{FormatVersionError, FormatVersionErrorInner},
     list::RustTestSuite,
     reporter::TestEventKind,
     runner::ExecutionResult,
@@ -159,7 +160,7 @@ impl<'cfg> LibtestReporter<'cfg> {
         let Some((major, minor)) = version.split_once('.') else {
             return Err(FormatVersionError {
                 input: version.into(),
-                err: FormatVersionErrorInner::InvalidFormat {
+                error: FormatVersionErrorInner::InvalidFormat {
                     expected: "<major>.<minor>",
                 },
             });
@@ -167,7 +168,7 @@ impl<'cfg> LibtestReporter<'cfg> {
 
         let major: u8 = major.parse().map_err(|err| FormatVersionError {
             input: version.into(),
-            err: FormatVersionErrorInner::InvalidInteger {
+            error: FormatVersionErrorInner::InvalidInteger {
                 which: "major",
                 err,
             },
@@ -175,7 +176,7 @@ impl<'cfg> LibtestReporter<'cfg> {
 
         let minor: u8 = minor.parse().map_err(|err| FormatVersionError {
             input: version.into(),
-            err: FormatVersionErrorInner::InvalidInteger {
+            error: FormatVersionErrorInner::InvalidInteger {
                 which: "minor",
                 err,
             },
@@ -186,7 +187,7 @@ impl<'cfg> LibtestReporter<'cfg> {
             o => {
                 return Err(FormatVersionError {
                     input: version.into(),
-                    err: FormatVersionErrorInner::InvalidValue {
+                    error: FormatVersionErrorInner::InvalidValue {
                         which: "major",
                         value: o,
                         range: (FormatMajorVersion::Unstable as u8)
@@ -201,7 +202,7 @@ impl<'cfg> LibtestReporter<'cfg> {
             o => {
                 return Err(FormatVersionError {
                     input: version.into(),
-                    err: FormatVersionErrorInner::InvalidValue {
+                    error: FormatVersionErrorInner::InvalidValue {
                         which: "minor",
                         value: o,
                         range: (FormatMinorVersion::First as u8)..(FormatMinorVersion::_Max as u8),


### PR DESCRIPTION
All errors go in this central location.