### PR TITLE
feat: support hyphen values for --build-jobs

### DIFF
--- a/cargo-nextest/src/cargo_cli.rs
+++ b/cargo-nextest/src/cargo_cli.rs
@@ -98,7 +98,8 @@ pub(crate) struct CargoOptions {
         long,
         value_name = "N",
         group = "cargo-opts",
-        help_heading = "Compilation options"
+        help_heading = "Compilation options",
+        allow_hyphen_values = true
     )]
     build_jobs: Option<String>,
 

--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -2406,6 +2406,9 @@ mod tests {
             // Test negative test threads
             "cargo nextest run --jobs -3",
             "cargo nextest run --jobs 3",
+            // Test negative cargo build jobs
+            "cargo nextest run --build-jobs -1",
+            "cargo nextest run --build-jobs 1",
         ];
 
         let invalid: &[(&'static str, ErrorKind)] = &[


### PR DESCRIPTION
cargo --jobs supports negative values: https://github.com/rust-lang/cargo/issues/9217

currently this fails:

```
cargo nextest run --build-jobs -1                                                                                                                                                                                                   
error: unexpected argument '-1' found

  tip: to pass '-1' as a value, use '-- -1'
```

because clap doesn't support this by default and requires `allow_hyphen_values = true`

https://github.com/clap-rs/clap/issues/1245