### PR TITLE
Add a FAIL + LEAK test along with coverage for outputs being displayed

### DIFF
--- a/fixture-data/src/models.rs
+++ b/fixture-data/src/models.rs
@@ -86,6 +86,7 @@ pub enum TestCaseFixtureStatus {
     Fail,
     Flaky { pass_attempt: usize },
     Leak,
+    FailLeak,
     Segfault,
     IgnoredPass,
     IgnoredFail,

--- a/fixture-data/src/nextest_tests.rs
+++ b/fixture-data/src/nextest_tests.rs
@@ -51,6 +51,7 @@ pub static EXPECTED_TEST_SUITES: Lazy<BTreeMap<RustBinaryId, TestSuiteFixture>> 
                 ),
                 TestCaseFixture::new("test_stdin_closed", TestCaseFixtureStatus::Pass),
                 TestCaseFixture::new("test_subprocess_doesnt_exit", TestCaseFixtureStatus::Leak),
+                TestCaseFixture::new("test_subprocess_doesnt_exit_fail", TestCaseFixtureStatus::FailLeak),
                 TestCaseFixture::new("test_success", TestCaseFixtureStatus::Pass),
                 TestCaseFixture::new("test_success_should_panic", TestCaseFixtureStatus::Pass),
             ],

--- a/fixtures/nextest-tests/tests/basic.rs
+++ b/fixtures/nextest-tests/tests/basic.rs
@@ -308,6 +308,15 @@ fn test_subprocess_doesnt_exit() {
     cmd.spawn().unwrap();
 }
 
+#[cfg(any(unix, windows))]
+#[test]
+fn test_subprocess_doesnt_exit_fail() {
+    let mut cmd = sleep_cmd(360);
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.spawn().unwrap();
+    panic!("this is a panic");
+}
+
 #[cfg(windows)]
 fn sleep_cmd(secs: usize) -> std::process::Command {
     // Apparently, this is the most reliable way to sleep for a bit on Windows.

--- a/integration-tests/tests/integration/fixtures.rs
+++ b/integration-tests/tests/integration/fixtures.rs
@@ -294,6 +294,7 @@ enum CheckResult {
     Pass,
     Leak,
     Fail,
+    FailLeak,
     Abort,
 }
 
@@ -304,6 +305,7 @@ impl CheckResult {
             CheckResult::Pass => Regex::new(&format!(r"PASS \[.*\] *{name}")).unwrap(),
             CheckResult::Leak => Regex::new(&format!(r"LEAK \[.*\] *{name}")).unwrap(),
             CheckResult::Fail => Regex::new(&format!(r"FAIL \[.*\] *{name}")).unwrap(),
+            CheckResult::FailLeak => Regex::new(&format!(r"FAIL \+ LEAK \[.*\] *{name}")).unwrap(),
             CheckResult::Abort => Regex::new(&format!(r"(ABORT|SIGSEGV) \[.*\] *{name}")).unwrap(),
         }
     }
@@ -445,6 +447,14 @@ pub fn check_run_output(stderr: &[u8], properties: u64) {
                     run_count += 1;
                     fail_count += 1;
                     CheckResult::Fail
+                }
+                TestCaseFixtureStatus::FailLeak => {
+                    run_count += 1;
+                    fail_count += 1;
+                    // Currently, fail + leak tests are not added to the
+                    // leak_count, just the fail_count. (Maybe this is worth
+                    // changing in the UI?)
+                    CheckResult::FailLeak
                 }
                 TestCaseFixtureStatus::Segfault => {
                     run_count += 1;

--- a/integration-tests/tests/integration/snapshots/integration__list_with_default_set_basic.snap
+++ b/integration-tests/tests/integration/snapshots/integration__list_with_default_set_basic.snap
@@ -19,6 +19,7 @@ nextest-tests::basic:
     test_result_failure
     test_stdin_closed
     test_subprocess_doesnt_exit
+    test_subprocess_doesnt_exit_fail
     test_success
     test_success_should_panic
 nextest-tests::other:

--- a/integration-tests/tests/integration/snapshots/integration__list_with_default_set_bound_all.snap
+++ b/integration-tests/tests/integration/snapshots/integration__list_with_default_set_bound_all.snap
@@ -1,6 +1,7 @@
 ---
 source: integration-tests/tests/integration/main.rs
 expression: bound_all_output.stdout_as_str()
+snapshot_kind: text
 ---
 cdylib-example:
     tests::test_multiply_two_cdylib
@@ -23,6 +24,7 @@ nextest-tests::basic:
     test_result_failure
     test_stdin_closed
     test_subprocess_doesnt_exit
+    test_subprocess_doesnt_exit_fail
     test_success
     test_success_should_panic
 nextest-tests::other:

--- a/integration-tests/tests/integration/snapshots/integration__list_with_default_set_expr_all.snap
+++ b/integration-tests/tests/integration/snapshots/integration__list_with_default_set_expr_all.snap
@@ -19,6 +19,7 @@ nextest-tests::basic:
     test_result_failure
     test_stdin_closed
     test_subprocess_doesnt_exit
+    test_subprocess_doesnt_exit_fail
     test_success
     test_success_should_panic
 nextest-tests::other:

--- a/integration-tests/tests/integration/snapshots/integration__list_with_default_set_expr_default.snap
+++ b/integration-tests/tests/integration/snapshots/integration__list_with_default_set_expr_default.snap
@@ -19,6 +19,7 @@ nextest-tests::basic:
     test_result_failure
     test_stdin_closed
     test_subprocess_doesnt_exit
+    test_subprocess_doesnt_exit_fail
     test_success
     test_success_should_panic
 nextest-tests::other:

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-2.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-2.snap
@@ -1,6 +1,7 @@
 ---
 source: integration-tests/tests/integration/main.rs
 expression: default_profile_all_output.stdout_as_str()
+snapshot_kind: text
 ---
 group: flaky (max threads = 4)
     (no matches)
@@ -29,6 +30,7 @@ group: @global
           test_result_failure
           test_stdin_closed
           test_subprocess_doesnt_exit
+          test_subprocess_doesnt_exit_fail
           test_success
           test_success_should_panic
       nextest-tests::other:
@@ -49,4 +51,3 @@ group: @global
       with-build-script:
           tests::test_build_script_vars_set
           tests::test_out_dir_present
-

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-4.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-4.snap
@@ -1,6 +1,7 @@
 ---
 source: integration-tests/tests/integration/main.rs
 expression: with_retries_all_output.stdout_as_str()
+snapshot_kind: text
 ---
 group: flaky (max threads = 4)
   * override for with-retries profile with filter 'test(test_flaky_mod) | test(~test_flaky_mod_4)':
@@ -30,6 +31,7 @@ group: @global
           test_result_failure
           test_stdin_closed
           test_subprocess_doesnt_exit
+          test_subprocess_doesnt_exit_fail
           test_success
           test_success_should_panic
       nextest-tests::other:
@@ -50,4 +52,3 @@ group: @global
       with-build-script:
           tests::test_build_script_vars_set
           tests::test_out_dir_present
-

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-6.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-6.snap
@@ -1,6 +1,7 @@
 ---
 source: integration-tests/tests/integration/main.rs
 expression: with_termination_all_output.stdout_as_str()
+snapshot_kind: text
 ---
 group: flaky (max threads = 4)
     (no matches)
@@ -31,6 +32,7 @@ group: @global
           test_result_failure
           test_stdin_closed
           test_subprocess_doesnt_exit
+          test_subprocess_doesnt_exit_fail
           test_success
           test_success_should_panic
       nextest-tests::other:
@@ -51,4 +53,3 @@ group: @global
       with-build-script:
           tests::test_build_script_vars_set
           tests::test_out_dir_present
-

--- a/nextest-runner/tests/integration/basic.rs
+++ b/nextest-runner/tests/integration/basic.rs
@@ -516,9 +516,9 @@ fn test_retries(retries: Option<RetryPolicy>) -> Result<()> {
                         TestCaseFixtureStatus::Pass | TestCaseFixtureStatus::Leak => 1,
                         // Note that currently only the flaky test fixtures are controlled by overrides.
                         // If more tests are controlled by retry overrides, this may need to be updated.
-                        TestCaseFixtureStatus::Fail | TestCaseFixtureStatus::Segfault => {
-                            profile_retries.count() + 1
-                        }
+                        TestCaseFixtureStatus::Fail
+                        | TestCaseFixtureStatus::FailLeak
+                        | TestCaseFixtureStatus::Segfault => profile_retries.count() + 1,
                         TestCaseFixtureStatus::IgnoredPass | TestCaseFixtureStatus::IgnoredFail => {
                             unreachable!("ignored tests should be skipped")
                         }

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -74,6 +74,10 @@ pub(crate) fn make_execution_result(
             abort_status: None,
             leaked: false,
         },
+        TestCaseFixtureStatus::FailLeak => ExecutionResult::Fail {
+            abort_status: None,
+            leaked: true,
+        },
         TestCaseFixtureStatus::Leak => ExecutionResult::Leak,
     }
 }


### PR DESCRIPTION
Per #1891 -- this bug was quietly fixed but there was no coverage for it apparently.