### PR TITLE
[nextest-runner] use Unicode characters if available

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,6 +1773,7 @@ dependencies = [
  "smallvec",
  "smol_str",
  "strip-ansi-escapes",
+ "supports-unicode",
  "swrite",
  "tar",
  "target-spec",

--- a/integration-tests/tests/integration/fixtures.rs
+++ b/integration-tests/tests/integration/fixtures.rs
@@ -322,11 +322,11 @@ impl CheckResult {
                 vec![
                     (
                         "stdout",
-                        Regex::new(&format!("---- STDOUT: +{name}")).unwrap(),
+                        Regex::new(&format!("──── STDOUT: +{name}")).unwrap(),
                     ),
                     (
                         "stderr",
-                        Regex::new(&format!("---- STDERR: +{name}")).unwrap(),
+                        Regex::new(&format!("──── STDERR: +{name}")).unwrap(),
                     ),
                 ]
             }

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -60,6 +60,7 @@ shell-words.workspace = true
 smallvec.workspace = true
 smol_str = { workspace = true, features = ["serde"] }
 strip-ansi-escapes.workspace = true
+supports-unicode.workspace = true
 swrite.workspace = true
 tar.workspace = true
 # For cfg expression evaluation for [target.'cfg()'] expressions


### PR DESCRIPTION
Nextest has rigorously followed Cargo's theming so far -- but I think it's time to start breaking from that a bit. An easy change is to use Unicode hbar and progress characters.