### PR TITLE
[nextest-runner] improve error handling for child process management

### DIFF
--- a/nextest-runner/src/reporter/structured/snapshots/nextest_runner__reporter__structured__libtest__test__strips_human_output_start_error.snap
+++ b/nextest-runner/src/reporter/structured/snapshots/nextest_runner__reporter__structured__libtest__test__strips_human_output_start_error.snap
@@ -1,0 +1,6 @@
+---
+source: nextest-runner/src/reporter/structured/libtest.rs
+expression: "std::str::from_utf8(&actual).unwrap()"
+snapshot_kind: text
+---
+--- EXECUTION ERROR ---\nerror spawning child process\n  caused by:\n  - inner error

--- a/nextest-runner/src/test_command.rs
+++ b/nextest-runner/src/test_command.rs
@@ -20,7 +20,7 @@ use std::{
 use tracing::warn;
 
 mod imp;
-pub(crate) use imp::{Child, ChildAccumulator, ChildFds, ChildOutputMut};
+pub(crate) use imp::{Child, ChildAccumulator, ChildFds};
 
 #[derive(Clone, Debug)]
 pub(crate) struct LocalExecuteContext<'a> {

--- a/nextest-runner/tests/integration/basic.rs
+++ b/nextest-runner/tests/integration/basic.rs
@@ -23,7 +23,7 @@ use nextest_runner::{
     signal::SignalHandlerKind,
     target_runner::TargetRunner,
     test_filter::{RunIgnored, TestFilterBuilder, TestFilterPatterns},
-    test_output::{TestExecutionOutput, TestOutput},
+    test_output::{ChildExecutionResult, ChildOutput},
 };
 use pretty_assertions::assert_eq;
 use std::{io::Cursor, time::Duration};
@@ -172,8 +172,10 @@ fn test_run() -> Result<()> {
 
                         if can_extract_description {
                             // Check that stderr can be parsed heuristically.
-                            let TestExecutionOutput::Output(TestOutput::Split(split)) =
-                                &run_status.output
+                            let ChildExecutionResult::Output {
+                                output: ChildOutput::Split(split),
+                                ..
+                            } = &run_status.output
                             else {
                                 panic!("this test should always use split output")
                             };

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -25,7 +25,7 @@ use nextest_runner::{
     },
     target_runner::TargetRunner,
     test_filter::{FilterBound, TestFilterBuilder},
-    test_output::{TestExecutionOutput, TestOutput},
+    test_output::{ChildExecutionResult, ChildOutput},
 };
 use once_cell::sync::Lazy;
 use std::{
@@ -295,7 +295,10 @@ impl fmt::Debug for InstanceStatus {
             InstanceStatus::Skipped(reason) => write!(f, "skipped: {reason}"),
             InstanceStatus::Finished(run_statuses) => {
                 for run_status in run_statuses.iter() {
-                    let TestExecutionOutput::Output(TestOutput::Split(split)) = &run_status.output
+                    let ChildExecutionResult::Output {
+                        output: ChildOutput::Split(split),
+                        ..
+                    } = &run_status.output
                     else {
                         panic!("this test should always use split output")
                     };


### PR DESCRIPTION
* Don't eat up stdout/stderr if there's an error that occurs after the process is spawned
* Scripts can now combine stdout and stderr (though this isn't exposed in the UI yet).
* Fix up names to reflect that "child" can mean either a test process or a script process.

This is going to need a bunch of TLC, but I think this is generally a good shape for the types to be in.