### PR TITLE
[nextest-runner] handle SIGINFO and SIGUSR1 to dump info to screen

### DIFF
--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -6,10 +6,9 @@
 use crate::{
     cargo_config::{TargetTriple, TargetTripleSource},
     config::{ConfigExperimental, CustomTestGroup, ScriptId, TestGroup},
-    helpers::{dylib_path_envvar, extract_abort_status},
+    helpers::{display_exit_status, dylib_path_envvar},
     redact::Redactor,
     reuse_build::{ArchiveFormat, ArchiveStep},
-    runner::AbortStatus,
     target_runner::PlatformRunnerSource,
 };
 use camino::{FromPathBufError, Utf8Path, Utf8PathBuf};
@@ -971,30 +970,6 @@ impl CreateTestListError {
 
     pub(crate) fn dylib_join_paths(new_paths: Vec<Utf8PathBuf>, error: JoinPathsError) -> Self {
         Self::DylibJoinPaths { new_paths, error }
-    }
-}
-
-fn display_exit_status(exit_status: ExitStatus) -> String {
-    match extract_abort_status(exit_status) {
-        #[cfg(unix)]
-        Some(AbortStatus::UnixSignal(sig)) => match crate::helpers::signal_str(sig) {
-            Some(s) => {
-                format!("signal {sig} (SIG{s})")
-            }
-            None => {
-                format!("signal {sig}")
-            }
-        },
-        #[cfg(windows)]
-        Some(AbortStatus::WindowsNtStatus(nt_status)) => {
-            format!("code {}", crate::helpers::display_nt_status(nt_status))
-        }
-        None => match exit_status.code() {
-            Some(code) => {
-                format!("code {code}")
-            }
-            None => "an unknown error".to_owned(),
-        },
     }
 }
 

--- a/nextest-runner/src/helpers.rs
+++ b/nextest-runner/src/helpers.rs
@@ -313,6 +313,35 @@ pub(crate) fn extract_abort_status(exit_status: ExitStatus) -> Option<AbortStatu
     }
 }
 
+pub(crate) fn display_exit_status(exit_status: ExitStatus) -> String {
+    match extract_abort_status(exit_status) {
+        Some(abort_status) => display_abort_status(abort_status),
+        None => match exit_status.code() {
+            Some(code) => format!("exit code {}", code),
+            None => "an unknown error".to_owned(),
+        },
+    }
+}
+
+/// Display the abort status.
+pub(crate) fn display_abort_status(abort_status: AbortStatus) -> String {
+    match abort_status {
+        #[cfg(unix)]
+        AbortStatus::UnixSignal(sig) => match crate::helpers::signal_str(sig) {
+            Some(s) => {
+                format!("signal {sig} (SIG{s})")
+            }
+            None => {
+                format!("signal {sig}")
+            }
+        },
+        #[cfg(windows)]
+        AbortStatus::WindowsNtStatus(nt_status) => {
+            format!("code {}", crate::helpers::display_nt_status(nt_status))
+        }
+    }
+}
+
 #[cfg(unix)]
 pub(crate) fn signal_str(signal: i32) -> Option<&'static str> {
     // These signal numbers are the same on at least Linux, macOS, FreeBSD and illumos.

--- a/nextest-runner/src/list/test_list.rs
+++ b/nextest-runner/src/list/test_list.rs
@@ -990,7 +990,7 @@ impl<'a> TestInstance<'a> {
     /// Return an identifier for test instances, including being able to sort
     /// them.
     #[inline]
-    pub(crate) fn id(&self) -> TestInstanceId<'a> {
+    pub fn id(&self) -> TestInstanceId<'a> {
         TestInstanceId {
             binary_id: &self.suite_info.binary_id,
             test_name: self.name,
@@ -1060,7 +1060,7 @@ impl<'a> TestInstance<'a> {
 ///
 /// Returned by [`TestInstance::id`].
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub(crate) struct TestInstanceId<'a> {
+pub struct TestInstanceId<'a> {
     /// The binary ID.
     pub binary_id: &'a RustBinaryId,
 

--- a/nextest-runner/src/reporter/aggregator.rs
+++ b/nextest-runner/src/reporter/aggregator.rs
@@ -65,7 +65,10 @@ impl<'cfg> MetadataJunit<'cfg> {
             | TestEventKind::RunContinued { .. } => {}
             TestEventKind::SetupScriptStarted { .. }
             | TestEventKind::SetupScriptSlow { .. }
-            | TestEventKind::SetupScriptFinished { .. } => {}
+            | TestEventKind::SetupScriptFinished { .. }
+            | TestEventKind::InfoStarted { .. }
+            | TestEventKind::InfoResponse { .. }
+            | TestEventKind::InfoFinished { .. } => {}
             TestEventKind::TestStarted { .. } => {}
             TestEventKind::TestSlow { .. } => {}
             TestEventKind::TestAttemptFailedWillRetry { .. }

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__info_response_output.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__info_response_output.snap
@@ -1,0 +1,122 @@
+---
+source: nextest-runner/src/reporter/displayer.rs
+expression: "String::from_utf8(out).expect(\"output only consists of UTF-8\")"
+snapshot_kind: text
+---
+────────────
+info: 30 running, 17 passed (4 slow, 2 flaky, 1 leaky), 2 failed, 1 exec failed, 1 timed out, 5 skipped in 0.000s
+
+* 1/20:   setup: setup arg1 arg2
+  status: script running for 1.234s as PID 4567
+  stdout:
+    script stdout 1
+  stderr:
+    script stderr 1
+
+
+────────
+
+* 2/20:   setup-slow: setup-slow arg1 arg2
+  status: script running for 1.234s as PID 4568 (marked slow after 1.000s)
+  errors:
+    error reading standard output
+      caused by:
+      - read stdout error
+  output:
+    script output 2
+
+
+────────
+
+* 3/20:   setup-terminating: setup-terminating arg1 arg2
+  status: terminating script PID 5094 due to signal (script ran for 1.234s)
+  note:   fake termination method; spent 6.789s waiting for script to exit, will kill after another 9.786s
+  errors:
+    2 errors occurred executing script:
+    * error reading standard output
+        caused by:
+        - read stdout error
+    * error reading standard error
+        caused by:
+        - read stderr error
+
+  stdout:
+    script output 3
+  stderr:
+    script stderr 3
+
+
+────────
+
+* 4/20:   setup-exiting: setup-exiting arg1 arg2
+  status: script failed to execute after 1.234s (marked slow after 1.000s)
+  note:   spent 10.467s waiting for script PID 9987 to shut down, will mark as leaky after another 0.335s
+  errors:
+    error spawning child process
+      caused by:
+      - exec error
+
+
+────────
+
+* 5/20:   setup-exited: setup-exited arg1 arg2
+  status: script failed with leaked handles after 9.999s (marked slow after 3.000s)
+  errors:
+    error spawning child process
+      caused by:
+      - exec error
+
+
+────────
+
+* 6/20:   my-binary-id test1
+  status: test running for 0.400s as PID 12345
+  stdout:
+    abc
+  stderr:
+    def
+
+
+────────
+
+* 7/20:   my-binary-id test2
+  status: (attempt 2/3) terminating test PID 12346 due to timeout (test ran for 99.999s)
+  note:   fake termination method; spent 6.789s waiting for test to exit, will kill after another 9.786s
+  stdout:
+    abc
+  stderr:
+    def
+
+
+────────
+
+* 8/20:   my-binary-id test3
+  status: (attempt 2/3) test failed with unknown status after 99.999s (marked slow after 33.333s)
+  stdout:
+    abc
+  stderr:
+    def
+
+
+────────
+
+* 9/20:   my-binary-id test4
+  status: test passed after 99.999s (marked slow after 33.333s)
+  errors:
+    error waiting for child process to exit
+      caused by:
+      - error waiting
+  output:
+    abc
+    def
+    ghi
+
+
+────────
+
+* 10/20:  my-binary-id test4
+  status: (attempt 1/5) test failed to execute, currently waiting before next attempt
+  note:   waited 1.234s so far, will wait another 5.678s before retrying test
+
+info: missing 2 responses
+────────────

--- a/nextest-runner/src/test_output.rs
+++ b/nextest-runner/src/test_output.rs
@@ -112,6 +112,25 @@ pub enum ChildExecutionOutput {
     StartError(ChildStartError),
 }
 
+impl ChildExecutionOutput {
+    /// Returns true if there are any errors in this output.
+    pub(crate) fn has_errors(&self) -> bool {
+        match self {
+            ChildExecutionOutput::Output { errors, result, .. } => {
+                if errors.is_some() {
+                    return true;
+                }
+                if let Some(result) = result {
+                    return !result.is_success();
+                }
+
+                false
+            }
+            ChildExecutionOutput::StartError(_) => true,
+        }
+    }
+}
+
 /// The output of a child process: stdout and/or stderr.
 ///
 /// Part of [`ChildExecutionOutput`], and can be used independently as well.

--- a/nextest-runner/src/time/pausable_sleep.rs
+++ b/nextest-runner/src/time/pausable_sleep.rs
@@ -29,6 +29,7 @@ impl PausableSleep {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn is_paused(&self) -> bool {
         matches!(self.pause_state, SleepPauseState::Paused { .. })
     }

--- a/nextest-runner/src/time/stopwatch.rs
+++ b/nextest-runner/src/time/stopwatch.rs
@@ -76,7 +76,7 @@ impl StopwatchStart {
 }
 
 /// A snapshot of the state of the stopwatch.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub(crate) struct StopwatchSnapshot {
     /// The time at which the stopwatch was started.
     pub(crate) start_time: DateTime<Local>,
@@ -90,7 +90,7 @@ pub(crate) struct StopwatchSnapshot {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) enum StopwatchPauseState {
+enum StopwatchPauseState {
     Running,
     Paused { paused_at: Instant },
 }


### PR DESCRIPTION
Part 1 of work to perform interactive queries.

With this change, if nextest receives either SIGINFO (where available) or SIGUSR1, it will print a list of all currently running tests with their states. The full test state machine is modeled in the event responses, along with possible sources of errors.

I tried making Ctrl-Break on Windows do the same thing, but unfortunately that doesn't quite work in practice. That's because Ctrl-Break is received by all processes connected to the console, not just by the equivalent of the "foreground process group". The printing out of info works, but running tests are immediately aborted as well. So remove this. (In interactive terminals we'll support an alternative -- pressing `i` -- which should work for most use cases on Windows.)

There is also an undocumented environment variable `__NEXTEST_SIGQUIT_AS_INFO` which allows `SIGQUIT` (`Ctrl-\`) to perform an info query. Quite useful for testing on Linux, where SIGINFO is sadly unavailable.

Note: illumos does support SIGINFO, but that is blocked on an upstream issue: https://github.com/tokio-rs/tokio/pull/6995