### PR TITLE
[nextest-runner] add a way to pass extra args at runtime

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -12,6 +12,10 @@ slow-timeout = { period = "60s", terminate-after = 3 }
 test-group = "my-group"
 junit.store-success-output = true
 
+[[profile.default.overrides]]
+filter = 'test(test_single_threaded)'
+phase.run.extra-args = ["--test-threads", "1"]
+
 [[profile.default.scripts]]
 filter = 'package(integration-tests) or binary_id(nextest-runner::integration)'
 setup = "build-seed-archive"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "escape8259"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5692dd7b5a1978a5aeb0ce83b7655c58ca8efdcb79d21036ea249da95afec2c6"
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,8 +1470,10 @@ dependencies = [
  "hex",
  "insta",
  "itertools",
+ "libtest-mimic",
  "nextest-metadata",
  "nextest-workspace-hack",
+ "num_threads",
  "pathdiff",
  "regex",
  "serde_json",
@@ -1552,6 +1560,18 @@ dependencies = [
  "bitflags",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "libtest-mimic"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5297962ef19edda4ce33aaa484386e0a5b3d7f2f4e037cbeee00503ef6b29d33"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap",
+ "escape8259",
 ]
 
 [[package]]
@@ -1919,6 +1939,15 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ insta = { version = "1.41.1", default-features = false }
 is_ci = "1.2.0"
 itertools = "0.13.0"
 libc = "0.2.168"
+libtest-mimic = "0.8.1"
 log = "0.4.22"
 maplit = "1.0.2"
 miette = "7.4.0"
@@ -84,6 +85,7 @@ nextest-filtering = { version = "0.12.0", path = "nextest-filtering" }
 nextest-metadata = { version = "0.12.1", path = "nextest-metadata" }
 nextest-workspace-hack = "0.1.0"
 nix = { version = "0.29.0", default-features = false, features = ["signal"] }
+num_threads = "0.1.7"
 once_cell = "1.20.2"
 owo-colors = "4.1.0"
 pathdiff = { version = "0.2.3", features = ["camino"] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -13,6 +13,10 @@ path = "test-helpers/cargo-nextest-dup.rs"
 name = "build-seed-archive"
 path = "test-helpers/build-seed-archive.rs"
 
+[[test]]
+name = "custom-harness"
+harness = false
+
 [dependencies]
 camino.workspace = true
 camino-tempfile.workspace = true
@@ -43,7 +47,13 @@ cp_r.workspace = true
 fixture-data.workspace = true
 insta.workspace = true
 itertools.workspace = true
+libtest-mimic.workspace = true
 nextest-metadata.workspace = true
 pathdiff.workspace = true
 regex.workspace = true
 target-spec.workspace = true
+
+# These platforms are supported by num_threads.
+# https://docs.rs/num_threads/0.1.7/src/num_threads/lib.rs.html#5-8
+[target.'cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "macos", target_os = "ios", target_os = "aix"))'.dev-dependencies]
+num_threads.workspace = true

--- a/integration-tests/tests/custom-harness.rs
+++ b/integration-tests/tests/custom-harness.rs
@@ -1,0 +1,93 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Test that with libtest-mimic, passing in `--test-threads=1` runs the tests in a
+//! single thread, and not passing it runs the tests in multiple threads.
+//!
+//! This is technically a fixture and should live in `fixtures/nextest-tests`,
+//! but making it so pulls in several dependencies and makes the test run quite
+//! a bit slower. So we make it part of integration-tests instead.
+//!
+//! This behavior used to be the case with libtest in the past, but was changed
+//! in 2022. See <https://github.com/rust-lang/rust/issues/104053>.
+
+use libtest_mimic::{Arguments, Trial};
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let args = Arguments::from_args();
+
+    let tests = vec![
+        Trial::test(
+            "thread_count::test_single_threaded",
+            thread_count::test_single_threaded,
+        )
+        // Because nextest's CI runs tests against the latest stable version of
+        // nextest, which doesn't have support for phase.run.extra-args yet, we
+        // have to use the `with_ignored_flag` method to ignore the test. This
+        // is temporary until phase.run.extra-args is in stable nextest.
+        .with_ignored_flag(true),
+        Trial::test(
+            "thread_count::test_multi_threaded",
+            thread_count::test_multi_threaded,
+        ),
+    ];
+
+    libtest_mimic::run(&args, tests).exit_code()
+}
+
+// These platforms are supported by num_threads.
+// https://docs.rs/num_threads/0.1.7/src/num_threads/lib.rs.html#5-8
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "aix"
+))]
+mod thread_count {
+    use libtest_mimic::Failed;
+
+    pub(crate) fn test_single_threaded() -> Result<(), Failed> {
+        let num_threads = num_threads::num_threads()
+            .expect("successfully obtained number of threads")
+            .get();
+        assert_eq!(num_threads, 1, "number of threads is 1");
+        Ok(())
+    }
+
+    pub(crate) fn test_multi_threaded() -> Result<(), Failed> {
+        // There must be at least two threads here, because libtest-mimic always
+        // creates a second thread.
+        let num_threads = num_threads::num_threads()
+            .expect("successfully obtained number of threads")
+            .get();
+        assert!(num_threads > 1, "number of threads > 1");
+        Ok(())
+    }
+}
+
+// On other platforms we just say "pass" -- if/when nextest gains a way to say
+// that tests were skipped at runtime, we can use that instead.
+#[cfg(not(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "freebsd",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "aix"
+)))]
+mod thread_count {
+    use libtest_mimic::Failed;
+
+    pub(crate) fn test_single_threaded() -> Result<(), Failed> {
+        eprintln!("skipped test on unsupported platform");
+        Ok(())
+    }
+
+    pub(crate) fn test_multi_threaded() -> Result<(), Failed> {
+        eprintln!("skipped test on unsupported platform");
+        Ok(())
+    }
+}

--- a/nextest-runner/default-config.toml
+++ b/nextest-runner/default-config.toml
@@ -29,6 +29,10 @@ test-threads = "num-cpus"
 # mark certain tests as heavier than others. However, it can also be set as a global parameter.
 threads-required = 1
 
+# Extra arguments to pass in to the test binary at runtime. Intended primarily for
+# communication with custom test harnesses -- use with caution!
+phase.run.extra-args = []
+
 # Show these test statuses in the output.
 #
 # The possible values this can take are:

--- a/nextest-runner/src/config/mod.rs
+++ b/nextest-runner/src/config/mod.rs
@@ -18,6 +18,7 @@
 //! Multi-pass parsing allows for profile parsing errors to be returned as early
 //! as possible -- before the host and target platforms are known. Returning
 //! errors early leads to a better user experience.
+
 mod archive;
 mod config_impl;
 mod helpers;
@@ -25,6 +26,7 @@ mod identifier;
 mod max_fail;
 mod nextest_version;
 mod overrides;
+mod phase;
 mod retry_policy;
 mod scripts;
 mod slow_timeout;

--- a/nextest-runner/src/config/phase.rs
+++ b/nextest-runner/src/config/phase.rs
@@ -1,0 +1,23 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Settings for the runtime environment.
+
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(super) struct DeserializedPhase {
+    pub(crate) run: DeserializedPhaseSettings,
+}
+
+/// Configuration for the test runtime environment.
+///
+/// In the future, this will support target runners and other similar settings.
+///
+/// Overrides are per-setting, not for the entire environment. TODO: ensure this in tests.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(super) struct DeserializedPhaseSettings {
+    pub(super) extra_args: Option<Vec<String>>,
+}

--- a/nextest-runner/src/config/retry_policy.rs
+++ b/nextest-runner/src/config/retry_policy.rs
@@ -631,11 +631,11 @@ mod tests {
             binary_query: binary_query.to_query(),
             test_name: "my_test",
         };
-        let settings_for = config
+        let profile = config
             .profile("ci")
             .expect("ci profile is defined")
-            .apply_build_platforms(&build_platforms())
-            .settings_for(&query);
+            .apply_build_platforms(&build_platforms());
+        let settings_for = profile.settings_for(&query);
         assert_eq!(
             settings_for.retries(),
             retries,

--- a/nextest-runner/src/list/test_list.rs
+++ b/nextest-runner/src/list/test_list.rs
@@ -1016,6 +1016,7 @@ impl<'a> TestInstance<'a> {
         &self,
         ctx: &TestExecuteContext<'_>,
         test_list: &TestList<'_>,
+        extra_args: &[String],
     ) -> TestCommand {
         let platform_runner = ctx
             .target_runner
@@ -1037,6 +1038,7 @@ impl<'a> TestInstance<'a> {
         if self.test_info.ignored {
             args.push("--ignored");
         }
+        args.extend(extra_args.iter().map(String::as_str));
 
         let lctx = LocalExecuteContext {
             rust_build_meta: &test_list.rust_build_meta,

--- a/nextest-runner/src/runner/executor.rs
+++ b/nextest-runner/src/runner/executor.rs
@@ -170,7 +170,7 @@ impl<'a> ExecutorContext<'a> {
     pub(super) async fn run_test_instance(
         &self,
         test_instance: TestInstance<'a>,
-        settings: TestSettings,
+        settings: TestSettings<'a>,
         resp_tx: UnboundedSender<ExecutorEvent<'a>>,
         cancelled_ref: &AtomicBool,
         mut cancel_receiver: broadcast::Receiver<()>,
@@ -587,7 +587,9 @@ impl<'a> ExecutorContext<'a> {
             double_spawn: &self.double_spawn,
             target_runner: &self.target_runner,
         };
-        let mut cmd = test.test_instance.make_command(&ctx, self.test_list);
+        let mut cmd =
+            test.test_instance
+                .make_command(&ctx, self.test_list, test.settings.run_extra_args());
         let command_mut = cmd.command_mut();
 
         // Debug environment variable for testing.
@@ -891,7 +893,7 @@ impl UnitPacket<'_> {
 pub(super) struct TestPacket<'a> {
     test_instance: TestInstance<'a>,
     retry_data: RetryData,
-    settings: Arc<TestSettings>,
+    settings: Arc<TestSettings<'a>>,
     setup_script_data: Arc<SetupScriptExecuteData<'a>>,
     delay_before_start: Duration,
 }


### PR DESCRIPTION
Add a way to do this:

```toml
[[profile.default.overrides]]
filter = "test(some_filter)"
phase.run.extra-args = ["--test-threads", "1"]
```

See https://github.com/nextest-rs/nextest/discussions/1959 for why this is required. This is an advanced option that should be used with care, but it's worth implementing.

The `phase.run` is because (a) we may want `phase.list` in the future as well, and (b) in the future, we'll want to support setting the environment here as well.