### PR TITLE
[nextest-runner] use grace period on receiving Windows Ctrl-C

### DIFF
--- a/nextest-runner/src/reporter/displayer.rs
+++ b/nextest-runner/src/reporter/displayer.rs
@@ -1661,7 +1661,6 @@ impl<'a> TestReporterImpl<'a> {
         state: &UnitTerminatingState,
         writer: &mut dyn Write,
     ) -> io::Result<()> {
-        #[cfg_attr(not(any(unix, test)), expect(unused_variables))]
         let UnitTerminatingState {
             pid,
             time_taken,
@@ -1705,6 +1704,18 @@ impl<'a> TestReporterImpl<'a> {
                     // remaining time.
                     "{}:   instructed job object to terminate",
                     "note".style(self.styles.count),
+                )?;
+            }
+            #[cfg(windows)]
+            UnitTerminateMethod::Wait => {
+                writeln!(
+                    writer,
+                    "{}:   waiting for {} to exit on its own; spent {:.3?}s, will terminate \
+                     job object after another {:.3?}s",
+                    "note".style(self.styles.count),
+                    kind,
+                    waiting_duration.as_secs_f64(),
+                    remaining.as_secs_f64(),
                 )?;
             }
             #[cfg(test)]

--- a/nextest-runner/src/reporter/error_description.rs
+++ b/nextest-runner/src/reporter/error_description.rs
@@ -166,7 +166,9 @@ impl fmt::Display for UnitAbortDescription {
                 write!(
                     f,
                     " with code {}",
-                    crate::helpers::display_nt_status(exception)
+                    // TODO: pass in bold style (probably need to not use
+                    // fmt::Display)
+                    crate::helpers::display_nt_status(exception, owo_colors::Style::new())
                 )?;
             }
         }

--- a/nextest-runner/src/reporter/events.rs
+++ b/nextest-runner/src/reporter/events.rs
@@ -1063,6 +1063,16 @@ pub enum UnitTerminateMethod {
     #[cfg(windows)]
     JobObject,
 
+    /// The unit is being waited on to exit. A termination signal will be sent
+    /// if it doesn't exit within the grace period.
+    ///
+    /// On Windows, this occurs when nextest receives Ctrl-C. In that case, it
+    /// is assumed that tests will also receive Ctrl-C and exit on their own. If
+    /// tests do not exit within the grace period configured for them, their
+    /// corresponding job objects will be terminated.
+    #[cfg(windows)]
+    Wait,
+
     /// A fake method used for testing.
     #[cfg(test)]
     Fake,

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__windows_tests__ctrl_c_code.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__windows_tests__ctrl_c_code.snap
@@ -1,0 +1,7 @@
+---
+source: nextest-runner/src/reporter/displayer.rs
+expression: buf
+snapshot_kind: text
+---
+   with code 0xc000013a: {Application Exit by CTRL+C}
+                       - The application terminated as a result of a CTRL+C. (os error 572)

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__windows_tests__stack_violation_code.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__windows_tests__stack_violation_code.snap
@@ -1,0 +1,6 @@
+---
+source: nextest-runner/src/reporter/displayer.rs
+expression: to_message_line(STATUS_CONTROL_STACK_VIOLATION)
+snapshot_kind: text
+---
+   with code 0xc00001b2: Invalid access to memory location. (os error 998)

--- a/nextest-runner/src/runner/dispatcher.rs
+++ b/nextest-runner/src/runner/dispatcher.rs
@@ -349,6 +349,11 @@ where
                 total,
                 req_rx_tx,
             }) => {
+                if self.cancel_state.is_some() {
+                    // The run has been cancelled: don't start any new units.
+                    return HandleEventResponse::None;
+                }
+
                 let (req_tx, req_rx) = unbounded_channel();
                 match req_rx_tx.send(req_rx) {
                     Ok(_) => {}
@@ -415,6 +420,11 @@ where
                 test_instance,
                 req_rx_tx,
             }) => {
+                if self.cancel_state.is_some() {
+                    // The run has been cancelled: don't start any new units.
+                    return HandleEventResponse::None;
+                }
+
                 let (req_tx, req_rx) = unbounded_channel();
                 match req_rx_tx.send(req_rx) {
                     Ok(_) => {}

--- a/nextest-runner/src/runner/executor.rs
+++ b/nextest-runner/src/runner/executor.rs
@@ -857,7 +857,6 @@ pub(super) struct UnitContext<'a> {
 }
 
 impl<'a> UnitContext<'a> {
-    #[cfg_attr(not(unix), expect(dead_code))]
     pub(super) fn packet(&self) -> &UnitPacket<'a> {
         &self.packet
     }

--- a/nextest-runner/src/runner/executor.rs
+++ b/nextest-runner/src/runner/executor.rs
@@ -124,8 +124,8 @@ impl<'a> ExecutorContext<'a> {
                 let mut req_rx = match req_rx_rx.await {
                     Ok(req_rx) => req_rx,
                     Err(_) => {
-                        // The receiver was dropped -- most likely the test
-                        // exited.
+                        // The receiver was dropped -- the dispatcher has
+                        // signaled that this unit should exit.
                         return None;
                     }
                 };
@@ -209,8 +209,8 @@ impl<'a> ExecutorContext<'a> {
         let mut req_rx = match req_rx_rx.await {
             Ok(rx) => rx,
             Err(_) => {
-                // The receiver was dropped, which means the
-                // test was cancelled.
+                // The receiver was dropped -- the dispatcher has signaled that this unit should
+                // exit.
                 return;
             }
         };

--- a/nextest-runner/src/runner/internal_events.rs
+++ b/nextest-runner/src/runner/internal_events.rs
@@ -89,6 +89,8 @@ pub(super) enum ExecutorEvent<'a> {
     RetryStarted {
         test_instance: TestInstance<'a>,
         retry_data: RetryData,
+        // This is used to indicate that the dispatcher still wants to run the test.
+        tx: oneshot::Sender<()>,
     },
     Finished {
         test_instance: TestInstance<'a>,

--- a/site/src/docs/design/architecture/signal-handling.md
+++ b/site/src/docs/design/architecture/signal-handling.md
@@ -224,6 +224,10 @@ Unlike process groups, job objects form a tree. If something else runs nextest
 within a job object and then calls `TerminateJobObject`, both nextest and all
 its child processes are terminated.
 
+When a test times out, nextest calls `TerminateJobObject` on the job object
+associated with the test immediately. In the future, it would be interesting
+to send a Ctrl-C (or maybe a `WM_CLOSE`?) to the test process first.
+
 [job objects]: https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects
 [terminate-job-object]: https://docs.microsoft.com/en-us/windows/win32/api/jobapi2/nf-jobapi2-terminatejobobject
 


### PR DESCRIPTION
Previously on Windows, we would not do anything at all on receiving Ctrl-C, letting tests exit on their own.

With this change, in case of Ctrl-C, nextest will apply the same grace period that it does on Unix. By default, nextest will now wait 10 seconds before calling `TerminateJobObject` on the test. Like on Unix, a double Ctrl-C will kill the test immediately.

The behavior in case of timeouts is unchanged -- call `TerminateJobObject` immediately.

This PR also has a few more fixes to Windows display, and to cancellation on all platforms.