### PR TITLE
[nextest-runner] make Windows job object termination clearer

### DIFF
--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -6,7 +6,7 @@
 use crate::{
     cargo_config::{TargetTriple, TargetTripleSource},
     config::{ConfigExperimental, CustomTestGroup, ScriptId, TestGroup},
-    helpers::{display_exit_status, dylib_path_envvar},
+    helpers::{display_exited_with, dylib_path_envvar},
     redact::Redactor,
     reuse_build::{ArchiveFormat, ArchiveStep},
     target_runner::PlatformRunnerSource,
@@ -873,9 +873,9 @@ pub enum CreateTestListError {
 
     /// Running a command to gather the list of tests failed failed with a non-zero exit code.
     #[error(
-        "for `{binary_id}`, command `{}` exited with {}\n--- stdout:\n{}\n--- stderr:\n{}\n---",
+        "for `{binary_id}`, command `{}` {}\n--- stdout:\n{}\n--- stderr:\n{}\n---",
         shell_words::join(command),
-        display_exit_status(*exit_status),
+        display_exited_with(*exit_status),
         String::from_utf8_lossy(stdout),
         String::from_utf8_lossy(stderr),
     )]

--- a/nextest-runner/src/reporter/aggregator/junit.rs
+++ b/nextest-runner/src/reporter/aggregator/junit.rs
@@ -532,8 +532,8 @@ mod tests {
                     errors: None,
                 },
                 store_stdout_stderr: true,
-                message: Some("process aborted with signal SIGTERM"),
-                description: Some("process aborted with signal SIGTERM"),
+                message: Some("process aborted with signal 15 (SIGTERM)"),
+                description: Some("process aborted with signal 15 (SIGTERM)"),
                 system_out: Some("stdout\nstdout 2\n"),
                 system_err: Some(STDERR_NOT_CAPTURED),
             },
@@ -566,7 +566,7 @@ mod tests {
                     * error waiting for child process to exit
                         caused by:
                         - huh
-                    * process aborted with signal SIGTERM, and also leaked handles
+                    * process aborted with signal 15 (SIGTERM), and also leaked handles
                     * thread 'foo' panicked at xyz.rs:40
                 "}),
                 system_out: None,

--- a/nextest-runner/src/reporter/error_description.rs
+++ b/nextest-runner/src/reporter/error_description.rs
@@ -4,6 +4,7 @@
 use super::events::{AbortStatus, ExecutionResult, UnitKind};
 use crate::{
     errors::{ChildError, ChildStartError, ErrorList},
+    helpers::display_abort_status,
     test_output::{ChildExecutionOutput, ChildOutput},
 };
 use bstr::ByteSlice;
@@ -152,26 +153,7 @@ struct UnitAbortDescription {
 
 impl fmt::Display for UnitAbortDescription {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "process aborted")?;
-        match self.status {
-            #[cfg(unix)]
-            AbortStatus::UnixSignal(sig) => {
-                let signal_str = crate::helpers::signal_str(sig)
-                    .map(|signal_str| format!("SIG{signal_str}"))
-                    .unwrap_or_else(|| sig.to_string());
-                write!(f, " with signal {signal_str}")?;
-            }
-            #[cfg(windows)]
-            AbortStatus::WindowsNtStatus(exception) => {
-                write!(
-                    f,
-                    " with code {}",
-                    // TODO: pass in bold style (probably need to not use
-                    // fmt::Display)
-                    crate::helpers::display_nt_status(exception, owo_colors::Style::new())
-                )?;
-            }
-        }
+        write!(f, "process {}", display_abort_status(self.status))?;
         if self.leaked {
             write!(f, ", and also leaked handles")?;
         }

--- a/nextest-runner/src/reporter/events.rs
+++ b/nextest-runner/src/reporter/events.rs
@@ -741,7 +741,7 @@ pub enum ExecutionResult {
     },
     /// An error occurred while executing the test.
     ExecFail,
-    /// The test was terminated due to timeout.
+    /// The test was terminated due to a timeout.
     Timeout,
 }
 
@@ -769,6 +769,10 @@ pub enum AbortStatus {
     /// The test was determined to have aborted because the high bit was set on Windows.
     #[cfg(windows)]
     WindowsNtStatus(windows_sys::Win32::Foundation::NTSTATUS),
+
+    /// The test was terminated via job object on Windows.
+    #[cfg(windows)]
+    JobObject,
 }
 
 impl AbortStatus {

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__windows_tests__ctrl_c_code.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__windows_tests__ctrl_c_code.snap
@@ -1,7 +1,7 @@
 ---
 source: nextest-runner/src/reporter/displayer.rs
-expression: buf
+expression: "to_message_line(AbortStatus::WindowsNtStatus(STATUS_CONTROL_C_EXIT))"
 snapshot_kind: text
 ---
-   with code 0xc000013a: {Application Exit by CTRL+C}
-                       - The application terminated as a result of a CTRL+C. (os error 572)
+           - with code 0xc000013a: {Application Exit by CTRL+C}
+           - The application terminated as a result of a CTRL+C. (os error 572)

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__windows_tests__job_object.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__windows_tests__job_object.snap
@@ -1,0 +1,6 @@
+---
+source: nextest-runner/src/reporter/displayer.rs
+expression: "to_message_line(AbortStatus::JobObject)"
+snapshot_kind: text
+---
+           - terminated via job object

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__windows_tests__stack_violation_code.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__windows_tests__stack_violation_code.snap
@@ -1,6 +1,6 @@
 ---
 source: nextest-runner/src/reporter/displayer.rs
-expression: to_message_line(STATUS_CONTROL_STACK_VIOLATION)
+expression: "to_message_line(AbortStatus::WindowsNtStatus(STATUS_CONTROL_STACK_VIOLATION))"
 snapshot_kind: text
 ---
-   with code 0xc00001b2: Invalid access to memory location. (os error 998)
+           - with code 0xc00001b2: Invalid access to memory location. (os error 998)

--- a/nextest-runner/src/runner/internal_events.rs
+++ b/nextest-runner/src/runner/internal_events.rs
@@ -249,3 +249,25 @@ impl RunnerTaskState {
         }
     }
 }
+
+#[derive(Clone, Copy, Debug)]
+#[must_use]
+pub(super) enum HandleSignalResult {
+    /// A job control signal was delivered.
+    #[cfg(unix)]
+    JobControl,
+
+    /// The child was terminated.
+    #[cfg_attr(not(windows), expect(dead_code))]
+    Terminated(TerminateChildResult),
+}
+
+#[derive(Clone, Copy, Debug)]
+#[must_use]
+pub(super) enum TerminateChildResult {
+    /// The child process exited without being forcibly killed.
+    Exited,
+
+    /// The child process was forcibly killed.
+    Killed,
+}


### PR DESCRIPTION
In case of a Ctrl-C grace period expiring, we should make it clear to users what's happening rather than just printing out "FAIL".