### PR TITLE
[ci] run coverage on Windows as well

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,12 @@ name: Test coverage
 jobs:
   coverage:
     name: Collect test coverage
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
     # nightly rust might break from time to time
     continue-on-error: true
     env:


### PR DESCRIPTION
There's a bunch of Windows-specific code that is covered, but isn't reflected in the coverage metrics.