### PR TITLE
[cargo-nextest] fail if --target wasn't understood

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,6 +735,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "datatest-stable"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5bb15663f97601af4c8d17237f2f884593bf59b4c013003babcb3cae66711b7"
+dependencies = [
+ "camino",
+ "fancy-regex",
+ "include_dir",
+ "libtest-mimic",
+ "walkdir",
+]
+
+[[package]]
 name = "debug-ignore"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,6 +897,17 @@ checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -1409,6 +1433,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfdf4f5d937a025381f5ab13624b1c5f51414bfe5c9885663226eae8d6d39560"
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indent_write"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,6 +1525,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "cp_r",
+ "datatest-stable",
  "enable-ansi-support",
  "fixture-data",
  "fs-err",
@@ -1497,6 +1541,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "target-spec",
+ "target-spec-miette",
  "tokio",
  "whoami",
 ]
@@ -1887,7 +1932,10 @@ dependencies = [
 name = "nextest-workspace-hack"
 version = "0.1.0"
 dependencies = [
+ "aho-corasick",
  "backtrace",
+ "bit-set",
+ "bit-vec",
  "camino",
  "cc",
  "clap",
@@ -1909,11 +1957,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rand",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
  "rustix",
  "serde",
  "serde_json",
  "smallvec",
  "syn",
+ "target-spec",
+ "target-spec-miette",
  "tokio",
  "tracing-core",
  "tracing-subscriber",
@@ -2599,6 +2651,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3032,6 +3093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41754f40e3eeb0f884fd2f6bd32835e611e5d1be8568af1c6313fde1dcb96c2e"
 dependencies = [
  "guppy-workspace-hack",
+ "include_dir",
  "miette",
  "target-spec",
 ]
@@ -3582,6 +3644,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3734,6 +3806,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ clap = { version = "4.5.23", features = ["derive"] }
 console-subscriber = "0.4.1"
 cp_r = "0.5.2"
 crossterm = { version = "0.28.1", features = ["event-stream"] }
+datatest-stable = { version = "0.3.0", features = ["include-dir"] }
 dialoguer = "0.11.0"
 debug-ignore = "1.0.5"
 derive-where = "1.2.7"

--- a/cargo-nextest/src/cargo_cli.rs
+++ b/cargo-nextest/src/cargo_cli.rs
@@ -187,7 +187,7 @@ pub(crate) struct CargoOptions {
 
     // NOTE: this does not conflict with reuse build opts (not part of the cargo-opts group) since
     // we let target.runner be specified this way
-    /// Override a configuration value
+    /// Override a Cargo configuration value
     #[arg(long, value_name = "KEY=VALUE", help_heading = "Other Cargo options")]
     pub(crate) config: Vec<String>,
 

--- a/cargo-nextest/src/errors.rs
+++ b/cargo-nextest/src/errors.rs
@@ -657,8 +657,14 @@ impl ExpectedError {
                 Some(err as &dyn Error)
             }
             Self::TargetTripleError { err } => {
-                error!("{err}");
-                err.source()
+                if let Some(report) = err.source_report() {
+                    // Display the miette report if available.
+                    error!(target: "cargo_nextest::no_heading", "{report:?}");
+                    None
+                } else {
+                    error!("{err}");
+                    err.source()
+                }
             }
             Self::MetadataMaterializeError { arg_name, err } => {
                 error!(

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -17,6 +17,10 @@ path = "test-helpers/build-seed-archive.rs"
 name = "custom-harness"
 harness = false
 
+[[test]]
+name = "datatest"
+harness = false
+
 [dependencies]
 camino.workspace = true
 camino-tempfile.workspace = true
@@ -44,6 +48,7 @@ whoami.workspace = true
 [dev-dependencies]
 cfg-if.workspace = true
 cp_r.workspace = true
+datatest-stable.workspace = true
 fixture-data.workspace = true
 insta.workspace = true
 itertools.workspace = true
@@ -52,6 +57,7 @@ nextest-metadata.workspace = true
 pathdiff.workspace = true
 regex.workspace = true
 target-spec.workspace = true
+target-spec-miette = { workspace = true, features = ["fixtures"] }
 tokio.workspace = true
 
 # These platforms are supported by num_threads.

--- a/integration-tests/tests/datatest/custom_target.rs
+++ b/integration-tests/tests/datatest/custom_target.rs
@@ -1,0 +1,46 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::helpers::bind_insta_settings;
+use camino::Utf8Path;
+use camino_tempfile::Utf8TempDir;
+use integration_tests::nextest_cli::CargoNextestCli;
+use nextest_metadata::NextestExitCode;
+
+pub(crate) fn custom_invalid(path: &Utf8Path, contents: String) -> datatest_stable::Result<()> {
+    let (_guard, insta_prefix) = bind_insta_settings(path, "snapshots/custom-invalid");
+
+    let dir = Utf8TempDir::with_prefix("nextest-custom-target-")?;
+    let json_path = dir.path().join(path.file_name().unwrap());
+    std::fs::write(&json_path, contents)?;
+
+    let output = CargoNextestCli::for_test()
+        .args([
+            // Use color in snapshots to ensure that it is correctly passed
+            // through.
+            //
+            // It might be nice to use snapbox in the future, because it has
+            // really nice color support.
+            "--color",
+            "always",
+            "debug",
+            "show-target",
+            "--target",
+            json_path.as_str(),
+        ])
+        .unchecked(true)
+        .output();
+
+    // We expect this to fail with a setup error.
+    assert!(!output.exit_status.success());
+    assert_eq!(
+        output.exit_status.code(),
+        Some(NextestExitCode::SETUP_ERROR),
+        "exit code matches"
+    );
+
+    // Print the output.
+    insta::assert_snapshot!(format!("{insta_prefix}-stderr"), output.stderr_as_str());
+
+    Ok(())
+}

--- a/integration-tests/tests/datatest/helpers.rs
+++ b/integration-tests/tests/datatest/helpers.rs
@@ -1,0 +1,22 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use datatest_stable::Utf8Path;
+use insta::internals::SettingsBindDropGuard;
+
+/// Binds insta settings for a test, and returns the prefix to use for snapshots.
+pub(crate) fn bind_insta_settings<'a>(
+    path: &'a Utf8Path,
+    snapshot_path: &str,
+) -> (SettingsBindDropGuard, &'a str) {
+    let mut settings = insta::Settings::clone_current();
+    // Make insta suitable for datatest-stable use.
+    settings.set_input_file(path);
+    settings.set_snapshot_path(snapshot_path);
+    settings.set_prepend_module_to_snapshot(false);
+
+    let guard = settings.bind_to_scope();
+    let insta_prefix = path.file_name().unwrap();
+
+    (guard, insta_prefix)
+}

--- a/integration-tests/tests/datatest/main.rs
+++ b/integration-tests/tests/datatest/main.rs
@@ -1,0 +1,15 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Data-driven tests.
+
+mod custom_target;
+mod helpers;
+
+datatest_stable::harness! {
+    {
+        test = custom_target::custom_invalid,
+        root = &target_spec_miette::fixtures::CUSTOM_INVALID,
+        pattern = r"^.*$",
+    },
+}

--- a/integration-tests/tests/datatest/snapshots/custom-invalid/invalid-arch.json-stderr.snap
+++ b/integration-tests/tests/datatest/snapshots/custom-invalid/invalid-arch.json-stderr.snap
@@ -1,0 +1,13 @@
+---
+source: integration-tests/tests/datatest/custom_target.rs
+expression: output.stderr_as_str()
+snapshot_kind: text
+---
+  [31;1merror:[0m error deserializing custom target JSON for `invalid-arch`
+   ╭─[2:13]
+ [2m1[0m │ {
+ [2m2[0m │   "arch": 123,
+   · [31m            ▲[0m
+   ·             [31m╰── [31minvalid type: integer `123`, expected a string[0m[0m
+ [2m3[0m │   "cpu": "x86-64",
+   ╰────

--- a/integration-tests/tests/datatest/snapshots/custom-invalid/invalid-endian.json-stderr.snap
+++ b/integration-tests/tests/datatest/snapshots/custom-invalid/invalid-endian.json-stderr.snap
@@ -1,0 +1,13 @@
+---
+source: integration-tests/tests/datatest/custom_target.rs
+expression: output.stderr_as_str()
+snapshot_kind: text
+---
+  [31;1merror:[0m error deserializing custom target JSON for `invalid-endian`
+    ╭─[32:29]
+ [2m31[0m │     },
+ [2m32[0m │     "target-endian": "middle",
+    · [31m                            ▲[0m
+    ·                             [31m╰── [31munknown variant `middle`, expected `little` or `big`[0m[0m
+ [2m33[0m │     "target-family": ["unix"],
+    ╰────

--- a/integration-tests/tests/datatest/snapshots/custom-invalid/invalid-family.json-stderr.snap
+++ b/integration-tests/tests/datatest/snapshots/custom-invalid/invalid-family.json-stderr.snap
@@ -1,0 +1,13 @@
+---
+source: integration-tests/tests/datatest/custom_target.rs
+expression: output.stderr_as_str()
+snapshot_kind: text
+---
+  [31;1merror:[0m error deserializing custom target JSON for `invalid-family`
+    ╭─[33:27]
+ [2m32[0m │     "target-endian": "big",
+ [2m33[0m │     "target-family": "none",
+    · [31m                          ▲[0m
+    ·                           [31m╰── [31minvalid type: string "none", expected a sequence[0m[0m
+ [2m34[0m │     "target-mcount": "_mcount",
+    ╰────

--- a/integration-tests/tests/datatest/snapshots/custom-invalid/invalid-target-pointer-width.json-stderr.snap
+++ b/integration-tests/tests/datatest/snapshots/custom-invalid/invalid-target-pointer-width.json-stderr.snap
@@ -1,0 +1,14 @@
+---
+source: integration-tests/tests/datatest/custom_target.rs
+expression: output.stderr_as_str()
+snapshot_kind: text
+---
+  [31;1merror:[0m error deserializing custom target JSON for `invalid-target-pointer-
+  [31;1m│[0m width`
+    ╭─[52:30]
+ [2m51[0m │   ],
+ [2m52[0m │   "target-pointer-width": "xx",
+    · [31m                             ▲[0m
+    ·                              [31m╰── [31merror parsing as integer: invalid digit found in string[0m[0m
+ [2m53[0m │   "supports-xray": true,
+    ╰────

--- a/integration-tests/tests/datatest/snapshots/custom-invalid/missing-arch.json-stderr.snap
+++ b/integration-tests/tests/datatest/snapshots/custom-invalid/missing-arch.json-stderr.snap
@@ -1,0 +1,12 @@
+---
+source: integration-tests/tests/datatest/custom_target.rs
+expression: output.stderr_as_str()
+snapshot_kind: text
+---
+  [31;1merror:[0m error deserializing custom target JSON for `missing-arch`
+    ╭─[35:1]
+ [2m34[0m │     "target-pointer-width": "64"
+ [2m35[0m │ }
+    · [31m▲[0m
+    · [31m╰── [31mmissing field `arch`[0m[0m
+    ╰────

--- a/integration-tests/tests/datatest/snapshots/custom-invalid/syntax-error.json-stderr.snap
+++ b/integration-tests/tests/datatest/snapshots/custom-invalid/syntax-error.json-stderr.snap
@@ -1,0 +1,12 @@
+---
+source: integration-tests/tests/datatest/custom_target.rs
+expression: output.stderr_as_str()
+snapshot_kind: text
+---
+  [31;1merror:[0m error deserializing custom target JSON for `syntax-error`
+    ╭─[40:13]
+ [2m39[0m │     "leak",
+ [2m40[0m │     "memory",
+    · [31m            ▲[0m
+    ·             [31m╰── [31mEOF while parsing a value[0m[0m
+    ╰────

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -1551,6 +1551,26 @@ pub enum TargetTripleError {
     },
 }
 
+impl TargetTripleError {
+    /// Returns a [`miette::Report`] for the source, if available.
+    ///
+    /// This should be preferred over [`std::error::Error::source`] if
+    /// available.
+    pub fn source_report(&self) -> Option<miette::Report> {
+        match self {
+            Self::TargetSpecError { error, .. } => {
+                Some(miette::Report::new_boxed(error.clone().into_diagnostic()))
+            }
+            // The remaining types are covered via the error source path.
+            TargetTripleError::InvalidEnvironmentVar
+            | TargetTripleError::TargetPathReadError { .. }
+            | TargetTripleError::CustomPlatformTempDirError { .. }
+            | TargetTripleError::CustomPlatformWriteError { .. }
+            | TargetTripleError::CustomPlatformCloseError { .. } => None,
+        }
+    }
+}
+
 /// An error occurred determining the target runner
 #[derive(Debug, Error)]
 pub enum TargetRunnerError {

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -15,7 +15,10 @@ publish = false
 
 ### BEGIN HAKARI SECTION
 [dependencies]
+aho-corasick = { version = "1.1.3" }
 backtrace = { version = "0.3.71", features = ["gimli-symbolize"] }
+bit-set = { version = "0.8.0" }
+bit-vec = { version = "0.8.0" }
 camino = { version = "1.1.9", default-features = false, features = ["serde1"] }
 clap = { version = "4.5.23", features = ["derive", "env", "unicode", "wrap_help"] }
 clap_builder = { version = "4.5.23", default-features = false, features = ["color", "env", "std", "suggestions", "unicode", "usage", "wrap_help"] }
@@ -28,9 +31,13 @@ memchr = { version = "2.7.4" }
 miette = { version = "7.4.0", features = ["fancy"] }
 num-traits = { version = "0.2.19", default-features = false, features = ["std"] }
 rand = { version = "0.8.5" }
+regex-automata = { version = "0.4.8", default-features = false, features = ["dfa", "hybrid", "meta", "nfa", "perf", "unicode"] }
+regex-syntax = { version = "0.8.5" }
 serde = { version = "1.0.216", features = ["alloc", "derive"] }
 serde_json = { version = "1.0.134", features = ["unbounded_depth"] }
 smallvec = { version = "1.13.2", default-features = false, features = ["const_generics"] }
+target-spec = { version = "3.3.1", default-features = false, features = ["custom", "summaries"] }
+target-spec-miette = { version = "0.4.4", default-features = false, features = ["fixtures"] }
 tokio = { version = "1.42.0", features = ["fs", "io-std", "io-util", "macros", "process", "rt-multi-thread", "signal", "sync", "time", "tracing"] }
 tracing-core = { version = "0.1.33" }
 tracing-subscriber = { version = "0.3.19", default-features = false, features = ["fmt", "tracing-log"] }
@@ -78,7 +85,7 @@ futures-core = { version = "0.3.31" }
 futures-sink = { version = "0.3.31", default-features = false, features = ["std"] }
 smallvec = { version = "1.13.2", default-features = false, features = ["const_new"] }
 tokio = { version = "1.42.0", default-features = false, features = ["net"] }
-windows-sys-73dcd821b1037cfd = { package = "windows-sys", version = "0.59.0", features = ["Win32_Globalization", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_JobObjects", "Win32_System_Pipes", "Win32_System_Threading", "Win32_UI_Shell"] }
+windows-sys-73dcd821b1037cfd = { package = "windows-sys", version = "0.59.0", features = ["Win32_Globalization", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_JobObjects", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_UI_Shell"] }
 windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52.0", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_Environment", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell"] }
 
 ### END HAKARI SECTION


### PR DESCRIPTION
Currently, if nextest cannot parse a target triple it prints a warning, and instead just builds on the host platform. I think that isn't the right behavior, and instead nextest should loudly fail.

Implement this change: fail with a clear error message. I consider the current behavior a bug, so I don't think this needs to go through the behavior change process.

Also, hook up miette support to produce better error messages if deserializing custom JSON fails, and add tests to verify this behavior.

For target runners, we continue to warn rather than fail.