### PR TITLE
handle newline/enter in input events

### DIFF
--- a/nextest-runner/src/input.rs
+++ b/nextest-runner/src/input.rs
@@ -100,10 +100,16 @@ impl InputHandler {
         let (_, stream) = self.imp.as_mut()?;
         loop {
             let next = stream.next().await?;
+            // Everything after here must be cancel-safe: ideally no await
+            // points at all, but okay with discarding `next` if there are any
+            // await points.
             match next {
                 Ok(Event::Key(key)) => {
                     if key.code == KeyCode::Char(Self::INFO_CHAR) && key.modifiers.is_empty() {
                         return Some(InputEvent::Info);
+                    }
+                    if key.code == KeyCode::Enter {
+                        return Some(InputEvent::Enter);
                     }
                 }
                 Ok(event) => {
@@ -416,4 +422,5 @@ mod imp {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(crate) enum InputEvent {
     Info,
+    Enter,
 }

--- a/nextest-runner/src/reporter/aggregator/junit.rs
+++ b/nextest-runner/src/reporter/aggregator/junit.rs
@@ -103,6 +103,7 @@ impl<'cfg> MetadataJunit<'cfg> {
             TestEventKind::InfoStarted { .. }
             | TestEventKind::InfoResponse { .. }
             | TestEventKind::InfoFinished { .. } => {}
+            TestEventKind::InputEnter => {}
             TestEventKind::TestStarted { .. } => {}
             TestEventKind::TestSlow { .. } => {}
             TestEventKind::TestAttemptFailedWillRetry { .. }

--- a/nextest-runner/src/reporter/events.rs
+++ b/nextest-runner/src/reporter/events.rs
@@ -251,6 +251,10 @@ pub enum TestEventKind<'a> {
         missing: usize,
     },
 
+    /// `Enter` was pressed. Either a newline or a progress bar snapshot needs
+    /// to be printed.
+    InputEnter,
+
     /// A cancellation notice was received.
     RunBeginCancel {
         /// The number of setup scripts still running.

--- a/nextest-runner/src/runner/dispatcher.rs
+++ b/nextest-runner/src/runner/dispatcher.rs
@@ -535,6 +535,9 @@ where
                 // Print current statistics.
                 HandleEventResponse::Info(InfoEvent::Input)
             }
+            InternalEvent::Input(InputEvent::Enter) => {
+                self.callback_none_response(TestEventKind::InputEnter)
+            }
             InternalEvent::ReportCancel => {
                 self.begin_cancel(CancelReason::ReportError, CancelEvent::Report)
             }


### PR DESCRIPTION
If input handling is enabled, also handle newline/enter events.

* If a progress bar is present, take a snapshot of it.
* If not, then print a blank line.

This allows for the common usage pattern of users pressing enter-enter-enter to
mark a particular point in the output.