### PR TITLE
[nextest-runner] better InputEnter display

### DIFF
--- a/nextest-runner/src/reporter/aggregator/junit.rs
+++ b/nextest-runner/src/reporter/aggregator/junit.rs
@@ -103,7 +103,7 @@ impl<'cfg> MetadataJunit<'cfg> {
             TestEventKind::InfoStarted { .. }
             | TestEventKind::InfoResponse { .. }
             | TestEventKind::InfoFinished { .. } => {}
-            TestEventKind::InputEnter => {}
+            TestEventKind::InputEnter { .. } => {}
             TestEventKind::TestStarted { .. } => {}
             TestEventKind::TestSlow { .. } => {}
             TestEventKind::TestAttemptFailedWillRetry { .. }

--- a/nextest-runner/src/reporter/events.rs
+++ b/nextest-runner/src/reporter/events.rs
@@ -253,7 +253,16 @@ pub enum TestEventKind<'a> {
 
     /// `Enter` was pressed. Either a newline or a progress bar snapshot needs
     /// to be printed.
-    InputEnter,
+    InputEnter {
+        /// Current statistics for number of tests so far.
+        current_stats: RunStats,
+
+        /// The number of tests running.
+        running: usize,
+
+        /// The cancel status of the run. This is None if the run is still ongoing.
+        cancel_reason: Option<CancelReason>,
+    },
 
     /// A cancellation notice was received.
     RunBeginCancel {

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_exec_failed_with_cancel_reason.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_exec_failed_with_cancel_reason.snap
@@ -1,0 +1,6 @@
+---
+source: nextest-runner/src/reporter/displayer.rs
+expression: s
+snapshot_kind: text
+---
+[31;1m  Cancelling[0m [ 34:17:36] 10/20: [1m10[0m running, [1m0[0m [32;1mpassed[0m, [1m1[0m [31;1mexec failed[0m, [1m0[0m [33;1mskipped[0m

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_exec_failed_without_cancel_reason.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_exec_failed_without_cancel_reason.snap
@@ -1,0 +1,6 @@
+---
+source: nextest-runner/src/reporter/displayer.rs
+expression: s
+snapshot_kind: text
+---
+[31;1m     Running[0m [ 34:17:36] 10/20: [1m10[0m running, [1m0[0m [32;1mpassed[0m, [1m1[0m [31;1mexec failed[0m, [1m0[0m [33;1mskipped[0m

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_failed_one_passed_with_cancel_reason.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_failed_one_passed_with_cancel_reason.snap
@@ -1,0 +1,6 @@
+---
+source: nextest-runner/src/reporter/displayer.rs
+expression: s
+snapshot_kind: text
+---
+[31;1m  Cancelling[0m [ 34:17:36] 2/20: [1m10[0m running, [1m1[0m [32;1mpassed[0m, [1m1[0m [31;1mfailed[0m, [1m0[0m [33;1mskipped[0m

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_failed_one_passed_without_cancel_reason.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_failed_one_passed_without_cancel_reason.snap
@@ -1,0 +1,6 @@
+---
+source: nextest-runner/src/reporter/displayer.rs
+expression: s
+snapshot_kind: text
+---
+[31;1m     Running[0m [ 34:17:36] 2/20: [1m10[0m running, [1m1[0m [32;1mpassed[0m, [1m1[0m [31;1mfailed[0m, [1m0[0m [33;1mskipped[0m

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_failed_with_cancel_reason.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_failed_with_cancel_reason.snap
@@ -1,0 +1,6 @@
+---
+source: nextest-runner/src/reporter/displayer.rs
+expression: s
+snapshot_kind: text
+---
+[31;1m  Cancelling[0m [ 34:17:36] 1/20: [1m10[0m running, [1m0[0m [32;1mpassed[0m, [1m1[0m [31;1mfailed[0m, [1m0[0m [33;1mskipped[0m

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_failed_without_cancel_reason.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_failed_without_cancel_reason.snap
@@ -1,0 +1,6 @@
+---
+source: nextest-runner/src/reporter/displayer.rs
+expression: s
+snapshot_kind: text
+---
+[31;1m     Running[0m [ 34:17:36] 1/20: [1m10[0m running, [1m0[0m [32;1mpassed[0m, [1m1[0m [31;1mfailed[0m, [1m0[0m [33;1mskipped[0m

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_setup_script_exec_failed_with_cancel_reason.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_setup_script_exec_failed_with_cancel_reason.snap
@@ -1,0 +1,6 @@
+---
+source: nextest-runner/src/reporter/displayer.rs
+expression: s
+snapshot_kind: text
+---
+[31;1m  Cancelling[0m [ 34:17:36] 0/35: [1m10[0m running, [1m0[0m [32;1mpassed[0m, [1m0[0m [33;1mskipped[0m

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_setup_script_exec_failed_without_cancel_reason.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_setup_script_exec_failed_without_cancel_reason.snap
@@ -1,0 +1,6 @@
+---
+source: nextest-runner/src/reporter/displayer.rs
+expression: s
+snapshot_kind: text
+---
+[31;1m     Running[0m [ 34:17:36] 0/35: [1m10[0m running, [1m0[0m [32;1mpassed[0m, [1m0[0m [33;1mskipped[0m

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_setup_script_failed_with_cancel_reason.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_setup_script_failed_with_cancel_reason.snap
@@ -1,0 +1,6 @@
+---
+source: nextest-runner/src/reporter/displayer.rs
+expression: s
+snapshot_kind: text
+---
+[31;1m  Cancelling[0m [ 34:17:36] 0/30: [1m10[0m running, [1m0[0m [32;1mpassed[0m, [1m0[0m [33;1mskipped[0m

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_setup_script_failed_without_cancel_reason.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_setup_script_failed_without_cancel_reason.snap
@@ -1,0 +1,6 @@
+---
+source: nextest-runner/src/reporter/displayer.rs
+expression: s
+snapshot_kind: text
+---
+[31;1m     Running[0m [ 34:17:36] 0/30: [1m10[0m running, [1m0[0m [32;1mpassed[0m, [1m0[0m [33;1mskipped[0m

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_setup_script_timed_out_with_cancel_reason.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_setup_script_timed_out_with_cancel_reason.snap
@@ -1,0 +1,6 @@
+---
+source: nextest-runner/src/reporter/displayer.rs
+expression: s
+snapshot_kind: text
+---
+[31;1m  Cancelling[0m [ 34:17:36] 0/40: [1m10[0m running, [1m0[0m [32;1mpassed[0m, [1m0[0m [33;1mskipped[0m

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_setup_script_timed_out_without_cancel_reason.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_setup_script_timed_out_without_cancel_reason.snap
@@ -1,0 +1,6 @@
+---
+source: nextest-runner/src/reporter/displayer.rs
+expression: s
+snapshot_kind: text
+---
+[31;1m     Running[0m [ 34:17:36] 0/40: [1m10[0m running, [1m0[0m [32;1mpassed[0m, [1m0[0m [33;1mskipped[0m

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_timed_out_with_cancel_reason.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_timed_out_with_cancel_reason.snap
@@ -1,0 +1,6 @@
+---
+source: nextest-runner/src/reporter/displayer.rs
+expression: s
+snapshot_kind: text
+---
+[31;1m  Cancelling[0m [ 34:17:36] 10/20: [1m10[0m running, [1m0[0m [32;1mpassed[0m, [1m1[0m [31;1mtimed out[0m, [1m0[0m [33;1mskipped[0m

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_timed_out_without_cancel_reason.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__displayer__tests__one_timed_out_without_cancel_reason.snap
@@ -1,0 +1,6 @@
+---
+source: nextest-runner/src/reporter/displayer.rs
+expression: s
+snapshot_kind: text
+---
+[31;1m     Running[0m [ 34:17:36] 10/20: [1m10[0m running, [1m0[0m [32;1mpassed[0m, [1m1[0m [31;1mtimed out[0m, [1m0[0m [33;1mskipped[0m

--- a/nextest-runner/src/runner/dispatcher.rs
+++ b/nextest-runner/src/runner/dispatcher.rs
@@ -536,7 +536,11 @@ where
                 HandleEventResponse::Info(InfoEvent::Input)
             }
             InternalEvent::Input(InputEvent::Enter) => {
-                self.callback_none_response(TestEventKind::InputEnter)
+                self.callback_none_response(TestEventKind::InputEnter {
+                    current_stats: self.run_stats,
+                    running: self.running(),
+                    cancel_reason: self.cancel_state,
+                })
             }
             InternalEvent::ReportCancel => {
                 self.begin_cancel(CancelReason::ReportError, CancelEvent::Report)

--- a/site/src/docs/design/architecture/input-handling.md
+++ b/site/src/docs/design/architecture/input-handling.md
@@ -323,23 +323,39 @@ handling](signal-handling.md#on-windows).
 ## Handling the Enter key { #handling-enter }
 
 As discussed in [*the appendix*](#no-raw-mode) below, echoing characters is
-disabled for a better user experience. However, users sometimes want characters
-to be echoed.
+disabled for a better user experience. However, users sometimes _want_
+characters to be echoed.
 
 For example, a common pattern to mark a spot in some interactive output is to
 press Enter a bunch. (This is safe to do with programs that don't consume
 input, because those lines are treated as no-ops by the shell.)
 
-Nextest supports this pattern by handling the Enter key, and emulating the
-behavior that would happen.
+Nextest supports this pattern by handling the Enter key. On receiving Enter,
+nextest displays the current state as would be visible in the progress bar, but
+not the progress bar itself. This acts as both a report of the current state and
+as a visual marker.
 
-- If the progress bar is visible, pressing Enter takes a snapshot of the
-  progress bar in a new line. This matches observed behavior with
-  `--no-input-handler`. We could do something different here, but a progress bar
-  snapshot seems great: it succinctly captures the state of execution
-  at that moment.
+For example, nextest might display:
 
-- If the progress bar is not visible, pressing Enter prints a blank line.
+=== "Colorized"
+
+    ```bash exec="true" result="ansi"
+    cat src/outputs/enter-output.ansi
+    ```
+
+=== "Plaintext"
+
+    ```bash exec="true" result="text"
+    cat src/outputs/enter-output.ansi | ../scripts/strip-ansi.sh
+    ```
+
+Compare this behavior to what happens without input handling:
+
+- If the progress bar is visible, a snapshot of the progress bar is printed.
+- If not, a blank line is printed.
+
+Nextest's behavior with input handling is user-friendly, and consistent
+regardless of whether the progress bar is visible.
 
 ## Translating inputs to events { #translating-inputs }
 
@@ -384,10 +400,9 @@ synchronous APIs is likely possible.
 ## Conclusion
 
 Nextest's approach to input handling prioritizes cross-platform consistency and
-an improved user experience. By processing keyboard inputs, nextest can provide
-cross-platform interactive status functionality. By carefully managing terminal
-settings and input events in a principled manner, nextest ensures a robust and
-extensible foundation for interactive functionality.
+an good user experience. By carefully managing terminal settings and input
+events in a principled manner, nextest ensures a robust and extensible
+foundation for interactive functionality.
 
 ---
 

--- a/site/src/outputs/enter-output.ansi
+++ b/site/src/outputs/enter-output.ansi
@@ -1,0 +1,4 @@
+[32;1m        PASS[0m [   0.749s] [35;1mintegration-tests::integration[0m [34;1mtest_target_arg[0m
+(Enter pressed)
+[32;1m     Running[0m [ 00:00:02] 293/296: [1m3[0m running, [1m293[0m [32;1mpassed[0m, [1m1[0m [33;1mskipped[0m
+[32;1m        PASS[0m [   2.160s] [35;1mnextest-runner::integration[0m [36mbasic[0m[36m::[0m[34;1mtest_termination[0m


### PR DESCRIPTION
Rather than trying to do different things with and without the progress bar, just display a summary of the current state (everything that would be shown except for the progress itself).

Also add some tests.