### PR TITLE
[nextest-runner] fix accidentally-missing newline in write_final_status

### DIFF
--- a/nextest-runner/src/reporter/displayer/snapshots/nextest_runner__reporter__displayer__imp__tests__final_status_output.snap
+++ b/nextest-runner/src/reporter/displayer/snapshots/nextest_runner__reporter__displayer__imp__tests__final_status_output.snap
@@ -1,0 +1,7 @@
+---
+source: nextest-runner/src/reporter/displayer/imp.rs
+expression: "String::from_utf8(out).expect(\"output only consists of UTF-8\")"
+snapshot_kind: text
+---
+        FAIL [   1.000s] my-binary-id test1
+   FLAKY 2/2 [   2.000s] my-binary-id test1


### PR DESCRIPTION
Accidentally switched a `writeln!` to a `write!` in 6f9689329e9cda1f96f3ed37443df50e3a450501. Whoops, this bit of code didn't quite have coverage, so added some tests.