### PR TITLE
[nextest-runner] reset progress bar elapsed time on SIGCONT

### DIFF
--- a/nextest-runner/src/reporter/displayer/progress.rs
+++ b/nextest-runner/src/reporter/displayer/progress.rs
@@ -116,6 +116,9 @@ impl ProgressBarState {
                 // Continuing the run should show the progress bar since we'll
                 // continue to output to it.
                 self.hidden_run_paused = false;
+                // Wish a mutable form of with_elapsed were supported.
+                let bar = std::mem::replace(&mut self.bar, ProgressBar::hidden());
+                self.bar = bar.with_elapsed(event.elapsed);
             }
             TestEventKind::RunBeginCancel { reason, .. }
             | TestEventKind::RunBeginKill { reason, .. } => {


### PR DESCRIPTION
On continuing, ensure that the elapsed time is set to the actual time.