### PR TITLE
chore: Upgrade to Winnow 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4138,9 +4138,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,7 +552,7 @@ dependencies = [
  "serde",
  "serde_json",
  "toml",
- "winnow",
+ "winnow 0.6.26",
 ]
 
 [[package]]
@@ -1839,7 +1839,7 @@ dependencies = [
  "test-case",
  "test-strategy",
  "thiserror 2.0.11",
- "winnow",
+ "winnow 0.7.0",
  "xxhash-rust",
 ]
 
@@ -3442,7 +3442,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.6.26",
 ]
 
 [[package]]
@@ -4141,6 +4141,15 @@ name = "winnow"
 version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e49d2d35d3fad69b39b94139037ecfb4f359f08958b9c11e7315ce770462419"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ unicode-normalization = "0.1.24"
 whoami = "1.5.2"
 win32job = "2.0.1"
 windows-sys = "0.59.0"
-winnow = "0.6.26"
+winnow = "0.7.0"
 xxhash-rust = "0.8.13"
 zstd = { version = "0.13.2", features = ["zstdmt"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,7 +133,7 @@ unicode-normalization = "0.1.24"
 whoami = "1.5.2"
 win32job = "2.0.1"
 windows-sys = "0.59.0"
-winnow = "0.6.24"
+winnow = "0.6.26"
 xxhash-rust = "0.8.13"
 zstd = { version = "0.13.2", features = ["zstdmt"] }
 

--- a/nextest-filtering/src/parsing.rs
+++ b/nextest-filtering/src/parsing.rs
@@ -32,7 +32,7 @@ pub(crate) use unicode_string::DisplayParsedString;
 
 pub(crate) type Span<'a> = winnow::Stateful<LocatingSlice<&'a str>, State<'a>>;
 type Error = ();
-type PResult<T> = winnow::PResult<T, Error>;
+type PResult<T> = winnow::ModalResult<T, Error>;
 
 pub(crate) fn new_span<'a>(input: &'a str, errors: &'a mut Vec<ParseSingleError>) -> Span<'a> {
     Span {

--- a/nextest-filtering/src/parsing/glob.rs
+++ b/nextest-filtering/src/parsing/glob.rs
@@ -62,7 +62,7 @@ pub(super) fn parse_glob<'i>(
     implicit: bool,
 ) -> impl ModalParser<Span<'i>, Option<NameMatcher>, Error> {
     trace("parse_glob", move |input: &mut Span<'i>| {
-        let start = input.location();
+        let start = input.current_token_start();
         let res = match parse_matcher_text.parse_next(input) {
             Ok(res) => res,
             Err(_) => {
@@ -77,7 +77,7 @@ pub(super) fn parse_glob<'i>(
         match GenericGlob::new(parsed_value) {
             Ok(glob) => Ok(Some(NameMatcher::Glob { glob, implicit })),
             Err(error) => {
-                let end = input.location();
+                let end = input.current_token_start();
                 let err = ParseSingleError::InvalidGlob {
                     span: (start, end - start).into(),
                     error,

--- a/nextest-filtering/src/parsing/glob.rs
+++ b/nextest-filtering/src/parsing/glob.rs
@@ -8,7 +8,7 @@ use crate::{
     errors::{GlobConstructError, ParseSingleError},
     NameMatcher,
 };
-use winnow::{combinator::trace, stream::Location, Parser};
+use winnow::{combinator::trace, stream::Location, ModalParser, Parser};
 
 /// A glob pattern.
 ///
@@ -58,7 +58,9 @@ impl GenericGlob {
 }
 
 // This never returns Err(()) -- instead, it reports an error to the parsing state.
-pub(super) fn parse_glob<'i>(implicit: bool) -> impl Parser<Span<'i>, Option<NameMatcher>, Error> {
+pub(super) fn parse_glob<'i>(
+    implicit: bool,
+) -> impl ModalParser<Span<'i>, Option<NameMatcher>, Error> {
     trace("parse_glob", move |input: &mut Span<'i>| {
         let start = input.location();
         let res = match parse_matcher_text.parse_next(input) {


### PR DESCRIPTION
With 0.7, `ErrMode` is optional.  It looks like `cut_err` isn't used but I held off on migrating from `ModalResult` to `winnow::Result` and `ModalParser` to `Parser` in case there is a future possibility of using `ErrMode`.