### PR TITLE
[meta] remove direct dep on once_cell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,6 @@ dependencies = [
  "nextest-metadata",
  "nextest-runner",
  "nextest-workspace-hack",
- "once_cell",
  "owo-colors 4.1.0",
  "pathdiff",
  "quick-junit",
@@ -957,7 +956,6 @@ dependencies = [
  "maplit",
  "nextest-metadata",
  "nextest-workspace-hack",
- "once_cell",
 ]
 
 [[package]]
@@ -1902,7 +1900,6 @@ dependencies = [
  "nextest-metadata",
  "nextest-workspace-hack",
  "nix",
- "once_cell",
  "owo-colors 4.1.0",
  "pathdiff",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,6 @@ nextest-metadata = { version = "0.12.1", path = "nextest-metadata" }
 nextest-workspace-hack = "0.1.0"
 nix = { version = "0.29.0", default-features = false, features = ["signal"] }
 num_threads = "0.1.7"
-once_cell = "1.20.2"
 owo-colors = "4.1.0"
 pathdiff = { version = "0.2.3", features = ["camino"] }
 pin-project-lite = "0.2.16"

--- a/cargo-nextest/Cargo.toml
+++ b/cargo-nextest/Cargo.toml
@@ -28,7 +28,6 @@ nextest-filtering = { version = "=0.13.0", path = "../nextest-filtering" }
 nextest-metadata = { version = "=0.12.1", path = "../nextest-metadata" }
 nextest-runner = { version = "=0.71.0", path = "../nextest-runner" }
 nextest-workspace-hack.workspace = true
-once_cell.workspace = true
 owo-colors.workspace = true
 pathdiff.workspace = true
 quick-junit.workspace = true

--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -44,7 +44,6 @@ use nextest_runner::{
     write_str::WriteStr,
     RustcCli,
 };
-use once_cell::sync::OnceCell;
 use owo_colors::OwoColorize;
 use quick_junit::XmlString;
 use semver::Version;
@@ -53,7 +52,7 @@ use std::{
     env::VarError,
     fmt,
     io::{Cursor, Write},
-    sync::Arc,
+    sync::{Arc, OnceLock},
 };
 use swrite::{swrite, SWrite};
 use tracing::{debug, info, warn, Level};
@@ -1133,8 +1132,8 @@ struct BaseApp {
     current_version: Version,
 
     cargo_configs: CargoConfigs,
-    double_spawn: OnceCell<DoubleSpawnInfo>,
-    target_runner: OnceCell<TargetRunner>,
+    double_spawn: OnceLock<DoubleSpawnInfo>,
+    target_runner: OnceLock<TargetRunner>,
 }
 
 impl BaseApp {
@@ -1235,8 +1234,8 @@ impl BaseApp {
             cargo_configs,
             current_version,
 
-            double_spawn: OnceCell::new(),
-            target_runner: OnceCell::new(),
+            double_spawn: OnceLock::new(),
+            target_runner: OnceLock::new(),
         })
     }
 

--- a/cargo-nextest/src/version.rs
+++ b/cargo-nextest/src/version.rs
@@ -1,8 +1,7 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use once_cell::sync::Lazy;
-use std::fmt::Write;
+use std::{fmt::Write, sync::LazyLock};
 
 pub(crate) fn short() -> &'static str {
     &VERSION_INFO.short
@@ -13,7 +12,7 @@ pub(crate) fn long() -> &'static str {
 }
 
 // All the data here is static so we can use a singleton.
-static VERSION_INFO: Lazy<VersionInfo> = Lazy::new(|| {
+static VERSION_INFO: LazyLock<VersionInfo> = LazyLock::new(|| {
     let inner = VersionInfoInner::new();
     let short = inner.to_short();
     let long = inner.to_long();

--- a/fixture-data/Cargo.toml
+++ b/fixture-data/Cargo.toml
@@ -12,4 +12,3 @@ publish = false
 maplit.workspace = true
 nextest-metadata.workspace = true
 nextest-workspace-hack.workspace = true
-once_cell.workspace = true

--- a/fixture-data/src/nextest_tests.rs
+++ b/fixture-data/src/nextest_tests.rs
@@ -11,174 +11,175 @@ use crate::models::{
 };
 use maplit::btreemap;
 use nextest_metadata::{BuildPlatform, RustBinaryId};
-use once_cell::sync::Lazy;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, sync::LazyLock};
 
-pub static EXPECTED_TEST_SUITES: Lazy<BTreeMap<RustBinaryId, TestSuiteFixture>> = Lazy::new(|| {
-    btreemap! {
-        // Integration tests
-        "nextest-tests::basic".into() => TestSuiteFixture::new(
-            "nextest-tests::basic",
-            "basic",
-            BuildPlatform::Target,
-            vec![
-                TestCaseFixture::new("test_cargo_env_vars", TestCaseFixtureStatus::Pass)
-                    .with_property(TestCaseFixtureProperty::NotInDefaultSetUnix),
-                TestCaseFixture::new("test_cwd", TestCaseFixtureStatus::Pass),
-                TestCaseFixture::new("test_execute_bin", TestCaseFixtureStatus::Pass),
-                TestCaseFixture::new("test_failure_assert", TestCaseFixtureStatus::Fail),
-                TestCaseFixture::new("test_failure_error", TestCaseFixtureStatus::Fail),
-                TestCaseFixture::new("test_failure_should_panic", TestCaseFixtureStatus::Fail),
-                TestCaseFixture::new(
-                    "test_flaky_mod_4",
-                    TestCaseFixtureStatus::Flaky { pass_attempt: 4 },
-                )
-                .with_property(TestCaseFixtureProperty::NotInDefaultSet),
-                TestCaseFixture::new(
-                    "test_flaky_mod_6",
-                    TestCaseFixtureStatus::Flaky { pass_attempt: 6 },
-                )
-                .with_property(TestCaseFixtureProperty::NotInDefaultSet),
-                TestCaseFixture::new("test_ignored", TestCaseFixtureStatus::IgnoredPass),
-                TestCaseFixture::new("test_ignored_fail", TestCaseFixtureStatus::IgnoredFail),
-                TestCaseFixture::new("test_result_failure", TestCaseFixtureStatus::Fail),
-                TestCaseFixture::new("test_slow_timeout", TestCaseFixtureStatus::IgnoredPass),
-                TestCaseFixture::new("test_slow_timeout_2", TestCaseFixtureStatus::IgnoredPass),
-                TestCaseFixture::new(
-                    "test_slow_timeout_subprocess",
-                    TestCaseFixtureStatus::IgnoredPass,
-                ),
-                TestCaseFixture::new("test_stdin_closed", TestCaseFixtureStatus::Pass),
-                TestCaseFixture::new("test_subprocess_doesnt_exit", TestCaseFixtureStatus::Leak),
-                TestCaseFixture::new("test_subprocess_doesnt_exit_fail", TestCaseFixtureStatus::FailLeak),
-                TestCaseFixture::new("test_success", TestCaseFixtureStatus::Pass),
-                TestCaseFixture::new("test_success_should_panic", TestCaseFixtureStatus::Pass),
-            ],
-        ),
-        "nextest-tests::other".into() => TestSuiteFixture::new(
-            "nextest-tests::other",
-            "other",
-            BuildPlatform::Target,
-            vec![
-                TestCaseFixture::new("other_test_success", TestCaseFixtureStatus::Pass),
-            ],
-        ),
-        "nextest-tests::segfault".into() => TestSuiteFixture::new(
-            "nextest-tests::segfault",
-            "segfault",
-            BuildPlatform::Target,
-            vec![
-                TestCaseFixture::new("test_segfault", TestCaseFixtureStatus::Segfault),
-            ],
-        ),
-        // Unit tests
-        "nextest-tests".into() => TestSuiteFixture::new(
-            "nextest-tests",
-            "nextest-tests",
-            BuildPlatform::Target,
-            vec![
-                TestCaseFixture::new("tests::call_dylib_add_two", TestCaseFixtureStatus::Pass),
-                TestCaseFixture::new("tests::unit_test_success", TestCaseFixtureStatus::Pass),
-            ],
-        ),
-        // Binary tests
-        "nextest-tests::bin/nextest-tests".into() => TestSuiteFixture::new(
-            "nextest-tests::bin/nextest-tests",
-            "nextest-tests",
-            BuildPlatform::Target,
-            vec![
-                TestCaseFixture::new("tests::bin_success", TestCaseFixtureStatus::Pass),
-            ],
-        ),
-        "nextest-tests::bin/other".into() => TestSuiteFixture::new(
-            "nextest-tests::bin/other",
-            "other",
-            BuildPlatform::Target,
-            vec![
-                TestCaseFixture::new("tests::other_bin_success", TestCaseFixtureStatus::Pass),
-            ],
-        ),
-        // Example tests
-        "nextest-tests::example/nextest-tests".into() => TestSuiteFixture::new(
-            "nextest-tests::example/nextest-tests",
-            "nextest-tests",
-            BuildPlatform::Target,
-            vec![
-                TestCaseFixture::new("tests::example_success", TestCaseFixtureStatus::Pass),
-            ],
-        ),
-        "nextest-tests::example/other".into() => TestSuiteFixture::new(
-            "nextest-tests::example/other",
-            "other",
-            BuildPlatform::Target,
-            vec![
-                TestCaseFixture::new("tests::other_example_success", TestCaseFixtureStatus::Pass),
-            ],
-        ),
-        // Benchmarks
-        "nextest-tests::bench/my-bench".into() => TestSuiteFixture::new(
-            "nextest-tests::bench/my-bench",
-            "my-bench",
-            BuildPlatform::Target,
-            vec![
-                TestCaseFixture::new("bench_add_two", TestCaseFixtureStatus::Pass),
-                TestCaseFixture::new("tests::test_execute_bin", TestCaseFixtureStatus::Pass),
-            ],
-        ),
-        // Proc-macro tests
-        "nextest-derive".into() => TestSuiteFixture::new(
-            "nextest-derive",
-            "nextest-derive",
-            BuildPlatform::Host,
-            vec![
-                TestCaseFixture::new("it_works", TestCaseFixtureStatus::Pass),
-            ],
-        ),
-        // Dynamic library tests
-        "cdylib-link".into() => TestSuiteFixture::new(
-            "cdylib-link",
-            "cdylib-link",
-            BuildPlatform::Target,
-            vec![
-                TestCaseFixture::new("test_multiply_two", TestCaseFixtureStatus::Pass)
-                    .with_property(TestCaseFixtureProperty::MatchesTestMultiplyTwo),
-            ],
-        ),
-        "dylib-test".into() => TestSuiteFixture::new(
-            "dylib-test",
-            "dylib-test",
-            BuildPlatform::Target,
-            vec![],
-        ),
-        "cdylib-example".into() => TestSuiteFixture::new(
-            "cdylib-example",
-            "cdylib-example",
-            BuildPlatform::Target,
-            vec![
-                TestCaseFixture::new("tests::test_multiply_two_cdylib", TestCaseFixtureStatus::Pass)
-                    .with_property(TestCaseFixtureProperty::MatchesCdylib)
-                    .with_property(TestCaseFixtureProperty::MatchesTestMultiplyTwo),
-            ],
-        )
-        .with_property(TestSuiteFixtureProperty::NotInDefaultSet),
-        // Build script tests
-        "with-build-script".into() => TestSuiteFixture::new(
-            "with-build-script",
-            "with-build-script",
-            BuildPlatform::Target,
-            vec![
-                TestCaseFixture::new("tests::test_build_script_vars_set", TestCaseFixtureStatus::Pass),
-                TestCaseFixture::new("tests::test_out_dir_present", TestCaseFixtureStatus::Pass),
-            ],
-        ),
-        "proc-macro-test".into() => TestSuiteFixture::new(
-            "proc-macro-test",
-            "proc-macro-test",
-            BuildPlatform::Host,
-            vec![],
-        ),
-    }
-});
+pub static EXPECTED_TEST_SUITES: LazyLock<BTreeMap<RustBinaryId, TestSuiteFixture>> = LazyLock::new(
+    || {
+        btreemap! {
+            // Integration tests
+            "nextest-tests::basic".into() => TestSuiteFixture::new(
+                "nextest-tests::basic",
+                "basic",
+                BuildPlatform::Target,
+                vec![
+                    TestCaseFixture::new("test_cargo_env_vars", TestCaseFixtureStatus::Pass)
+                        .with_property(TestCaseFixtureProperty::NotInDefaultSetUnix),
+                    TestCaseFixture::new("test_cwd", TestCaseFixtureStatus::Pass),
+                    TestCaseFixture::new("test_execute_bin", TestCaseFixtureStatus::Pass),
+                    TestCaseFixture::new("test_failure_assert", TestCaseFixtureStatus::Fail),
+                    TestCaseFixture::new("test_failure_error", TestCaseFixtureStatus::Fail),
+                    TestCaseFixture::new("test_failure_should_panic", TestCaseFixtureStatus::Fail),
+                    TestCaseFixture::new(
+                        "test_flaky_mod_4",
+                        TestCaseFixtureStatus::Flaky { pass_attempt: 4 },
+                    )
+                    .with_property(TestCaseFixtureProperty::NotInDefaultSet),
+                    TestCaseFixture::new(
+                        "test_flaky_mod_6",
+                        TestCaseFixtureStatus::Flaky { pass_attempt: 6 },
+                    )
+                    .with_property(TestCaseFixtureProperty::NotInDefaultSet),
+                    TestCaseFixture::new("test_ignored", TestCaseFixtureStatus::IgnoredPass),
+                    TestCaseFixture::new("test_ignored_fail", TestCaseFixtureStatus::IgnoredFail),
+                    TestCaseFixture::new("test_result_failure", TestCaseFixtureStatus::Fail),
+                    TestCaseFixture::new("test_slow_timeout", TestCaseFixtureStatus::IgnoredPass),
+                    TestCaseFixture::new("test_slow_timeout_2", TestCaseFixtureStatus::IgnoredPass),
+                    TestCaseFixture::new(
+                        "test_slow_timeout_subprocess",
+                        TestCaseFixtureStatus::IgnoredPass,
+                    ),
+                    TestCaseFixture::new("test_stdin_closed", TestCaseFixtureStatus::Pass),
+                    TestCaseFixture::new("test_subprocess_doesnt_exit", TestCaseFixtureStatus::Leak),
+                    TestCaseFixture::new("test_subprocess_doesnt_exit_fail", TestCaseFixtureStatus::FailLeak),
+                    TestCaseFixture::new("test_success", TestCaseFixtureStatus::Pass),
+                    TestCaseFixture::new("test_success_should_panic", TestCaseFixtureStatus::Pass),
+                ],
+            ),
+            "nextest-tests::other".into() => TestSuiteFixture::new(
+                "nextest-tests::other",
+                "other",
+                BuildPlatform::Target,
+                vec![
+                    TestCaseFixture::new("other_test_success", TestCaseFixtureStatus::Pass),
+                ],
+            ),
+            "nextest-tests::segfault".into() => TestSuiteFixture::new(
+                "nextest-tests::segfault",
+                "segfault",
+                BuildPlatform::Target,
+                vec![
+                    TestCaseFixture::new("test_segfault", TestCaseFixtureStatus::Segfault),
+                ],
+            ),
+            // Unit tests
+            "nextest-tests".into() => TestSuiteFixture::new(
+                "nextest-tests",
+                "nextest-tests",
+                BuildPlatform::Target,
+                vec![
+                    TestCaseFixture::new("tests::call_dylib_add_two", TestCaseFixtureStatus::Pass),
+                    TestCaseFixture::new("tests::unit_test_success", TestCaseFixtureStatus::Pass),
+                ],
+            ),
+            // Binary tests
+            "nextest-tests::bin/nextest-tests".into() => TestSuiteFixture::new(
+                "nextest-tests::bin/nextest-tests",
+                "nextest-tests",
+                BuildPlatform::Target,
+                vec![
+                    TestCaseFixture::new("tests::bin_success", TestCaseFixtureStatus::Pass),
+                ],
+            ),
+            "nextest-tests::bin/other".into() => TestSuiteFixture::new(
+                "nextest-tests::bin/other",
+                "other",
+                BuildPlatform::Target,
+                vec![
+                    TestCaseFixture::new("tests::other_bin_success", TestCaseFixtureStatus::Pass),
+                ],
+            ),
+            // Example tests
+            "nextest-tests::example/nextest-tests".into() => TestSuiteFixture::new(
+                "nextest-tests::example/nextest-tests",
+                "nextest-tests",
+                BuildPlatform::Target,
+                vec![
+                    TestCaseFixture::new("tests::example_success", TestCaseFixtureStatus::Pass),
+                ],
+            ),
+            "nextest-tests::example/other".into() => TestSuiteFixture::new(
+                "nextest-tests::example/other",
+                "other",
+                BuildPlatform::Target,
+                vec![
+                    TestCaseFixture::new("tests::other_example_success", TestCaseFixtureStatus::Pass),
+                ],
+            ),
+            // Benchmarks
+            "nextest-tests::bench/my-bench".into() => TestSuiteFixture::new(
+                "nextest-tests::bench/my-bench",
+                "my-bench",
+                BuildPlatform::Target,
+                vec![
+                    TestCaseFixture::new("bench_add_two", TestCaseFixtureStatus::Pass),
+                    TestCaseFixture::new("tests::test_execute_bin", TestCaseFixtureStatus::Pass),
+                ],
+            ),
+            // Proc-macro tests
+            "nextest-derive".into() => TestSuiteFixture::new(
+                "nextest-derive",
+                "nextest-derive",
+                BuildPlatform::Host,
+                vec![
+                    TestCaseFixture::new("it_works", TestCaseFixtureStatus::Pass),
+                ],
+            ),
+            // Dynamic library tests
+            "cdylib-link".into() => TestSuiteFixture::new(
+                "cdylib-link",
+                "cdylib-link",
+                BuildPlatform::Target,
+                vec![
+                    TestCaseFixture::new("test_multiply_two", TestCaseFixtureStatus::Pass)
+                        .with_property(TestCaseFixtureProperty::MatchesTestMultiplyTwo),
+                ],
+            ),
+            "dylib-test".into() => TestSuiteFixture::new(
+                "dylib-test",
+                "dylib-test",
+                BuildPlatform::Target,
+                vec![],
+            ),
+            "cdylib-example".into() => TestSuiteFixture::new(
+                "cdylib-example",
+                "cdylib-example",
+                BuildPlatform::Target,
+                vec![
+                    TestCaseFixture::new("tests::test_multiply_two_cdylib", TestCaseFixtureStatus::Pass)
+                        .with_property(TestCaseFixtureProperty::MatchesCdylib)
+                        .with_property(TestCaseFixtureProperty::MatchesTestMultiplyTwo),
+                ],
+            )
+            .with_property(TestSuiteFixtureProperty::NotInDefaultSet),
+            // Build script tests
+            "with-build-script".into() => TestSuiteFixture::new(
+                "with-build-script",
+                "with-build-script",
+                BuildPlatform::Target,
+                vec![
+                    TestCaseFixture::new("tests::test_build_script_vars_set", TestCaseFixtureStatus::Pass),
+                    TestCaseFixture::new("tests::test_out_dir_present", TestCaseFixtureStatus::Pass),
+                ],
+            ),
+            "proc-macro-test".into() => TestSuiteFixture::new(
+                "proc-macro-test",
+                "proc-macro-test",
+                BuildPlatform::Host,
+                vec![],
+            ),
+        }
+    },
+);
 
 pub fn get_expected_test(binary_id: &RustBinaryId, test_name: &str) -> &'static TestCaseFixture {
     let v = EXPECTED_TEST_SUITES

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -46,7 +46,6 @@ newtype-uuid.workspace = true
 nextest-filtering.workspace = true
 nextest-metadata.workspace = true
 nextest-workspace-hack.workspace = true
-once_cell.workspace = true
 owo-colors.workspace = true
 pin-project-lite.workspace = true
 quick-junit.workspace = true
@@ -152,5 +151,15 @@ name = "passthrough"
 path = "test-helpers/passthrough.rs"
 
 [features]
-self-update = ["dep:hex", "dep:self_update", "dep:http", "dep:mukti-metadata", "dep:sha2"]
-experimental-tokio-console = ["dep:console-subscriber", "dep:tracing-subscriber", "tokio/tracing"]
+self-update = [
+    "dep:hex",
+    "dep:self_update",
+    "dep:http",
+    "dep:mukti-metadata",
+    "dep:sha2",
+]
+experimental-tokio-console = [
+    "dep:console-subscriber",
+    "dep:tracing-subscriber",
+    "tokio/tracing",
+]

--- a/nextest-runner/src/config/config_impl.rs
+++ b/nextest-runner/src/config/config_impl.rs
@@ -24,10 +24,10 @@ use config::{
 use guppy::graph::PackageGraph;
 use indexmap::IndexMap;
 use nextest_filtering::{EvalContext, TestQuery};
-use once_cell::sync::Lazy;
 use serde::Deserialize;
 use std::{
     collections::{hash_map, BTreeMap, BTreeSet, HashMap},
+    sync::LazyLock,
     time::Duration,
 };
 use tracing::warn;
@@ -35,13 +35,14 @@ use tracing::warn;
 /// Gets the number of available CPUs and caches the value.
 #[inline]
 pub fn get_num_cpus() -> usize {
-    static NUM_CPUS: Lazy<usize> = Lazy::new(|| match std::thread::available_parallelism() {
-        Ok(count) => count.into(),
-        Err(err) => {
-            warn!("unable to determine num-cpus ({err}), assuming 1 logical CPU");
-            1
-        }
-    });
+    static NUM_CPUS: LazyLock<usize> =
+        LazyLock::new(|| match std::thread::available_parallelism() {
+            Ok(count) => count.into(),
+            Err(err) => {
+                warn!("unable to determine num-cpus ({err}), assuming 1 logical CPU");
+                1
+            }
+        });
 
     *NUM_CPUS
 }

--- a/nextest-runner/src/list/test_list.rs
+++ b/nextest-runner/src/list/test_list.rs
@@ -1100,8 +1100,8 @@ mod tests {
     use maplit::btreemap;
     use nextest_filtering::{CompiledExpr, Filterset, FiltersetKind, ParseContext};
     use nextest_metadata::{FilterMatch, MismatchReason, PlatformLibdirUnavailable};
-    use once_cell::sync::Lazy;
     use pretty_assertions::assert_eq;
+    use std::sync::LazyLock;
     use target_spec::Platform;
 
     #[test]
@@ -1420,7 +1420,7 @@ mod tests {
         );
     }
 
-    static PACKAGE_GRAPH_FIXTURE: Lazy<PackageGraph> = Lazy::new(|| {
+    static PACKAGE_GRAPH_FIXTURE: LazyLock<PackageGraph> = LazyLock::new(|| {
         static FIXTURE_JSON: &str = include_str!("../../../fixtures/cargo-metadata.json");
         let metadata = CargoMetadata::parse_json(FIXTURE_JSON).expect("fixture is valid JSON");
         metadata

--- a/nextest-runner/src/redact.rs
+++ b/nextest-runner/src/redact.rs
@@ -10,12 +10,16 @@ use crate::{
     list::RustBuildMeta,
 };
 use camino::{Utf8Path, Utf8PathBuf};
-use once_cell::sync::Lazy;
 use regex::Regex;
-use std::{collections::BTreeMap, fmt, sync::Arc, time::Duration};
+use std::{
+    collections::BTreeMap,
+    fmt,
+    sync::{Arc, LazyLock},
+    time::Duration,
+};
 
-static CRATE_NAME_HASH_REGEX: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^([a-zA-Z0-9_-]+)-[a-f0-9]{16}$").unwrap());
+static CRATE_NAME_HASH_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^([a-zA-Z0-9_-]+)-[a-f0-9]{16}$").unwrap());
 static TARGET_DIR_REDACTION: &str = "<target-dir>";
 static FILE_COUNT_REDACTION: &str = "<file-count>";
 static DURATION_REDACTION: &str = "<duration>";

--- a/nextest-runner/src/reporter/error_description.rs
+++ b/nextest-runner/src/reporter/error_description.rs
@@ -8,9 +8,8 @@ use crate::{
     test_output::{ChildExecutionOutput, ChildOutput},
 };
 use bstr::ByteSlice;
-use once_cell::sync::Lazy;
 use regex::bytes::{Regex, RegexBuilder};
-use std::fmt;
+use std::{fmt, sync::LazyLock};
 use thiserror::Error;
 
 /// Given an error or failure running a test or script, collects and aggregates
@@ -342,14 +341,14 @@ fn heuristic_error_str(stderr: &[u8]) -> Option<ByteSubslice<'_>> {
 // This regex works for the default panic handler for Rust -- other panic handlers may not work,
 // which is why this is heuristic.
 static PANICKED_AT_REGEX_STR: &str = "^thread '([^']+)' panicked at ";
-static PANICKED_AT_REGEX: Lazy<Regex> = Lazy::new(|| {
+static PANICKED_AT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     let mut builder = RegexBuilder::new(PANICKED_AT_REGEX_STR);
     builder.multi_line(true);
     builder.build().unwrap()
 });
 
 static ERROR_REGEX_STR: &str = "^Error: ";
-static ERROR_REGEX: Lazy<Regex> = Lazy::new(|| {
+static ERROR_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     let mut builder = RegexBuilder::new(ERROR_REGEX_STR);
     builder.multi_line(true);
     builder.build().unwrap()

--- a/nextest-runner/src/test_command.rs
+++ b/nextest-runner/src/test_command.rs
@@ -10,12 +10,12 @@ use crate::{
 };
 use camino::{Utf8Path, Utf8PathBuf};
 use guppy::graph::PackageMetadata;
-use once_cell::sync::Lazy;
 use std::{
     collections::{BTreeSet, HashMap},
     ffi::{OsStr, OsString},
     fs::File,
     io::{BufRead, BufReader},
+    sync::LazyLock,
 };
 use tracing::warn;
 
@@ -263,7 +263,7 @@ pub(crate) fn apply_ld_dyld_env(cmd: &mut std::process::Command, dylib_path: &Os
         var.starts_with("LD_") || var.starts_with("DYLD_")
     }
 
-    static LD_DYLD_ENV_VARS: Lazy<HashMap<String, OsString>> = Lazy::new(|| {
+    static LD_DYLD_ENV_VARS: LazyLock<HashMap<String, OsString>> = LazyLock::new(|| {
         std::env::vars_os()
             .filter_map(|(k, v)| match k.into_string() {
                 Ok(k) => is_sip_sanitized(&k).then_some((k, v)),

--- a/nextest-runner/src/test_command/windows.rs
+++ b/nextest-runner/src/test_command/windows.rs
@@ -5,6 +5,7 @@ use std::{
     io,
     os::windows::{ffi::OsStrExt as _, io::FromRawHandle as _, prelude::OwnedHandle},
     ptr::null_mut,
+    sync::OnceLock,
 };
 use windows_sys::Win32::{
     Foundation as fnd, Security::SECURITY_ATTRIBUTES, Storage::FileSystem as fs,
@@ -18,7 +19,7 @@ pub struct State {
 pub(super) fn setup_io(cmd: &mut std::process::Command) -> io::Result<State> {
     use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 
-    static RANDOM_SEQ: once_cell::sync::OnceCell<AtomicUsize> = once_cell::sync::OnceCell::new();
+    static RANDOM_SEQ: OnceLock<AtomicUsize> = OnceLock::new();
     let rand_seq = RANDOM_SEQ.get_or_init(|| {
         use rand::{rngs::OsRng, RngCore};
         AtomicUsize::new(OsRng.next_u32() as _)

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -24,12 +24,11 @@ use nextest_runner::{
     test_filter::{FilterBound, TestFilterBuilder},
     test_output::{ChildExecutionOutput, ChildOutput},
 };
-use once_cell::sync::Lazy;
 use std::{
     collections::{BTreeMap, HashMap},
     env, fmt,
     io::Cursor,
-    sync::Arc,
+    sync::{Arc, LazyLock},
 };
 
 pub(crate) fn ensure_execution_result(
@@ -197,7 +196,7 @@ pub(crate) fn load_config() -> NextestConfig {
     .expect("loaded fixture config")
 }
 
-pub(crate) static PACKAGE_GRAPH: Lazy<PackageGraph> = Lazy::new(|| {
+pub(crate) static PACKAGE_GRAPH: LazyLock<PackageGraph> = LazyLock::new(|| {
     let mut metadata_command = MetadataCommand::new();
     // Construct a package graph with --no-deps since we don't need full dependency
     // information.
@@ -208,8 +207,8 @@ pub(crate) static PACKAGE_GRAPH: Lazy<PackageGraph> = Lazy::new(|| {
         .expect("building package graph failed")
 });
 
-pub(crate) static FIXTURE_RAW_CARGO_TEST_OUTPUT: Lazy<Vec<u8>> =
-    Lazy::new(init_fixture_raw_cargo_test_output);
+pub(crate) static FIXTURE_RAW_CARGO_TEST_OUTPUT: LazyLock<Vec<u8>> =
+    LazyLock::new(init_fixture_raw_cargo_test_output);
 
 fn init_fixture_raw_cargo_test_output() -> Vec<u8> {
     // This is a simple version of what cargo does.
@@ -238,7 +237,7 @@ fn init_fixture_raw_cargo_test_output() -> Vec<u8> {
     output.stdout
 }
 
-pub(crate) static FIXTURE_TARGETS: Lazy<FixtureTargets> = Lazy::new(FixtureTargets::new);
+pub(crate) static FIXTURE_TARGETS: LazyLock<FixtureTargets> = LazyLock::new(FixtureTargets::new);
 
 #[derive(Debug)]
 pub(crate) struct FixtureTargets {


### PR DESCRIPTION
`Lazy` is now in Rust 1.80+ as `LazyLock`, so switch to that.