### PR TITLE
Add support for global and group slot numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,10 +1000,11 @@ dependencies = [
 
 [[package]]
 name = "future-queue"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d1aa68ae1a41111c2ebdfec3c73479b55751b0bdceb8e1e3f7a05f3cf6b2e6"
+checksum = "47cdf4a7eef4808ffa1e5c47dbf37124dfe33a7acc34e8568c5d5359b365a8cb"
 dependencies = [
+ "debug-ignore",
  "fnv",
  "futures-util",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ enable-ansi-support = "0.2.1"
 env_logger = { version = "0.11.6", default-features = false }
 fixture-data = { path = "fixture-data" }
 fs-err = "3.1.0"
-future-queue = "0.3.0"
+future-queue = "0.4.0"
 futures = "0.3.31"
 globset = "0.4.15"
 guppy = "0.17.13"
@@ -156,8 +156,8 @@ strip = "none"
 nextest-workspace-hack = { path = "workspace-hack" }
 
 # Uncomment for testing.
-# [patch.crates-io]
 # cargo_metadata = { path = "../cargo_metadata" }
+# future-queue = { path = "../future-queue" }
 # target-spec = { path = "../guppy/target-spec" }
 # target-spec-miette = { path = "../guppy/target-spec-miette" }
 # quick-junit = { path = "../quick-junit" }

--- a/fixtures/nextest-tests/.config/nextest.toml
+++ b/fixtures/nextest-tests/.config/nextest.toml
@@ -33,6 +33,11 @@ leak-timeout = '1s'
 [profile.with-retries]
 retries = 2
 
+# Test out serial tests.
+[[profile.with-retries.overrides]]
+filter = "test(=test_success) | test(=test_execute_bin)"
+test-group = 'serial'
+
 # Run test_flaky_mod_6 with 5 retries (6 tries) rather than 2.
 [[profile.with-retries.overrides]]
 filter = "test(=test_flaky_mod_6)"
@@ -90,6 +95,9 @@ max-threads = 4
 
 [test-groups.unused]
 max-threads = 20
+
+[test-groups.serial]
+max-threads = 1
 
 [script.my-script-unix]
 command = './scripts/my-script.sh'

--- a/fixtures/nextest-tests/tests/basic.rs
+++ b/fixtures/nextest-tests/tests/basic.rs
@@ -3,6 +3,8 @@ use std::{env, io::Read, path::PathBuf};
 
 #[test]
 fn test_success() {
+    assert_with_retries_serial();
+
     // Check that MY_ENV_VAR (set by the setup script) isn't enabled.
     assert_eq!(
         std::env::var("MY_ENV_VAR"),
@@ -104,6 +106,7 @@ fn test_ignored_fail() {
 /// Test that a binary can be successfully executed.
 #[test]
 fn test_execute_bin() {
+    assert_with_retries_serial();
     nextest_tests::test_execute_bin_helper();
 }
 
@@ -157,6 +160,11 @@ fn test_cargo_env_vars() {
         .expect("NEXTEST_RUN_ID must be set")
         .parse::<uuid::Uuid>()
         .expect("NEXTEST_RUN_ID must be a UUID");
+    let global_slot = std::env::var("NEXTEST_TEST_GLOBAL_SLOT")
+        .expect("NEXTEST_TEST_GLOBAL_SLOT must be set")
+        .parse::<u64>()
+        .expect("NEXTEST_TEST_GLOBAL_SLOT must be a u64");
+    println!("NEXTEST_TEST_GLOBAL_SLOT = {global_slot}");
 
     assert_eq!(
         std::env::var("NEXTEST_EXECUTION_MODE").as_deref(),
@@ -368,4 +376,21 @@ fn test_stdin_closed() {
             .read(&mut buf)
             .expect("reading from /dev/null succeeded")
     );
+}
+
+/// Asserts that if the with-retries profile is set, the test group slot is 0.
+///
+/// This should be called if and only if the test-group is serial.
+fn assert_with_retries_serial() {
+    let profile = std::env::var("NEXTEST_PROFILE").expect("NEXTEST_PROFILE should be set");
+    if profile == "with-retries" {
+        // Check that NEXTEST_TEST_GROUP_SLOT is set.
+        let group_slot = std::env::var("NEXTEST_TEST_GROUP_SLOT")
+            .expect("NEXTEST_TEST_GROUP_SLOT should be set")
+            .parse::<u64>()
+            .expect("NEXTEST_TEST_GROUP_SLOT should be a u64");
+        println!("NEXTEST_TEST_GROUP_SLOT = {group_slot}");
+        // This test is in a serial group, so the group slot should be 0.
+        assert_eq!(group_slot, 0, "NEXTEST_GROUP_SLOT should be 0");
+    }
 }

--- a/fixtures/nextest-tests/tests/basic.rs
+++ b/fixtures/nextest-tests/tests/basic.rs
@@ -384,6 +384,10 @@ fn test_stdin_closed() {
 fn assert_with_retries_serial() {
     let profile = std::env::var("NEXTEST_PROFILE").expect("NEXTEST_PROFILE should be set");
     if profile == "with-retries" {
+        // Check that NEXTEST_TEST_GROUP is set to "serial".
+        let group = std::env::var("NEXTEST_TEST_GROUP").expect("NEXTEST_TEST_GROUP should be set");
+        assert_eq!(group, "serial", "NEXTEST_GROUP should be serial");
+
         // Check that NEXTEST_TEST_GROUP_SLOT is set.
         let group_slot = std::env::var("NEXTEST_TEST_GROUP_SLOT")
             .expect("NEXTEST_TEST_GROUP_SLOT should be set")
@@ -392,5 +396,17 @@ fn assert_with_retries_serial() {
         println!("NEXTEST_TEST_GROUP_SLOT = {group_slot}");
         // This test is in a serial group, so the group slot should be 0.
         assert_eq!(group_slot, 0, "NEXTEST_GROUP_SLOT should be 0");
+    } else {
+        // NEXTEST_TEST_GROUP and NEXTEST_TEST_GROUP_SLOT must not be set.
+        assert_eq!(
+            std::env::var("NEXTEST_TEST_GROUP"),
+            Err(std::env::VarError::NotPresent),
+            "NEXTEST_TEST_GROUP should not be set"
+        );
+        assert_eq!(
+            std::env::var("NEXTEST_TEST_GROUP_SLOT"),
+            Err(std::env::VarError::NotPresent),
+            "NEXTEST_TEST_GROUP_SLOT should not be set"
+        );
     }
 }

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-2.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-2.snap
@@ -5,6 +5,8 @@ snapshot_kind: text
 ---
 group: flaky (max threads = 4)
     (no matches)
+group: serial (max threads = 1)
+    (no matches)
 group: unused (max threads = 20)
     (no matches)
 group: @global

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-3.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-3.snap
@@ -1,12 +1,17 @@
 ---
 source: integration-tests/tests/integration/main.rs
 expression: with_retries_output.stdout_as_str()
+snapshot_kind: text
 ---
 group: flaky (max threads = 4)
   * override for with-retries profile with filter 'test(test_flaky_mod) | test(~test_flaky_mod_4)':
       nextest-tests::basic:
           test_flaky_mod_4
           test_flaky_mod_6
+group: serial (max threads = 1)
+  * override for with-retries profile with filter 'test(=test_success) | test(=test_execute_bin)':
+      nextest-tests::basic:
+          test_execute_bin
+          test_success
 group: unused (max threads = 20)
     (no matches)
-

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-4.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-4.snap
@@ -8,6 +8,11 @@ group: flaky (max threads = 4)
       nextest-tests::basic:
           test_flaky_mod_4
           test_flaky_mod_6
+group: serial (max threads = 1)
+  * override for with-retries profile with filter 'test(=test_success) | test(=test_execute_bin)':
+      nextest-tests::basic:
+          test_execute_bin
+          test_success
 group: unused (max threads = 20)
     (no matches)
 group: @global
@@ -24,7 +29,6 @@ group: @global
       nextest-tests::basic:
           test_cargo_env_vars
           test_cwd
-          test_execute_bin
           test_failure_assert
           test_failure_error
           test_failure_should_panic
@@ -32,7 +36,6 @@ group: @global
           test_stdin_closed
           test_subprocess_doesnt_exit
           test_subprocess_doesnt_exit_fail
-          test_success
           test_success_should_panic
       nextest-tests::other:
           other_test_success

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-5.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-5.snap
@@ -1,12 +1,14 @@
 ---
 source: integration-tests/tests/integration/main.rs
 expression: with_termination_output.stdout_as_str()
+snapshot_kind: text
 ---
 group: flaky (max threads = 4)
+    (no matches)
+group: serial (max threads = 1)
     (no matches)
 group: unused (max threads = 20)
     (no matches)
 group: @global
   * override for with-termination profile with filter 'test(=test_slow_timeout_2)':
       nextest-tests::basic:
-

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-6.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups-6.snap
@@ -5,6 +5,8 @@ snapshot_kind: text
 ---
 group: flaky (max threads = 4)
     (no matches)
+group: serial (max threads = 1)
+    (no matches)
 group: unused (max threads = 20)
     (no matches)
 group: @global

--- a/integration-tests/tests/integration/snapshots/integration__show_config_test_groups.snap
+++ b/integration-tests/tests/integration/snapshots/integration__show_config_test_groups.snap
@@ -1,9 +1,11 @@
 ---
 source: integration-tests/tests/integration/main.rs
 expression: default_profile_output.stdout_as_str()
+snapshot_kind: text
 ---
 group: flaky (max threads = 4)
     (no matches)
+group: serial (max threads = 1)
+    (no matches)
 group: unused (max threads = 20)
     (no matches)
-

--- a/nextest-runner/src/runner/executor.rs
+++ b/nextest-runner/src/runner/executor.rs
@@ -33,6 +33,7 @@ use crate::{
     test_output::{CaptureStrategy, ChildExecutionOutput, ChildOutput, ChildSplitOutput},
     time::{PausableSleep, StopwatchStart},
 };
+use future_queue::FutureQueueContext;
 use nextest_metadata::FilterMatch;
 use quick_junit::ReportUuid;
 use rand::{distributions::OpenClosed01, thread_rng, Rng};
@@ -161,6 +162,7 @@ impl<'a> ExecutorContext<'a> {
     pub(super) async fn run_test_instance(
         &self,
         test_instance: TestInstance<'a>,
+        cx: FutureQueueContext,
         settings: TestSettings<'a>,
         resp_tx: UnboundedSender<ExecutorEvent<'a>>,
         setup_script_data: Arc<SetupScriptExecuteData<'a>>,
@@ -174,6 +176,10 @@ impl<'a> ExecutorContext<'a> {
         let mut backoff_iter = BackoffIter::new(retry_policy);
 
         if let FilterMatch::Mismatch { reason } = test_instance.test_info.filter_match {
+            debug_assert!(
+                false,
+                "this test should already have been skipped in a filter step"
+            );
             // Failure to send means the receiver was dropped.
             let _ = resp_tx.send(ExecutorEvent::Skipped {
                 test_instance,
@@ -234,6 +240,7 @@ impl<'a> ExecutorContext<'a> {
             // additional information later.
             let packet = TestPacket {
                 test_instance,
+                cx: cx.clone(),
                 retry_data,
                 settings: settings.clone(),
                 setup_script_data: setup_script_data.clone(),
@@ -619,7 +626,15 @@ impl<'a> ExecutorContext<'a> {
 
         // Debug environment variable for testing.
         command_mut.env("__NEXTEST_ATTEMPT", format!("{}", test.retry_data.attempt));
+
         command_mut.env("NEXTEST_RUN_ID", format!("{}", self.run_id));
+        command_mut.env(
+            "NEXTEST_TEST_GLOBAL_SLOT",
+            test.cx.global_slot().to_string(),
+        );
+        if let Some(group_slot) = test.cx.group_slot() {
+            command_mut.env("NEXTEST_TEST_GROUP_SLOT", group_slot.to_string());
+        }
         command_mut.stdin(Stdio::null());
         test.setup_script_data.apply(
             &test.test_instance.to_test_query(),
@@ -950,6 +965,7 @@ impl UnitPacket<'_> {
 #[derive(Clone, Debug)]
 pub(super) struct TestPacket<'a> {
     test_instance: TestInstance<'a>,
+    cx: FutureQueueContext,
     retry_data: RetryData,
     settings: Arc<TestSettings<'a>>,
     setup_script_data: Arc<SetupScriptExecuteData<'a>>,

--- a/nextest-runner/src/runner/executor.rs
+++ b/nextest-runner/src/runner/executor.rs
@@ -15,7 +15,7 @@ use super::HandleSignalResult;
 use crate::{
     config::{
         EvaluatableProfile, RetryPolicy, ScriptConfig, ScriptId, SetupScriptCommand,
-        SetupScriptExecuteData, SlowTimeout, TestSettings,
+        SetupScriptExecuteData, SlowTimeout, TestGroup, TestSettings,
     },
     double_spawn::DoubleSpawnInfo,
     errors::{ChildError, ChildFdError, ChildStartError, ErrorList},
@@ -628,13 +628,35 @@ impl<'a> ExecutorContext<'a> {
         command_mut.env("__NEXTEST_ATTEMPT", format!("{}", test.retry_data.attempt));
 
         command_mut.env("NEXTEST_RUN_ID", format!("{}", self.run_id));
+
+        // Set slot environment variables.
         command_mut.env(
             "NEXTEST_TEST_GLOBAL_SLOT",
             test.cx.global_slot().to_string(),
         );
         if let Some(group_slot) = test.cx.group_slot() {
             command_mut.env("NEXTEST_TEST_GROUP_SLOT", group_slot.to_string());
+        } else {
+            command_mut.env_remove("NEXTEST_TEST_GROUP_SLOT");
         }
+
+        match test.settings.test_group() {
+            TestGroup::Custom(name) => {
+                debug_assert!(
+                    test.cx.group_slot().is_some(),
+                    "test_group being set implies group_slot is set"
+                );
+                command_mut.env("NEXTEST_TEST_GROUP", name.as_str());
+            }
+            TestGroup::Global => {
+                debug_assert!(
+                    test.cx.group_slot().is_none(),
+                    "test_group being unset implies group_slot is unset"
+                );
+                command_mut.env_remove("NEXTEST_TEST_GROUP");
+            }
+        }
+
         command_mut.stdin(Stdio::null());
         test.setup_script_data.apply(
             &test.test_instance.to_test_query(),


### PR DESCRIPTION
Per https://github.com/nextest-rs/nextest/discussions/2142 -- add support for global and group slots.

This should address a class of problems around things like port number allocations. For example, if you want to reserve blocks of 5 ports for tests, you could pick an arbitrary starting port in the ephemeral port range (e.g. 46210) and then do `starting_port + 5 * NEXTEST_TEST_GROUP_SLOT`. 

These slots are numbers increasing from 0, are unique for the lifetime of the test within the nextest run (or within the group), and are compact (numbers are freed as tests finish, and the smallest possible number is always assigned to new tests).