### PR TITLE
[nextest-filtering] reject unknown binary IDs and binary names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,9 +1141,9 @@ dependencies = [
 
 [[package]]
 name = "guppy"
-version = "0.17.14"
+version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c20ac214f84bec493542e97ef5469eae1763789060740ed2f7aba2deaff393"
+checksum = "2dadc932032945158611b2b45baae9f6fc0024a6f91dd57f61f5edb4ad507f3b"
 dependencies = [
  "ahash",
  "camino",
@@ -1823,6 +1823,7 @@ dependencies = [
  "recursion",
  "regex",
  "regex-syntax 0.8.5",
+ "smol_str",
  "test-case",
  "test-strategy",
  "thiserror 2.0.11",
@@ -3068,16 +3069,15 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "target-spec"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e2827c8368f9860f6d263f872175b7dd1d62628fc7518335fb1a660e477d6a"
+checksum = "2bc8a7884e5638da28cd5bd0d9c33df2da1df204cbbb57a52a4762a4ab3b0be9"
 dependencies = [
  "cfg-expr",
  "guppy-workspace-hack",
  "serde",
  "serde_json",
  "target-lexicon",
- "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ fs-err = "3.1.0"
 future-queue = "0.4.0"
 futures = "0.3.31"
 globset = "0.4.15"
-guppy = "0.17.14"
+guppy = "0.17.16"
 hex = "0.4.3"
 home = "0.5.11"
 http = "1.2.0"
@@ -157,6 +157,7 @@ nextest-workspace-hack = { path = "workspace-hack" }
 
 # Uncomment for testing.
 # cargo_metadata = { path = "../cargo_metadata" }
+# guppy = { path = "../../guppy/guppy" }
 # future-queue = { path = "../future-queue" }
 # target-spec = { path = "../guppy/target-spec" }
 # target-spec-miette = { path = "../guppy/target-spec-miette" }

--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -1548,15 +1548,12 @@ impl App {
     }
 
     fn build_filtering_expressions(&self) -> Result<Vec<Filterset>> {
-        let pcx = ParseContext {
-            graph: self.base.graph(),
-            kind: FiltersetKind::Test,
-        };
+        let pcx = ParseContext::new(self.base.graph());
         let (exprs, all_errors): (Vec<_>, Vec<_>) = self
             .build_filter
             .filterset
             .iter()
-            .map(|input| Filterset::parse(input.clone(), &pcx))
+            .map(|input| Filterset::parse(input.clone(), &pcx, FiltersetKind::Test))
             .partition_result();
 
         if !all_errors.is_empty() {

--- a/fixtures/nextest-tests/Cargo.toml
+++ b/fixtures/nextest-tests/Cargo.toml
@@ -24,7 +24,10 @@ test = true
 
 [[example]]
 name = "other"
-test = true
+# Note that setting test = false does not mean that tests are disabled. It just
+# means that `cargo nextest run` won't run tests by default. It will run tests
+# when `cargo nextest run --all-targets` is used.
+test = false
 
 # Make this crate its own workspace.
 [workspace]
@@ -34,7 +37,7 @@ members = [
     "derive",
     "dylib-test",
     "with-build-script",
-    "proc-macro-test"
+    "proc-macro-test",
 ]
 
 [dependencies]

--- a/integration-tests/tests/integration/snapshots/integration__archive_includes.snap
+++ b/integration-tests/tests/integration/snapshots/integration__archive_includes.snap
@@ -1,6 +1,7 @@
 ---
 source: integration-tests/tests/integration/main.rs
 expression: output.stderr_as_str()
+snapshot_kind: text
 ---
    Archiving 17 binaries (including 2 non-test binaries), 2 build script output directories, 2 linked paths, 7 extra paths, and 1 standard library to <archive-file>
      Warning ignoring extra path `<target-dir>/excluded-dir` because it does not exist

--- a/integration-tests/tests/integration/snapshots/integration__archive_missing_includes.snap
+++ b/integration-tests/tests/integration/snapshots/integration__archive_missing_includes.snap
@@ -1,6 +1,7 @@
 ---
 source: integration-tests/tests/integration/main.rs
 expression: output.stderr_as_str()
+snapshot_kind: text
 ---
    Archiving 17 binaries (including 2 non-test binaries), 2 build script output directories, 2 linked paths, 1 extra path, and 1 standard library to <archive-file>
 error: error creating archive `<archive-file>`

--- a/integration-tests/tests/integration/snapshots/integration__archive_no_includes.snap
+++ b/integration-tests/tests/integration/snapshots/integration__archive_no_includes.snap
@@ -1,6 +1,7 @@
 ---
 source: integration-tests/tests/integration/main.rs
 expression: output.stderr_as_str()
+snapshot_kind: text
 ---
    Archiving 17 binaries (including 2 non-test binaries), 2 build script output directories, 2 linked paths, and 1 standard library to <archive-file>
      Warning linked path `<target-dir>/debug/build/<cdylib-link-hash>/does-not-exist` not found, requested by: cdylib-link v0.1.0

--- a/integration-tests/tests/integration/snapshots/integration__list_binaries_only.snap
+++ b/integration-tests/tests/integration/snapshots/integration__list_binaries_only.snap
@@ -1,0 +1,49 @@
+---
+source: integration-tests/tests/integration/main.rs
+expression: output.stderr_as_str()
+snapshot_kind: text
+---
+info: experimental features enabled: setup-scripts
+  error: operator didn't match any binary names
+   ╭────
+ 1 │ binary(unknown) & binary_id(unknown) & binary(=unknown) | binary_id(=unknown)
+   ·        ───┬───
+   ·           ╰── no binary names matched this
+   ╰────
+
+  error: operator didn't match any binary IDs
+   ╭────
+ 1 │ binary(unknown) & binary_id(unknown) & binary(=unknown) | binary_id(=unknown)
+   ·                             ───┬───
+   ·                                ╰── no binary IDs matched this
+   ╰────
+
+  error: operator didn't match any binary names
+   ╭────
+ 1 │ binary(unknown) & binary_id(unknown) & binary(=unknown) | binary_id(=unknown)
+   ·                                               ────┬───
+   ·                                                   ╰── no binary names matched this
+   ╰────
+
+  error: operator didn't match any binary IDs
+   ╭────
+ 1 │ binary(unknown) & binary_id(unknown) & binary(=unknown) | binary_id(=unknown)
+   ·                                                                     ────┬───
+   ·                                                                         ╰── no binary IDs matched this
+   ╰────
+
+  error: operator didn't match any binary IDs
+   ╭────
+ 1 │ binary_id(nextest-tests::does_not_exist) | binary_id(=nextest-tests::basic)
+   ·           ──────────────┬──────────────
+   ·                         ╰── no binary IDs matched this
+   ╰────
+
+  error: operator didn't match any binary IDs
+   ╭────
+ 1 │ binary_id(nextest-tests::example/*) | binary_id(dylib-test::example/*)
+   ·                                                 ──────────┬──────────
+   ·                                                           ╰── no binary IDs matched this
+   ╰────
+
+error: failed to parse filterset

--- a/nextest-filtering/Cargo.toml
+++ b/nextest-filtering/Cargo.toml
@@ -35,6 +35,7 @@ proptest = { workspace = true, optional = true }
 recursion.workspace = true
 regex-syntax.workspace = true
 regex.workspace = true
+smol_str.workspace = true
 test-strategy = { workspace = true, optional = true }
 thiserror.workspace = true
 winnow.workspace = true

--- a/nextest-filtering/examples/parser.rs
+++ b/nextest-filtering/examples/parser.rs
@@ -53,11 +53,12 @@ fn main() {
     let args = Args::parse();
 
     let graph = load_graph(args.cargo_metadata);
-    let cx = nextest_filtering::ParseContext {
-        graph: &graph,
-        kind: nextest_filtering::FiltersetKind::Test,
-    };
-    match nextest_filtering::Filterset::parse(args.expr, &cx) {
+    let cx = nextest_filtering::ParseContext::new(&graph);
+    match nextest_filtering::Filterset::parse(
+        args.expr,
+        &cx,
+        nextest_filtering::FiltersetKind::Test,
+    ) {
         Ok(expr) => println!("{expr:?}"),
         Err(FiltersetParseErrors { input, errors, .. }) => {
             for error in errors {

--- a/nextest-filtering/src/compile.rs
+++ b/nextest-filtering/src/compile.rs
@@ -17,17 +17,14 @@ use std::collections::HashSet;
 pub(crate) fn compile(
     expr: &ParsedExpr,
     cx: &ParseContext<'_>,
+    kind: FiltersetKind,
 ) -> Result<CompiledExpr, Vec<ParseSingleError>> {
     let mut errors = vec![];
-    check_banned_predicates(expr, cx.kind, &mut errors);
+    check_banned_predicates(expr, kind, &mut errors);
 
-    let in_workspace_packages: Vec<_> = cx
-        .graph
-        .resolve_workspace()
-        .packages(guppy::graph::DependencyDirection::Forward)
-        .collect();
-    let mut cache = cx.graph.new_depends_cache();
-    let expr = compile_expr(expr, &in_workspace_packages, &mut cache, &mut errors);
+    let workspace_packages = &cx.make_cache().workspace_packages;
+    let mut cache = cx.graph().new_depends_cache();
+    let expr = compile_expr(expr, workspace_packages, &mut cache, &mut errors);
 
     if errors.is_empty() {
         Ok(expr)

--- a/nextest-filtering/src/errors.rs
+++ b/nextest-filtering/src/errors.rs
@@ -118,6 +118,14 @@ pub enum ParseSingleError {
     #[error("operator didn't match any packages")]
     NoPackageMatch(#[label("no packages matched this")] SourceSpan),
 
+    /// This matcher didn't match any binary IDs.
+    #[error("operator didn't match any binary IDs")]
+    NoBinaryIdMatch(#[label("no binary IDs matched this")] SourceSpan),
+
+    /// This matcher didn't match any binary names.
+    #[error("operator didn't match any binary names")]
+    NoBinaryNameMatch(#[label("no binary names matched this")] SourceSpan),
+
     /// Expected "host" or "target" for a `platform()` predicate.
     #[error("invalid argument for platform")]
     InvalidPlatformArgument(#[label("expected \"target\" or \"host\"")] SourceSpan),

--- a/nextest-filtering/tests/match.rs
+++ b/nextest-filtering/tests/match.rs
@@ -448,7 +448,7 @@ fn test_expr_kind() {
 #[test]
 fn test_expr_binary() {
     let graph = load_graph();
-    let expr = parse("binary(my-binary)", &graph);
+    let expr = parse("binary(crate_f)", &graph);
 
     let pid_a = mk_pid('a');
     let cx = EvalContext {
@@ -457,7 +457,7 @@ fn test_expr_binary() {
 
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
+            binary_query: binary_query(&graph, &pid_a, "lib", "crate_f", BuildPlatform::Target)
                 .to_query(),
             test_name: "test_something"
         },
@@ -473,7 +473,7 @@ fn test_expr_binary() {
     ));
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib2", "my-binary", BuildPlatform::Target)
+            binary_query: binary_query(&graph, &pid_a, "lib2", "crate_f", BuildPlatform::Target)
                 .to_query(),
             test_name: "test_something"
         },
@@ -738,7 +738,7 @@ fn test_expr_test_intersect(input: &str) {
 fn test_binary_query() {
     let graph = load_graph();
     let expr = parse(
-        "binary(foo) + !platform(target) + kind(bench) + (package(~_a) & (!test(/foo/) | kind(bin)))",
+        "binary(crate_a) + !platform(target) + kind(bench) + (package(~_a) & (!test(/foo/) | kind(bin)))",
         &graph,
     );
 
@@ -748,10 +748,10 @@ fn test_binary_query() {
         default_filter: &CompiledExpr::ALL,
     };
 
-    // binary = foo should match the first predicate (pid_a should not be relevant).
+    // binary = crate_a should match the first predicate (pid_a should not be relevant).
     assert_eq!(
         expr.matches_binary(
-            &binary_query(&graph, &pid_a, "lib", "foo", BuildPlatform::Target).to_query(),
+            &binary_query(&graph, &pid_a, "lib", "crate_a", BuildPlatform::Target).to_query(),
             &cx,
         ),
         Some(true)

--- a/nextest-filtering/tests/match.rs
+++ b/nextest-filtering/tests/match.rs
@@ -28,11 +28,8 @@ fn mk_pid(c: char) -> PackageId {
 }
 
 fn parse(input: &str, graph: &PackageGraph) -> Filterset {
-    let cx = ParseContext {
-        graph,
-        kind: FiltersetKind::Test,
-    };
-    let expr = Filterset::parse(input.to_owned(), &cx).unwrap();
+    let cx = ParseContext::new(graph);
+    let expr = Filterset::parse(input.to_owned(), &cx, FiltersetKind::Test).unwrap();
     eprintln!("expression: {expr:?}");
     expr
 }
@@ -393,21 +390,22 @@ fn test_expr_with_no_matching_packages() {
     }
 
     let graph = load_graph();
-    let cx = ParseContext {
-        graph: &graph,
-        kind: FiltersetKind::Test,
-    };
+    let cx = ParseContext::new(&graph);
 
-    let errors = Filterset::parse("deps(does-not-exist)".to_owned(), &cx).unwrap_err();
+    let errors =
+        Filterset::parse("deps(does-not-exist)".to_owned(), &cx, FiltersetKind::Test).unwrap_err();
     assert_error(&errors);
 
-    let errors = Filterset::parse("deps(=does-not-exist)".to_owned(), &cx).unwrap_err();
+    let errors =
+        Filterset::parse("deps(=does-not-exist)".to_owned(), &cx, FiltersetKind::Test).unwrap_err();
     assert_error(&errors);
 
-    let errors = Filterset::parse("deps(~does-not-exist)".to_owned(), &cx).unwrap_err();
+    let errors =
+        Filterset::parse("deps(~does-not-exist)".to_owned(), &cx, FiltersetKind::Test).unwrap_err();
     assert_error(&errors);
 
-    let errors = Filterset::parse("deps(/does-not/)".to_owned(), &cx).unwrap_err();
+    let errors =
+        Filterset::parse("deps(/does-not/)".to_owned(), &cx, FiltersetKind::Test).unwrap_err();
     assert_error(&errors);
 }
 

--- a/nextest-metadata/src/test_list.rs
+++ b/nextest-metadata/src/test_list.rs
@@ -238,6 +238,9 @@ impl RustTestBinaryKind {
     /// The "bin" kind, used for unit tests within binaries.
     pub const BIN: Self = Self::new_const("bin");
 
+    /// The "example" kind, used for unit tests within examples.
+    pub const EXAMPLE: Self = Self::new_const("example");
+
     /// The "proc-macro" kind, used for tests within procedural macros.
     pub const PROC_MACRO: Self = Self::new_const("proc-macro");
 }
@@ -380,6 +383,9 @@ where
 impl Ord for RustBinaryId {
     fn cmp(&self, other: &RustBinaryId) -> Ordering {
         // Use the components as the canonical sort order.
+        //
+        // Note: this means that we can't impl Borrow<str> for RustBinaryId,
+        // since the Ord impl is inconsistent with that of &str.
         self.components().cmp(&other.components())
     }
 }

--- a/nextest-runner/src/config/archive.rs
+++ b/nextest-runner/src/config/archive.rs
@@ -248,6 +248,7 @@ mod tests {
     use camino_tempfile::tempdir;
     use config::ConfigError;
     use indoc::indoc;
+    use nextest_filtering::ParseContext;
     use test_case::test_case;
 
     #[test]
@@ -274,9 +275,11 @@ mod tests {
 
         let graph = temp_workspace(workspace_dir.path(), config_contents);
 
+        let pcx = ParseContext::new(&graph);
+
         let config = NextestConfig::from_sources(
             graph.workspace().root(),
-            &graph,
+            &pcx,
             None,
             [],
             &Default::default(),
@@ -424,9 +427,11 @@ mod tests {
 
         let graph = temp_workspace(workspace_path, config_contents);
 
+        let pcx = ParseContext::new(&graph);
+
         let config_err = NextestConfig::from_sources(
             graph.workspace().root(),
-            &graph,
+            &pcx,
             None,
             [],
             &Default::default(),

--- a/nextest-runner/src/config/max_fail.rs
+++ b/nextest-runner/src/config/max_fail.rs
@@ -172,6 +172,7 @@ mod tests {
     };
     use camino_tempfile::tempdir;
     use indoc::indoc;
+    use nextest_filtering::ParseContext;
     use test_case::test_case;
 
     #[test]
@@ -243,9 +244,11 @@ mod tests {
         let workspace_dir = tempdir().unwrap();
         let graph = temp_workspace(workspace_dir.path(), config_contents);
 
+        let pcx = ParseContext::new(&graph);
+
         let config = NextestConfig::from_sources(
             graph.workspace().root(),
-            &graph,
+            &pcx,
             None,
             [],
             &Default::default(),
@@ -335,10 +338,11 @@ mod tests {
     fn invalid_fail_fast(config_contents: &str, error_str: &str) {
         let workspace_dir = tempdir().unwrap();
         let graph = temp_workspace(workspace_dir.path(), config_contents);
+        let pcx = ParseContext::new(&graph);
 
         let error = NextestConfig::from_sources(
             graph.workspace().root(),
-            &graph,
+            &pcx,
             None,
             [],
             &Default::default(),

--- a/nextest-runner/src/config/retry_policy.rs
+++ b/nextest-runner/src/config/retry_policy.rs
@@ -177,7 +177,7 @@ mod tests {
     use config::ConfigError;
     use guppy::graph::cargo::BuildPlatform;
     use indoc::indoc;
-    use nextest_filtering::TestQuery;
+    use nextest_filtering::{ParseContext, TestQuery};
     use test_case::test_case;
 
     #[test]
@@ -205,10 +205,11 @@ mod tests {
         let workspace_dir = tempdir().unwrap();
 
         let graph = temp_workspace(workspace_dir.path(), config_contents);
+        let pcx = ParseContext::new(&graph);
 
         let config = NextestConfig::from_sources(
             graph.workspace().root(),
-            &graph,
+            &pcx,
             None,
             [],
             &Default::default(),
@@ -380,10 +381,11 @@ mod tests {
         let workspace_path: &Utf8Path = workspace_dir.path();
 
         let graph = temp_workspace(workspace_path, config_contents);
+        let pcx = ParseContext::new(&graph);
 
         let config_err = NextestConfig::from_sources(
             graph.workspace().root(),
-            &graph,
+            &pcx,
             None,
             [],
             &Default::default(),
@@ -617,10 +619,11 @@ mod tests {
 
         let graph = temp_workspace(workspace_path, config_contents);
         let package_id = graph.workspace().iter().next().unwrap().id();
+        let pcx = ParseContext::new(&graph);
 
         let config = NextestConfig::from_sources(
             graph.workspace().root(),
-            &graph,
+            &pcx,
             None,
             &[][..],
             &Default::default(),

--- a/nextest-runner/src/config/scripts.rs
+++ b/nextest-runner/src/config/scripts.rs
@@ -279,14 +279,17 @@ impl CompiledProfileScripts<PreBuildPlatform> {
 
         let host_spec = MaybeTargetSpec::new(source.platform.host.as_deref());
         let target_spec = MaybeTargetSpec::new(source.platform.target.as_deref());
-        let cx = ParseContext {
-            graph,
-            // TODO: probably want to restrict the set of expressions here.
-            kind: FiltersetKind::Test,
-        };
+        let cx = ParseContext::new(graph);
 
         let filter_expr = source.filter.as_ref().map_or(Ok(None), |filter| {
-            Some(Filterset::parse(filter.clone(), &cx)).transpose()
+            // TODO: probably want to restrict the set of expressions here via
+            // the `kind` parameter.
+            Some(Filterset::parse(
+                filter.clone(),
+                &cx,
+                FiltersetKind::DefaultFilter,
+            ))
+            .transpose()
         });
 
         match (host_spec, target_spec, filter_expr) {

--- a/nextest-runner/src/config/slow_timeout.rs
+++ b/nextest-runner/src/config/slow_timeout.rs
@@ -84,6 +84,7 @@ mod tests {
     };
     use camino_tempfile::tempdir;
     use indoc::indoc;
+    use nextest_filtering::ParseContext;
     use test_case::test_case;
 
     #[test_case(
@@ -184,9 +185,11 @@ mod tests {
 
         let graph = temp_workspace(workspace_dir.path(), config_contents);
 
+        let pcx = ParseContext::new(&graph);
+
         let nextest_config_result = NextestConfig::from_sources(
             graph.workspace().root(),
-            &graph,
+            &pcx,
             None,
             &[][..],
             &Default::default(),

--- a/nextest-runner/src/config/test_group.rs
+++ b/nextest-runner/src/config/test_group.rs
@@ -133,6 +133,7 @@ mod tests {
     use camino_tempfile::tempdir;
     use indoc::indoc;
     use maplit::btreeset;
+    use nextest_filtering::ParseContext;
     use std::collections::BTreeSet;
     use test_case::test_case;
 
@@ -202,9 +203,10 @@ mod tests {
         let tool_path = workspace_root.join(".config/tool.toml");
         std::fs::write(&tool_path, input).unwrap();
 
+        let pcx = ParseContext::new(&graph);
         let config_res = NextestConfig::from_sources(
             workspace_root,
-            &graph,
+            &pcx,
             None,
             &[ToolConfigFile {
                 tool: "my-tool".to_owned(),
@@ -298,8 +300,9 @@ mod tests {
         let graph = temp_workspace(workspace_path, config_contents);
         let workspace_root = graph.workspace().root();
 
+        let pcx = ParseContext::new(&graph);
         let config_res =
-            NextestConfig::from_sources(workspace_root, &graph, None, &[][..], &Default::default());
+            NextestConfig::from_sources(workspace_root, &pcx, None, &[][..], &Default::default());
         match expected {
             Ok(expected_groups) => {
                 let config = config_res.expect("config is valid");
@@ -443,9 +446,10 @@ mod tests {
         let tool2_path = workspace_root.join(".config/tool2.toml");
         std::fs::write(&tool2_path, tool2_config).unwrap();
 
+        let pcx = ParseContext::new(&graph);
         let config = NextestConfig::from_sources(
             workspace_root,
-            &graph,
+            &pcx,
             None,
             &[
                 ToolConfigFile {

--- a/nextest-runner/src/config/test_threads.rs
+++ b/nextest-runner/src/config/test_threads.rs
@@ -112,6 +112,7 @@ mod tests {
     use crate::config::{test_helpers::*, NextestConfig};
     use camino_tempfile::tempdir;
     use indoc::indoc;
+    use nextest_filtering::ParseContext;
     use test_case::test_case;
 
     #[test_case(
@@ -155,9 +156,10 @@ mod tests {
 
         let graph = temp_workspace(workspace_dir.path(), config_contents);
 
+        let pcx = ParseContext::new(&graph);
         let config = NextestConfig::from_sources(
             graph.workspace().root(),
-            &graph,
+            &pcx,
             None,
             [],
             &Default::default(),

--- a/nextest-runner/src/config/threads_required.rs
+++ b/nextest-runner/src/config/threads_required.rs
@@ -95,6 +95,7 @@ mod tests {
     use crate::config::{test_helpers::*, NextestConfig};
     use camino_tempfile::tempdir;
     use indoc::indoc;
+    use nextest_filtering::ParseContext;
     use test_case::test_case;
 
     #[test_case(
@@ -167,9 +168,10 @@ mod tests {
 
         let graph = temp_workspace(workspace_dir.path(), config_contents);
 
+        let pcx = ParseContext::new(&graph);
         let config = NextestConfig::from_sources(
             graph.workspace().root(),
-            &graph,
+            &pcx,
             None,
             [],
             &Default::default(),

--- a/nextest-runner/src/config/tool_config.rs
+++ b/nextest-runner/src/config/tool_config.rs
@@ -62,7 +62,7 @@ mod tests {
     };
     use camino_tempfile::tempdir;
     use guppy::graph::cargo::BuildPlatform;
-    use nextest_filtering::TestQuery;
+    use nextest_filtering::{ParseContext, TestQuery};
 
     #[test]
     fn parse_tool_config_file() {
@@ -208,9 +208,10 @@ mod tests {
             },
         );
 
+        let pcx = ParseContext::new(&graph);
         let config = NextestConfig::from_sources(
             workspace_root,
-            &graph,
+            &pcx,
             None,
             &tool_config_files,
             &Default::default(),

--- a/nextest-runner/src/list/test_list.rs
+++ b/nextest-runner/src/list/test_list.rs
@@ -1175,17 +1175,16 @@ mod tests {
             benches::ignored_bench_foo: benchmark
         "};
 
-        let cx = ParseContext {
-            graph: &PACKAGE_GRAPH_FIXTURE,
-            kind: FiltersetKind::Test,
-        };
+        let cx = ParseContext::new(&PACKAGE_GRAPH_FIXTURE);
 
         let test_filter = TestFilterBuilder::new(
             RunIgnored::Default,
             None,
             TestFilterPatterns::default(),
             // Test against the platform() predicate because this is the most important one here.
-            vec![Filterset::parse("platform(target)".to_owned(), &cx).unwrap()],
+            vec![
+                Filterset::parse("platform(target)".to_owned(), &cx, FiltersetKind::Test).unwrap(),
+            ],
         )
         .unwrap();
         let fake_cwd: Utf8PathBuf = "/fake/cwd".into();

--- a/nextest-runner/tests/integration/basic.rs
+++ b/nextest-runner/tests/integration/basic.rs
@@ -238,11 +238,13 @@ fn test_run() -> Result<()> {
 fn test_run_ignored() -> Result<()> {
     set_env_vars();
 
-    let pcx = ParseContext {
-        graph: &PACKAGE_GRAPH,
-        kind: FiltersetKind::Test,
-    };
-    let expr = Filterset::parse("not test(test_slow_timeout)".to_owned(), &pcx).unwrap();
+    let pcx = ParseContext::new(&PACKAGE_GRAPH);
+    let expr = Filterset::parse(
+        "not test(test_slow_timeout)".to_owned(),
+        &pcx,
+        FiltersetKind::Test,
+    )
+    .unwrap();
 
     let test_filter = TestFilterBuilder::new(
         RunIgnored::Only,
@@ -336,13 +338,11 @@ fn test_run_ignored() -> Result<()> {
 fn test_filter_expr_with_string_filters() -> Result<()> {
     set_env_vars();
 
-    let pcx = ParseContext {
-        graph: &PACKAGE_GRAPH,
-        kind: FiltersetKind::Test,
-    };
+    let pcx = ParseContext::new(&PACKAGE_GRAPH);
     let expr = Filterset::parse(
         "test(test_multiply_two) | test(=tests::call_dylib_add_two)".to_owned(),
         &pcx,
+        FiltersetKind::Test,
     )
     .expect("filterset is valid");
 
@@ -410,13 +410,11 @@ fn test_filter_expr_with_string_filters() -> Result<()> {
 fn test_filter_expr_without_string_filters() -> Result<()> {
     set_env_vars();
 
-    let pcx = ParseContext {
-        graph: &PACKAGE_GRAPH,
-        kind: FiltersetKind::Test,
-    };
+    let pcx = ParseContext::new(&PACKAGE_GRAPH);
     let expr = Filterset::parse(
         "test(test_multiply_two) | test(=tests::call_dylib_add_two)".to_owned(),
         &pcx,
+        FiltersetKind::Test,
     )
     .expect("filterset is valid");
 
@@ -653,11 +651,13 @@ fn test_retries(retries: Option<RetryPolicy>) -> Result<()> {
 fn test_termination() -> Result<()> {
     set_env_vars();
 
-    let pcx = ParseContext {
-        graph: &PACKAGE_GRAPH,
-        kind: FiltersetKind::Test,
-    };
-    let expr = Filterset::parse("test(/^test_slow_timeout/)".to_owned(), &pcx).unwrap();
+    let pcx = ParseContext::new(&PACKAGE_GRAPH);
+    let expr = Filterset::parse(
+        "test(/^test_slow_timeout/)".to_owned(),
+        &pcx,
+        FiltersetKind::Test,
+    )
+    .unwrap();
     let test_filter = TestFilterBuilder::new(
         RunIgnored::Only,
         None,

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -7,7 +7,7 @@ use duct::cmd;
 use fixture_data::models::TestCaseFixtureStatus;
 use guppy::{graph::PackageGraph, MetadataCommand};
 use maplit::btreeset;
-use nextest_filtering::{CompiledExpr, EvalContext};
+use nextest_filtering::{CompiledExpr, EvalContext, ParseContext};
 use nextest_metadata::{MismatchReason, RustBinaryId};
 use nextest_runner::{
     cargo_config::{CargoConfigs, EnvironmentMap},
@@ -185,9 +185,10 @@ pub(crate) fn workspace_root() -> Utf8PathBuf {
 }
 
 pub(crate) fn load_config() -> NextestConfig {
+    let pcx = ParseContext::new(&PACKAGE_GRAPH);
     NextestConfig::from_sources(
         workspace_root(),
-        &PACKAGE_GRAPH,
+        &pcx,
         None,
         [],
         // Enable setup scripts.

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -36,7 +36,7 @@ regex-syntax = { version = "0.8.5" }
 serde = { version = "1.0.217", features = ["alloc", "derive"] }
 serde_json = { version = "1.0.138", features = ["unbounded_depth"] }
 smallvec = { version = "1.14.0", default-features = false, features = ["const_generics"] }
-target-spec = { version = "3.4.0", default-features = false, features = ["custom", "summaries"] }
+target-spec = { version = "3.4.1", default-features = false, features = ["custom", "summaries"] }
 target-spec-miette = { version = "0.4.4", default-features = false, features = ["fixtures"] }
 tokio = { version = "1.43.0", features = ["fs", "io-std", "io-util", "macros", "process", "rt-multi-thread", "signal", "sync", "time", "tracing"] }
 tracing-core = { version = "0.1.33" }


### PR DESCRIPTION
We would previously accept binary IDs and names that were not present in the
graph. That is definitely not right -- we should reject any that weren't known.

This may cause some minor breakage, but hopefully that will alert folks about
mistakes rather than be disruptive.