### PR TITLE
[meta] switch style_edition to 2024

### DIFF
--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -2,23 +2,25 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::{
+    ExpectedError, Result, ReuseBuildKind,
     cargo_cli::{CargoCli, CargoOptions},
-    output::{should_redact, OutputContext, OutputOpts, OutputWriter, StderrStyles},
-    reuse_build::{make_path_mapper, ArchiveFormatOpt, ReuseBuildOpts},
-    version, ExpectedError, Result, ReuseBuildKind,
+    output::{OutputContext, OutputOpts, OutputWriter, StderrStyles, should_redact},
+    reuse_build::{ArchiveFormatOpt, ReuseBuildOpts, make_path_mapper},
+    version,
 };
 use camino::{Utf8Path, Utf8PathBuf};
-use clap::{builder::BoolishValueParser, ArgAction, Args, Parser, Subcommand, ValueEnum};
+use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum, builder::BoolishValueParser};
 use guppy::graph::PackageGraph;
 use itertools::Itertools;
 use nextest_filtering::{EvalContext, Filterset, FiltersetKind, ParseContext};
 use nextest_metadata::BuildPlatform;
 use nextest_runner::{
+    RustcCli,
     cargo_config::{CargoConfigs, EnvironmentMap, TargetTriple},
     config::{
-        get_num_cpus, ConfigExperimental, EarlyProfile, MaxFail, NextestConfig,
-        NextestVersionConfig, NextestVersionEval, RetryPolicy, TestGroup, TestThreads,
-        ToolConfigFile, VersionOnlyConfig,
+        ConfigExperimental, EarlyProfile, MaxFail, NextestConfig, NextestVersionConfig,
+        NextestVersionEval, RetryPolicy, TestGroup, TestThreads, ToolConfigFile, VersionOnlyConfig,
+        get_num_cpus,
     },
     double_spawn::DoubleSpawnInfo,
     errors::{TargetTripleError, WriteTestListError},
@@ -31,18 +33,17 @@ use nextest_runner::{
     platform::{BuildPlatforms, HostPlatform, PlatformLibdir, TargetPlatform},
     redact::Redactor,
     reporter::{
+        FinalStatusLevel, ReporterBuilder, StatusLevel, TestOutputDisplay, TestOutputErrorSlice,
         events::{FinalRunStats, RunStatsFailureKind},
-        highlight_end, structured, FinalStatusLevel, ReporterBuilder, StatusLevel,
-        TestOutputDisplay, TestOutputErrorSlice,
+        highlight_end, structured,
     },
-    reuse_build::{archive_to_file, ArchiveReporter, PathMapper, ReuseBuildInfo},
-    runner::{configure_handle_inheritance, TestRunnerBuilder},
+    reuse_build::{ArchiveReporter, PathMapper, ReuseBuildInfo, archive_to_file},
+    runner::{TestRunnerBuilder, configure_handle_inheritance},
     show_config::{ShowNextestVersion, ShowTestGroupSettings, ShowTestGroups, ShowTestGroupsMode},
     signal::SignalHandlerKind,
     target_runner::{PlatformRunner, TargetRunner},
     test_filter::{FilterBound, RunIgnored, TestFilterBuilder, TestFilterPatterns},
     write_str::WriteStr,
-    RustcCli,
 };
 use owo_colors::OwoColorize;
 use quick_junit::XmlString;
@@ -54,8 +55,8 @@ use std::{
     io::{Cursor, Write},
     sync::{Arc, OnceLock},
 };
-use swrite::{swrite, SWrite};
-use tracing::{debug, info, warn, Level};
+use swrite::{SWrite, swrite};
+use tracing::{Level, debug, info, warn};
 
 /// A next-generation test runner for Rust.
 ///
@@ -1537,7 +1538,9 @@ struct App {
 fn check_experimental_filtering(_output: OutputContext) {
     const EXPERIMENTAL_ENV: &str = "NEXTEST_EXPERIMENTAL_FILTER_EXPR";
     if std::env::var(EXPERIMENTAL_ENV).is_ok() {
-        warn!("filtersets are no longer experimental: NEXTEST_EXPERIMENTAL_FILTER_EXPR does not need to be set");
+        warn!(
+            "filtersets are no longer experimental: NEXTEST_EXPERIMENTAL_FILTER_EXPR does not need to be set"
+        );
     }
 }
 

--- a/cargo-nextest/src/double_spawn.rs
+++ b/cargo-nextest/src/double_spawn.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::{output::OutputContext, ExpectedError, Result};
+use crate::{ExpectedError, Result, output::OutputContext};
 use camino::Utf8PathBuf;
 use clap::Args;
 use nextest_runner::double_spawn::double_spawn_child_init;

--- a/cargo-nextest/src/errors.rs
+++ b/cargo-nextest/src/errors.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::{output::StderrStyles, ExtractOutputFormat};
+use crate::{ExtractOutputFormat, output::StderrStyles};
 use camino::Utf8PathBuf;
 use indent_write::indentable::Indented;
 use itertools::Itertools;
@@ -12,7 +12,7 @@ use owo_colors::OwoColorize;
 use semver::Version;
 use std::{error::Error, string::FromUtf8Error};
 use thiserror::Error;
-use tracing::{error, info, Level};
+use tracing::{Level, error, info};
 
 pub(crate) type Result<T, E = ExpectedError> = std::result::Result<T, E>;
 

--- a/cargo-nextest/src/output.rs
+++ b/cargo-nextest/src/output.rs
@@ -5,30 +5,30 @@
 use clap::{Args, ValueEnum};
 use miette::{GraphicalTheme, MietteHandlerOpts, ThemeStyles};
 use nextest_runner::{reporter::ReporterStderr, write_str::WriteStr};
-use owo_colors::{style, OwoColorize, Style};
+use owo_colors::{OwoColorize, Style, style};
 use std::{
     fmt,
     io::{self, BufWriter, Stderr, Stdout, Write},
     marker::PhantomData,
 };
 use tracing::{
+    Event, Level, Subscriber,
     field::{Field, Visit},
     level_filters::LevelFilter,
-    Event, Level, Subscriber,
 };
 use tracing_subscriber::{
+    Layer,
     filter::Targets,
-    fmt::{format, FmtContext, FormatEvent, FormatFields},
+    fmt::{FmtContext, FormatEvent, FormatFields, format},
     layer::SubscriberExt,
     registry::LookupSpan,
     util::SubscriberInitExt,
-    Layer,
 };
 
 pub(crate) mod clap_styles {
     use clap::builder::{
-        styling::{AnsiColor, Effects, Style},
         Styles,
+        styling::{AnsiColor, Effects, Style},
     };
 
     const HEADER: Style = AnsiColor::Green.on_default().effects(Effects::BOLD);

--- a/cargo-nextest/src/reuse_build.rs
+++ b/cargo-nextest/src/reuse_build.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::{output::OutputContext, ExpectedError, OutputWriter, Result};
+use crate::{ExpectedError, OutputWriter, Result, output::OutputContext};
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::{Args, ValueEnum};
 use guppy::graph::PackageGraph;
@@ -102,7 +102,9 @@ impl ReuseBuildOpts {
     // before calling this method)
     pub(crate) fn check_experimental(&self, _output: OutputContext) {
         if std::env::var(Self::EXPERIMENTAL_ENV).is_ok() {
-            warn!("build reuse is no longer experimental: NEXTEST_EXPERIMENTAL_REUSE_BUILD does not need to be set");
+            warn!(
+                "build reuse is no longer experimental: NEXTEST_EXPERIMENTAL_REUSE_BUILD does not need to be set"
+            );
         }
     }
 

--- a/cargo-nextest/src/update.rs
+++ b/cargo-nextest/src/update.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::{output::OutputContext, ExpectedError, Result};
+use crate::{ExpectedError, Result, output::OutputContext};
 use camino::Utf8PathBuf;
 use nextest_metadata::NextestExitCode;
 use nextest_runner::update::{CheckStatus, MuktiBackend, UpdateVersion};

--- a/integration-tests/src/nextest_cli.rs
+++ b/integration-tests/src/nextest_cli.rs
@@ -3,8 +3,8 @@
 
 use camino::Utf8PathBuf;
 use color_eyre::{
-    eyre::{bail, Context},
     Result,
+    eyre::{Context, bail},
 };
 use nextest_metadata::TestListSummary;
 use std::{

--- a/integration-tests/tests/integration/fixtures.rs
+++ b/integration-tests/tests/integration/fixtures.rs
@@ -6,7 +6,7 @@ use fixture_data::{
     models::{TestCaseFixtureProperty, TestCaseFixtureStatus, TestSuiteFixtureProperty},
     nextest_tests::EXPECTED_TEST_SUITES,
 };
-use integration_tests::nextest_cli::{cargo_bin, CargoNextestCli};
+use integration_tests::nextest_cli::{CargoNextestCli, cargo_bin};
 use nextest_metadata::{
     BinaryListSummary, BuildPlatform, RustTestSuiteStatusSummary, TestListSummary,
 };

--- a/integration-tests/tests/integration/main.rs
+++ b/integration-tests/tests/integration/main.rs
@@ -29,13 +29,13 @@ use integration_tests::{
 };
 use nextest_metadata::{BuildPlatform, NextestExitCode, TestListSummary};
 use std::{borrow::Cow, fs::File, io::Write};
-use target_spec::{summaries::TargetFeaturesSummary, Platform};
+use target_spec::{Platform, summaries::TargetFeaturesSummary};
 
 mod fixtures;
 mod stuck_signal;
 mod temp_project;
 
-use crate::temp_project::{create_uds, UdsStatus};
+use crate::temp_project::{UdsStatus, create_uds};
 use camino_tempfile::Utf8TempDir;
 use fixtures::*;
 use temp_project::TempProject;

--- a/integration-tests/tests/integration/temp_project.rs
+++ b/integration-tests/tests/integration/temp_project.rs
@@ -3,7 +3,7 @@
 
 use camino::{Utf8Path, Utf8PathBuf};
 use camino_tempfile::Utf8TempDir;
-use color_eyre::eyre::{bail, Context};
+use color_eyre::eyre::{Context, bail};
 use cp_r::CopyOptions;
 use fs_err as fs;
 use integration_tests::{nextest_cli::CargoNextestCli, seed::nextest_tests_dir};

--- a/nextest-filtering/src/compile.rs
+++ b/nextest-filtering/src/compile.rs
@@ -7,8 +7,8 @@ use crate::{
     parsing::{ParsedExpr, SetDef},
 };
 use guppy::{
-    graph::{DependsCache, PackageMetadata},
     PackageId,
+    graph::{DependsCache, PackageMetadata},
 };
 use miette::SourceSpan;
 use recursion::CollapsibleExt;

--- a/nextest-filtering/src/expression.rs
+++ b/nextest-filtering/src/expression.rs
@@ -4,13 +4,13 @@
 use crate::{
     errors::{FiltersetParseErrors, ParseSingleError},
     parsing::{
-        new_span, parse, DisplayParsedRegex, DisplayParsedString, ExprResult, GenericGlob,
-        ParsedExpr, SetDef,
+        DisplayParsedRegex, DisplayParsedString, ExprResult, GenericGlob, ParsedExpr, SetDef,
+        new_span, parse,
     },
 };
 use guppy::{
-    graph::{cargo::BuildPlatform, BuildTargetId, PackageGraph, PackageMetadata},
     PackageId,
+    graph::{BuildTargetId, PackageGraph, PackageMetadata, cargo::BuildPlatform},
 };
 use miette::SourceSpan;
 use nextest_metadata::{RustBinaryId, RustTestBinaryKind};

--- a/nextest-filtering/src/parsing.rs
+++ b/nextest-filtering/src/parsing.rs
@@ -17,16 +17,16 @@ use guppy::graph::cargo::BuildPlatform;
 use miette::SourceSpan;
 use std::fmt;
 use winnow::{
+    LocatingSlice, ModalParser, Parser,
     ascii::line_ending,
     combinator::{alt, delimited, eof, peek, preceded, repeat, terminated, trace},
     stream::{Location, SliceLen, Stream},
     token::{literal, take_till},
-    LocatingSlice, ModalParser, Parser,
 };
 
 mod glob;
 mod unicode_string;
-use crate::{errors::*, NameMatcher};
+use crate::{NameMatcher, errors::*};
 pub(crate) use glob::GenericGlob;
 pub(crate) use unicode_string::DisplayParsedString;
 

--- a/nextest-filtering/src/parsing/glob.rs
+++ b/nextest-filtering/src/parsing/glob.rs
@@ -3,12 +3,12 @@
 
 //! Glob matching.
 
-use super::{parse_matcher_text, Error, Span};
+use super::{Error, Span, parse_matcher_text};
 use crate::{
-    errors::{GlobConstructError, ParseSingleError},
     NameMatcher,
+    errors::{GlobConstructError, ParseSingleError},
 };
-use winnow::{combinator::trace, stream::Location, ModalParser, Parser};
+use winnow::{ModalParser, Parser, combinator::trace, stream::Location};
 
 /// A glob pattern.
 ///

--- a/nextest-filtering/src/parsing/unicode_string.rs
+++ b/nextest-filtering/src/parsing/unicode_string.rs
@@ -3,13 +3,13 @@
 
 // Adapted from https://github.com/Geal/nom/blob/294ffb3d9e0ade2c3b7ddfff52484b6d643dcce1/examples/string.rs
 
-use super::{expect_n, PResult, Span, SpanLength};
+use super::{PResult, Span, SpanLength, expect_n};
 use crate::errors::ParseSingleError;
 use std::fmt;
 use winnow::{
+    Parser,
     combinator::{alt, delimited, preceded, repeat, trace},
     token::{take_till, take_while},
-    Parser,
 };
 
 fn parse_unicode(input: &mut Span<'_>) -> PResult<char> {

--- a/nextest-filtering/src/proptest_helpers.rs
+++ b/nextest-filtering/src/proptest_helpers.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::{
+    NameMatcher,
     parsing::{
         AndOperator, DifferenceOperator, GenericGlob, NotOperator, OrOperator, ParsedExpr, SetDef,
     },
-    NameMatcher,
 };
 use guppy::graph::cargo::BuildPlatform;
 use proptest::prelude::*;

--- a/nextest-filtering/tests/match.rs
+++ b/nextest-filtering/tests/match.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use guppy::{
-    graph::{cargo::BuildPlatform, PackageGraph},
     PackageId,
+    graph::{PackageGraph, cargo::BuildPlatform},
 };
 use nextest_filtering::{
-    errors::{FiltersetParseErrors, ParseSingleError},
     BinaryQuery, CompiledExpr, EvalContext, Filterset, FiltersetKind, ParseContext, TestQuery,
+    errors::{FiltersetParseErrors, ParseSingleError},
 };
 use nextest_metadata::{RustBinaryId, RustTestBinaryKind};
 use test_case::test_case;
@@ -86,24 +86,24 @@ fn test_expr_package_contains() {
     };
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
     ));
     assert!(!expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_b, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_b, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
     ));
     assert!(!expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_c, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_c, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
@@ -124,24 +124,24 @@ fn test_expr_package_equal() {
 
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
     ));
     assert!(!expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_b, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_b, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
     ));
     assert!(!expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_c, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_c, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
@@ -162,24 +162,24 @@ fn test_expr_package_regex() {
 
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
     ));
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_b, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_b, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
     ));
     assert!(!expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_c, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_c, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
@@ -201,24 +201,24 @@ fn test_expr_binary_id_glob() {
 
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
     ));
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_b, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_b, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
     ));
     assert!(!expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_c, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_c, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
@@ -244,32 +244,32 @@ fn test_expr_deps() {
     // a-d are deps of d
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
     ));
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_b, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_b, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
     ));
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_c, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_c, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
     ));
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_d, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_d, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
@@ -278,24 +278,24 @@ fn test_expr_deps() {
     // e-g are not deps of d
     assert!(!expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_e, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_e, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
     ));
     assert!(!expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_f, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_f, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
     ));
     assert!(!expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_g, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_g, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
@@ -320,24 +320,24 @@ fn test_expr_rdeps() {
     // a-c are not rdeps of d
     assert!(!expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
     ));
     assert!(!expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_b, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_b, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
     ));
     assert!(!expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_c, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_c, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
@@ -346,32 +346,32 @@ fn test_expr_rdeps() {
     // d-g are rdeps of d
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_d, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_d, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
     ));
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_e, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_e, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
     ));
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_f, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_f, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
     ));
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_g, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_g, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
@@ -421,24 +421,24 @@ fn test_expr_kind() {
 
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
     ));
     assert!(!expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "test", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "test", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_parse"
         },
         &cx
     ));
     assert!(!expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib2", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib2", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
@@ -457,24 +457,32 @@ fn test_expr_binary() {
 
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "crate_f", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "crate_f", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
     ));
-    assert!(!expr.matches_test(
-        &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "test", "my-binary2", BuildPlatform::Target)
+    assert!(
+        !expr.matches_test(
+            &TestQuery {
+                binary_query: binary_query(
+                    &graph,
+                    &pid_a,
+                    "test",
+                    "my-binary2",
+                    BuildPlatform::Target
+                )
                 .to_query(),
-            test_name: "test_parse"
-        },
-        &cx
-    ));
+                test_name: "test_parse"
+            },
+            &cx
+        )
+    );
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib2", "crate_f", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib2", "crate_f", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
@@ -493,16 +501,16 @@ fn test_expr_platform() {
 
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Host)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Host).to_query(),
             test_name: "test_something"
         },
         &cx
     ));
     assert!(!expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
@@ -513,16 +521,16 @@ fn test_expr_platform() {
     let pid_a = mk_pid('a');
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
     ));
     assert!(!expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Host)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Host).to_query(),
             test_name: "test_something"
         },
         &cx
@@ -541,16 +549,16 @@ fn test_expr_kind_partial() {
 
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "test", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "test", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_something"
         },
         &cx
     ));
     assert!(!expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_parse"
         },
         &cx
@@ -570,24 +578,24 @@ fn test_expr_test() {
 
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_parse"
         },
         &cx
     ));
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_b, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_b, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_parse"
         },
         &cx
     ));
     assert!(!expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_run"
         },
         &cx
@@ -606,16 +614,16 @@ fn test_expr_test_not() {
 
     assert!(!expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_parse"
         },
         &cx
     ));
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_run"
         },
         &cx
@@ -636,24 +644,24 @@ fn test_expr_test_union(input: &str) {
 
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_parse"
         },
         &cx
     ));
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_run"
         },
         &cx
     ));
     assert!(!expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_build"
         },
         &cx
@@ -673,24 +681,24 @@ fn test_expr_test_difference(input: &str) {
 
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_parse"
         },
         &cx
     ));
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_parse_set"
         },
         &cx
     ));
     assert!(!expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_parse_expr"
         },
         &cx
@@ -710,24 +718,24 @@ fn test_expr_test_intersect(input: &str) {
 
     assert!(!expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_parse"
         },
         &cx
     ));
     assert!(!expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_expr"
         },
         &cx
     ));
     assert!(expr.matches_test(
         &TestQuery {
-            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
-                .to_query(),
+            binary_query:
+                binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
             test_name: "test_parse_expr"
         },
         &cx

--- a/nextest-runner/src/cargo_config/custom_platform.rs
+++ b/nextest-runner/src/cargo_config/custom_platform.rs
@@ -86,9 +86,9 @@ impl ExtractedCustomPlatform {
 mod tests {
     use super::*;
     use crate::cargo_config::{
-        test_helpers::setup_temp_dir, CargoTargetArg, TargetDefinitionLocation, TargetTriple,
+        CargoTargetArg, TargetDefinitionLocation, TargetTriple, test_helpers::setup_temp_dir,
     };
-    use color_eyre::eyre::{bail, eyre, Context, Result};
+    use color_eyre::eyre::{Context, Result, bail, eyre};
 
     #[test]
     fn test_extracted_custom_platform() -> Result<()> {

--- a/nextest-runner/src/cargo_config/env.rs
+++ b/nextest-runner/src/cargo_config/env.rs
@@ -4,7 +4,7 @@
 use super::{CargoConfigSource, CargoConfigs, DiscoveredConfig};
 use camino::{Utf8Path, Utf8PathBuf};
 use std::{
-    collections::{btree_map::Entry, BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, btree_map::Entry},
     ffi::OsString,
     process::Command,
 };
@@ -157,7 +157,7 @@ mod imp {
     use super::*;
     use std::{borrow::Borrow, cmp, ffi::OsStr, os::windows::prelude::OsStrExt};
     use windows_sys::Win32::Globalization::{
-        CompareStringOrdinal, CSTR_EQUAL, CSTR_GREATER_THAN, CSTR_LESS_THAN,
+        CSTR_EQUAL, CSTR_GREATER_THAN, CSTR_LESS_THAN, CompareStringOrdinal,
     };
 
     pub(super) fn strip_unc_prefix(path: &Utf8Path) -> &Utf8Path {

--- a/nextest-runner/src/cargo_config/target_triple.rs
+++ b/nextest-runner/src/cargo_config/target_triple.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use camino::{Utf8Path, Utf8PathBuf};
 use std::fmt;
-use target_spec::{summaries::PlatformSummary, Platform, TargetFeatures};
+use target_spec::{Platform, TargetFeatures, summaries::PlatformSummary};
 
 /// Represents a target triple that's being cross-compiled against.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/nextest-runner/src/config/archive.rs
+++ b/nextest-runner/src/config/archive.rs
@@ -4,7 +4,7 @@
 use super::TrackDefault;
 use crate::config::helpers::deserialize_relative_path;
 use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
-use serde::{de::Unexpected, Deserialize};
+use serde::{Deserialize, de::Unexpected};
 use std::fmt;
 
 /// Configuration for archives.
@@ -239,8 +239,8 @@ mod tests {
     use super::*;
     use crate::{
         config::{
-            test_helpers::{build_platforms, temp_workspace},
             NextestConfig,
+            test_helpers::{build_platforms, temp_workspace},
         },
         errors::ConfigParseErrorKind,
     };
@@ -442,7 +442,9 @@ mod tests {
             ConfigParseErrorKind::DeserializeError(path_error) => match path_error.inner() {
                 ConfigError::Message(message) => message,
                 other => {
-                    panic!("for config error {config_err:?}, expected ConfigError::Message for inner error {other:?}");
+                    panic!(
+                        "for config error {config_err:?}, expected ConfigError::Message for inner error {other:?}"
+                    );
                 }
             },
             other => {

--- a/nextest-runner/src/config/config_impl.rs
+++ b/nextest-runner/src/config/config_impl.rs
@@ -10,8 +10,8 @@ use super::{
 };
 use crate::{
     errors::{
-        provided_by_tool, ConfigParseError, ConfigParseErrorKind, ProfileNotFound,
-        UnknownConfigScriptError, UnknownTestGroupError,
+        ConfigParseError, ConfigParseErrorKind, ProfileNotFound, UnknownConfigScriptError,
+        UnknownTestGroupError, provided_by_tool,
     },
     list::TestList,
     platform::BuildPlatforms,
@@ -19,13 +19,13 @@ use crate::{
 };
 use camino::{Utf8Path, Utf8PathBuf};
 use config::{
-    builder::DefaultState, Config, ConfigBuilder, ConfigError, File, FileFormat, FileSourceFile,
+    Config, ConfigBuilder, ConfigError, File, FileFormat, FileSourceFile, builder::DefaultState,
 };
 use indexmap::IndexMap;
 use nextest_filtering::{EvalContext, ParseContext, TestQuery};
 use serde::Deserialize;
 use std::{
-    collections::{hash_map, BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap, hash_map},
     sync::LazyLock,
     time::Duration,
 };

--- a/nextest-runner/src/config/helpers.rs
+++ b/nextest-runner/src/config/helpers.rs
@@ -3,8 +3,8 @@
 
 use camino::{Utf8Component, Utf8PathBuf};
 use serde::{
-    de::{Error, Unexpected},
     Deserialize,
+    de::{Error, Unexpected},
 };
 
 /// Deserializes a well-formed relative path.
@@ -33,7 +33,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use color_eyre::eyre::{bail, Context, Result};
+    use color_eyre::eyre::{Context, Result, bail};
     use serde::de::IntoDeserializer;
 
     #[test]

--- a/nextest-runner/src/config/identifier.rs
+++ b/nextest-runner/src/config/identifier.rs
@@ -4,7 +4,7 @@
 use crate::errors::InvalidIdentifier;
 use smol_str::SmolStr;
 use std::fmt;
-use unicode_normalization::{is_nfc_quick, IsNormalized, UnicodeNormalization};
+use unicode_normalization::{IsNormalized, UnicodeNormalization, is_nfc_quick};
 
 /// An identifier used in configuration.
 ///

--- a/nextest-runner/src/config/max_fail.rs
+++ b/nextest-runner/src/config/max_fail.rs
@@ -18,11 +18,7 @@ pub enum MaxFail {
 impl MaxFail {
     /// Returns the max-fail corresponding to the fail-fast.
     pub fn from_fail_fast(fail_fast: bool) -> Self {
-        if fail_fast {
-            Self::Count(1)
-        } else {
-            Self::All
-        }
+        if fail_fast { Self::Count(1) } else { Self::All }
     }
 
     /// Returns true if the max-fail has been exceeded.
@@ -165,8 +161,8 @@ mod tests {
     use super::*;
     use crate::{
         config::{
-            test_helpers::{build_platforms, temp_workspace},
             NextestConfig,
+            test_helpers::{build_platforms, temp_workspace},
         },
         errors::ConfigParseErrorKind,
     };

--- a/nextest-runner/src/config/overrides.rs
+++ b/nextest-runner/src/config/overrides.rs
@@ -885,7 +885,7 @@ impl<'de> Deserialize<'de> for PlatformStrings {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{test_helpers::*, NextestConfig};
+    use crate::config::{NextestConfig, test_helpers::*};
     use camino::Utf8Path;
     use camino_tempfile::tempdir;
     use indoc::indoc;
@@ -1252,7 +1252,9 @@ mod tests {
                 assert_eq!(&reports, expected_reports, "reports match");
             }
             other => {
-                panic!("for config error {other:?}, expected ConfigParseErrorKind::FiltersetOrCfgParseError");
+                panic!(
+                    "for config error {other:?}, expected ConfigParseErrorKind::FiltersetOrCfgParseError"
+                );
             }
         };
     }

--- a/nextest-runner/src/config/retry_policy.rs
+++ b/nextest-runner/src/config/retry_policy.rs
@@ -167,8 +167,8 @@ mod tests {
     use super::*;
     use crate::{
         config::{
-            test_helpers::{binary_query, build_platforms, temp_workspace},
             NextestConfig,
+            test_helpers::{binary_query, build_platforms, temp_workspace},
         },
         errors::ConfigParseErrorKind,
     };
@@ -396,7 +396,9 @@ mod tests {
             ConfigParseErrorKind::DeserializeError(path_error) => match path_error.inner() {
                 ConfigError::Message(message) => message,
                 other => {
-                    panic!("for config error {config_err:?}, expected ConfigError::Message for inner error {other:?}");
+                    panic!(
+                        "for config error {config_err:?}, expected ConfigError::Message for inner error {other:?}"
+                    );
                 }
             },
             other => {

--- a/nextest-runner/src/config/scripts.rs
+++ b/nextest-runner/src/config/scripts.rs
@@ -22,7 +22,7 @@ use camino_tempfile::Utf8TempPath;
 use guppy::graph::cargo::BuildPlatform;
 use indexmap::IndexMap;
 use nextest_filtering::{EvalContext, Filterset, FiltersetKind, ParseContext, TestQuery};
-use serde::{de::Error, Deserialize};
+use serde::{Deserialize, de::Error};
 use smol_str::SmolStr;
 use std::{
     collections::{HashMap, HashSet},
@@ -592,7 +592,7 @@ where
 mod tests {
     use super::*;
     use crate::{
-        config::{test_helpers::*, ConfigExperimental, NextestConfig, ToolConfigFile},
+        config::{ConfigExperimental, NextestConfig, ToolConfigFile, test_helpers::*},
         errors::{ConfigParseErrorKind, DisplayErrorChain, UnknownConfigScriptError},
     };
     use camino_tempfile::tempdir;
@@ -948,7 +948,9 @@ mod tests {
                 assert_eq!(&reports, expected_reports, "reports match");
             }
             other => {
-                panic!("for config error {other:?}, expected ConfigParseErrorKind::CompiledDataParseError");
+                panic!(
+                    "for config error {other:?}, expected ConfigParseErrorKind::CompiledDataParseError"
+                );
             }
         }
     }
@@ -991,7 +993,9 @@ mod tests {
                 }
             }
             other => {
-                panic!("for config error {other:?}, expected ConfigParseErrorKind::InvalidConfigScriptsDefined");
+                panic!(
+                    "for config error {other:?}, expected ConfigParseErrorKind::InvalidConfigScriptsDefined"
+                );
             }
         }
     }
@@ -1043,7 +1047,9 @@ mod tests {
                 }
             }
             other => {
-                panic!("for config error {other:?}, expected ConfigParseErrorKind::InvalidConfigScriptsDefinedByTool");
+                panic!(
+                    "for config error {other:?}, expected ConfigParseErrorKind::InvalidConfigScriptsDefinedByTool"
+                );
             }
         }
     }
@@ -1128,7 +1134,9 @@ mod tests {
                 }
             }
             other => {
-                panic!("for config error {other:?}, expected ConfigParseErrorKind::UnknownConfigScripts");
+                panic!(
+                    "for config error {other:?}, expected ConfigParseErrorKind::UnknownConfigScripts"
+                );
             }
         }
     }

--- a/nextest-runner/src/config/slow_timeout.rs
+++ b/nextest-runner/src/config/slow_timeout.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use serde::{de::IntoDeserializer, Deserialize};
+use serde::{Deserialize, de::IntoDeserializer};
 use std::{fmt, num::NonZeroUsize, time::Duration};
 
 /// Type for the slow-timeout config key.
@@ -79,8 +79,8 @@ where
 mod tests {
     use super::*;
     use crate::config::{
-        test_helpers::{build_platforms, temp_workspace},
         NextestConfig,
+        test_helpers::{build_platforms, temp_workspace},
     };
     use camino_tempfile::tempdir;
     use indoc::indoc;

--- a/nextest-runner/src/config/test_group.rs
+++ b/nextest-runner/src/config/test_group.rs
@@ -126,7 +126,7 @@ pub struct TestGroupConfig {
 mod tests {
     use super::*;
     use crate::{
-        config::{test_helpers::*, NextestConfig, ToolConfigFile},
+        config::{NextestConfig, ToolConfigFile, test_helpers::*},
         errors::{ConfigParseErrorKind, UnknownTestGroupError},
     };
     use camino::Utf8Path;

--- a/nextest-runner/src/config/test_helpers.rs
+++ b/nextest-runner/src/config/test_helpers.rs
@@ -8,8 +8,8 @@ use crate::{
 };
 use camino::{Utf8Path, Utf8PathBuf};
 use guppy::{
-    graph::{cargo::BuildPlatform, PackageGraph},
     MetadataCommand, PackageId,
+    graph::{PackageGraph, cargo::BuildPlatform},
 };
 use nextest_filtering::BinaryQuery;
 use nextest_metadata::{RustBinaryId, RustTestBinaryKind};
@@ -87,9 +87,9 @@ pub(super) fn build_platforms() -> BuildPlatforms {
     BuildPlatforms {
         host: HostPlatform {
             platform: Platform::new("x86_64-unknown-linux-gnu", TargetFeatures::Unknown).unwrap(),
-            libdir: PlatformLibdir::Available(
-                Utf8PathBuf::from("/home/fake/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib")
-            ),
+            libdir: PlatformLibdir::Available(Utf8PathBuf::from(
+                "/home/fake/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib",
+            )),
         },
         target: Some(TargetPlatform {
             triple: TargetTriple {
@@ -97,9 +97,9 @@ pub(super) fn build_platforms() -> BuildPlatforms {
                 source: TargetTripleSource::Env,
                 location: TargetDefinitionLocation::Builtin,
             },
-            libdir: PlatformLibdir::Available(
-                Utf8PathBuf::from("/home/fake/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/aarch64-apple-darwin/lib")
-            ),
+            libdir: PlatformLibdir::Available(Utf8PathBuf::from(
+                "/home/fake/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/aarch64-apple-darwin/lib",
+            )),
         }),
     }
 }
@@ -134,9 +134,9 @@ pub(super) fn custom_build_platforms(workspace_dir: &Utf8Path) -> BuildPlatforms
 
     let host = HostPlatform {
         platform: Platform::new("x86_64-unknown-linux-gnu", TargetFeatures::Unknown).unwrap(),
-        libdir: PlatformLibdir::Available(
-            Utf8PathBuf::from("/home/fake/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib")
-        ),
+        libdir: PlatformLibdir::Available(Utf8PathBuf::from(
+            "/home/fake/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib",
+        )),
     };
     let target = TargetPlatform {
         triple,

--- a/nextest-runner/src/config/test_threads.rs
+++ b/nextest-runner/src/config/test_threads.rs
@@ -109,7 +109,7 @@ impl<'de> Deserialize<'de> for TestThreads {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{test_helpers::*, NextestConfig};
+    use crate::config::{NextestConfig, test_helpers::*};
     use camino_tempfile::tempdir;
     use indoc::indoc;
     use nextest_filtering::ParseContext;

--- a/nextest-runner/src/config/threads_required.rs
+++ b/nextest-runner/src/config/threads_required.rs
@@ -92,7 +92,7 @@ impl<'de> Deserialize<'de> for ThreadsRequired {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{test_helpers::*, NextestConfig};
+    use crate::config::{NextestConfig, test_helpers::*};
     use camino_tempfile::tempdir;
     use indoc::indoc;
     use nextest_filtering::ParseContext;

--- a/nextest-runner/src/config/tool_config.rs
+++ b/nextest-runner/src/config/tool_config.rs
@@ -57,8 +57,8 @@ impl FromStr for ToolConfigFile {
 mod tests {
     use super::*;
     use crate::config::{
-        test_helpers::*, NextestConfig, NextestVersionConfig, NextestVersionReq, RetryPolicy,
-        TestGroup, VersionOnlyConfig,
+        NextestConfig, NextestVersionConfig, NextestVersionReq, RetryPolicy, TestGroup,
+        VersionOnlyConfig, test_helpers::*,
     };
     use camino_tempfile::tempdir;
     use guppy::graph::cargo::BuildPlatform;

--- a/nextest-runner/src/console.rs
+++ b/nextest-runner/src/console.rs
@@ -6,7 +6,7 @@
 //! This is currently not shipped with release builds but is available as a debugging tool.
 
 use tracing::Subscriber;
-use tracing_subscriber::{registry::LookupSpan, Layer};
+use tracing_subscriber::{Layer, registry::LookupSpan};
 
 /// Spawns the Tokio console subscriber in a background thread, returning a tracing `Layer` that
 /// refers to it.

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -612,7 +612,9 @@ pub enum ToolConfigFileParseError {
 
 /// Error returned while parsing a [`MaxFail`](crate::config::MaxFail) input.
 #[derive(Clone, Debug, Error)]
-#[error("unrecognized value for max-fail: {input}\n(hint: expected either a positive integer or \"all\")")]
+#[error(
+    "unrecognized value for max-fail: {input}\n(hint: expected either a positive integer or \"all\")"
+)]
 pub struct MaxFailParseError {
     /// The input that failed to parse.
     pub input: String,
@@ -925,7 +927,7 @@ pub enum CreateTestListError {
         "for `{binary_id}`, command `{}` produced non-UTF-8 output:\n--- stdout:\n{}\n--- stderr:\n{}\n---",
         shell_words::join(command),
         String::from_utf8_lossy(stdout),
-        String::from_utf8_lossy(stderr),
+        String::from_utf8_lossy(stderr)
     )]
     CommandNonUtf8 {
         /// The binary ID for which gathering the list of tests failed.
@@ -1892,9 +1894,10 @@ mod self_update_errors {
         EmptyString,
 
         /// The input is not a valid version requirement.
-        #[error("`{input}` is not a valid semver requirement\n\
+        #[error(
+            "`{input}` is not a valid semver requirement\n\
                 (hint: see https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html for the correct format)"
-                )]
+        )]
         InvalidVersionReq {
             /// The input that was provided.
             input: String,

--- a/nextest-runner/src/helpers.rs
+++ b/nextest-runner/src/helpers.rs
@@ -13,11 +13,7 @@ use std::{fmt, io, path::PathBuf, process::ExitStatus, time::Duration};
 
 pub(crate) mod plural {
     pub(crate) fn were_plural_if(plural: bool) -> &'static str {
-        if plural {
-            "were"
-        } else {
-            "was"
-        }
+        if plural { "were" } else { "was" }
     }
 
     pub(crate) fn setup_scripts_str(count: usize) -> &'static str {
@@ -33,35 +29,19 @@ pub(crate) mod plural {
     }
 
     pub(crate) fn tests_plural_if(plural: bool) -> &'static str {
-        if plural {
-            "tests"
-        } else {
-            "test"
-        }
+        if plural { "tests" } else { "test" }
     }
 
     pub(crate) fn binaries_str(count: usize) -> &'static str {
-        if count == 1 {
-            "binary"
-        } else {
-            "binaries"
-        }
+        if count == 1 { "binary" } else { "binaries" }
     }
 
     pub(crate) fn paths_str(count: usize) -> &'static str {
-        if count == 1 {
-            "path"
-        } else {
-            "paths"
-        }
+        if count == 1 { "path" } else { "paths" }
     }
 
     pub(crate) fn files_str(count: usize) -> &'static str {
-        if count == 1 {
-            "file"
-        } else {
-            "files"
-        }
+        if count == 1 { "file" } else { "files" }
     }
 
     pub(crate) fn directories_str(count: usize) -> &'static str {
@@ -81,11 +61,7 @@ pub(crate) mod plural {
     }
 
     pub(crate) fn libraries_str(count: usize) -> &'static str {
-        if count == 1 {
-            "library"
-        } else {
-            "libraries"
-        }
+        if count == 1 { "library" } else { "libraries" }
     }
 }
 

--- a/nextest-runner/src/input.rs
+++ b/nextest-runner/src/input.rs
@@ -275,7 +275,7 @@ enum InputHandlerFinishError {
 
 #[cfg(unix)]
 mod imp {
-    use libc::{tcgetattr, tcsetattr, ECHO, ICANON, TCSAFLUSH, TCSANOW, VMIN, VTIME};
+    use libc::{ECHO, ICANON, TCSAFLUSH, TCSANOW, VMIN, VTIME, tcgetattr, tcsetattr};
     use std::{ffi::c_int, io, mem, os::fd::AsRawFd};
 
     pub(super) type Error = io::Error;
@@ -361,7 +361,7 @@ mod imp {
 mod imp {
     use std::{io, os::windows::io::AsRawHandle};
     use windows_sys::Win32::System::Console::{
-        GetConsoleMode, SetConsoleMode, CONSOLE_MODE, ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT,
+        CONSOLE_MODE, ENABLE_ECHO_INPUT, ENABLE_LINE_INPUT, GetConsoleMode, SetConsoleMode,
     };
 
     pub(super) type Error = io::Error;

--- a/nextest-runner/src/list/rust_build_meta.rs
+++ b/nextest-runner/src/list/rust_build_meta.rs
@@ -215,7 +215,7 @@ mod tests {
         BuildPlatformsSummary, HostPlatformSummary, PlatformLibdirSummary,
         PlatformLibdirUnavailable,
     };
-    use target_spec::{summaries::PlatformSummary, Platform};
+    use target_spec::{Platform, summaries::PlatformSummary};
     use test_case::test_case;
 
     impl Default for RustBuildMeta<BinaryListState> {
@@ -362,7 +362,10 @@ mod tests {
             ..Default::default()
         };
         let actual = RustBuildMeta::<BinaryListState>::from_summary(summary);
-        assert!(matches!(actual, Err(RustBuildMetaParseError::Unsupported { .. })), "Expect the parse result to be an error of RustBuildMetaParseError::Unsupported, actual {actual:?}");
+        assert!(
+            matches!(actual, Err(RustBuildMetaParseError::Unsupported { .. })),
+            "Expect the parse result to be an error of RustBuildMetaParseError::Unsupported, actual {actual:?}"
+        );
     }
 
     #[test]

--- a/nextest-runner/src/list/test_list.rs
+++ b/nextest-runner/src/list/test_list.rs
@@ -19,8 +19,8 @@ use crate::{
 use camino::{Utf8Path, Utf8PathBuf};
 use futures::prelude::*;
 use guppy::{
-    graph::{PackageGraph, PackageMetadata},
     PackageId,
+    graph::{PackageGraph, PackageMetadata},
 };
 use nextest_filtering::{BinaryQuery, EvalContext, TestQuery};
 use nextest_metadata::{

--- a/nextest-runner/src/platform.rs
+++ b/nextest-runner/src/platform.rs
@@ -4,12 +4,12 @@
 //! Platform-related data structures.
 
 use crate::{
+    RustcCli,
     cargo_config::{CargoTargetArg, TargetTriple},
     errors::{
         DisplayErrorChain, HostPlatformDetectError, RustBuildMetaParseError, TargetTripleError,
     },
     reuse_build::{LibdirMapper, PlatformLibdirMapper},
-    RustcCli,
 };
 use camino::{Utf8Path, Utf8PathBuf};
 use indent_write::indentable::Indented;
@@ -19,7 +19,7 @@ use nextest_metadata::{
 };
 pub use target_spec::Platform;
 use target_spec::{
-    errors::RustcVersionVerboseParseError, summaries::PlatformSummary, TargetFeatures,
+    TargetFeatures, errors::RustcVersionVerboseParseError, summaries::PlatformSummary,
 };
 use tracing::{debug, warn};
 

--- a/nextest-runner/src/redact.rs
+++ b/nextest-runner/src/redact.rs
@@ -6,7 +6,7 @@
 //! Used for snapshot testing.
 
 use crate::{
-    helpers::{convert_rel_path_to_forward_slash, FormattedDuration},
+    helpers::{FormattedDuration, convert_rel_path_to_forward_slash},
     list::RustBuildMeta,
 };
 use camino::{Utf8Path, Utf8PathBuf};

--- a/nextest-runner/src/reporter/aggregator/junit.rs
+++ b/nextest-runner/src/reporter/aggregator/junit.rs
@@ -8,8 +8,8 @@ use crate::{
     errors::{DisplayErrorChain, WriteEventError},
     list::TestInstanceId,
     reporter::{
-        events::{ExecutionDescription, ExecutionResult, TestEvent, TestEventKind, UnitKind},
         UnitErrorDescription,
+        events::{ExecutionDescription, ExecutionResult, TestEvent, TestEventKind, UnitKind},
     },
     test_output::{ChildExecutionOutput, ChildOutput},
 };

--- a/nextest-runner/src/reporter/displayer/imp.rs
+++ b/nextest-runner/src/reporter/displayer/imp.rs
@@ -6,19 +6,19 @@
 //! The main structure in this module is [`TestReporter`].
 
 use super::{
-    formatters::{
-        write_final_warnings, write_skip_counts, DisplayBracketedDuration, DisplayDurationBy,
-        DisplaySlowDuration,
-    },
-    progress::{progress_bar_msg, progress_str, write_summary_str, ProgressBarState},
-    unit_output::TestOutputDisplay,
     ChildOutputSpec, FinalStatusLevel, OutputStoreFinal, StatusLevel, StatusLevels,
     UnitOutputReporter,
+    formatters::{
+        DisplayBracketedDuration, DisplayDurationBy, DisplaySlowDuration, write_final_warnings,
+        write_skip_counts,
+    },
+    progress::{ProgressBarState, progress_bar_msg, progress_str, write_summary_str},
+    unit_output::TestOutputDisplay,
 };
 use crate::{
     config::{CompiledDefaultFilter, ScriptId},
     errors::WriteEventError,
-    helpers::{plural, DisplayScriptInstance, DisplayTestInstance},
+    helpers::{DisplayScriptInstance, DisplayTestInstance, plural},
     list::{TestInstance, TestInstanceId},
     reporter::{events::*, helpers::Styles, imp::ReporterStderr},
 };
@@ -32,7 +32,7 @@ use std::{
     io::{self, BufWriter, Write},
     time::Duration,
 };
-use swrite::{swrite, SWrite};
+use swrite::{SWrite, swrite};
 
 pub(crate) struct DisplayReporterBuilder {
     pub(crate) default_filter: CompiledDefaultFilter,

--- a/nextest-runner/src/reporter/displayer/progress.rs
+++ b/nextest-runner/src/reporter/displayer/progress.rs
@@ -8,7 +8,7 @@ use std::{
     io::{self, Write},
     time::Duration,
 };
-use swrite::{swrite, SWrite};
+use swrite::{SWrite, swrite};
 
 #[derive(Debug)]
 pub(super) struct ProgressBarState {

--- a/nextest-runner/src/reporter/displayer/unit_output.rs
+++ b/nextest-runner/src/reporter/displayer/unit_output.rs
@@ -6,9 +6,9 @@
 use crate::{
     errors::DisplayErrorChain,
     reporter::{
-        events::*,
-        helpers::{highlight_end, Styles},
         ByteSubslice, TestOutputErrorSlice, UnitErrorDescription,
+        events::*,
+        helpers::{Styles, highlight_end},
     },
     test_output::{ChildExecutionOutput, ChildOutput, ChildSingleOutput},
 };

--- a/nextest-runner/src/reporter/imp.rs
+++ b/nextest-runner/src/reporter/imp.rs
@@ -6,8 +6,8 @@
 //! The main structure in this module is [`TestReporter`].
 
 use super::{
-    displayer::{DisplayReporter, DisplayReporterBuilder, StatusLevels},
     FinalStatusLevel, StatusLevel, TestOutputDisplay,
+    displayer::{DisplayReporter, DisplayReporterBuilder, StatusLevels},
 };
 use crate::{
     config::EvaluatableProfile,

--- a/nextest-runner/src/reuse_build/archiver.rs
+++ b/nextest-runner/src/reuse_build/archiver.rs
@@ -4,18 +4,18 @@
 use super::{ArchiveCounts, ArchiveEvent, BINARIES_METADATA_FILE_NAME, CARGO_METADATA_FILE_NAME};
 use crate::{
     config::{
-        get_num_cpus, ArchiveConfig, ArchiveIncludeOnMissing, EvaluatableProfile, RecursionDepth,
+        ArchiveConfig, ArchiveIncludeOnMissing, EvaluatableProfile, RecursionDepth, get_num_cpus,
     },
     errors::{ArchiveCreateError, UnknownArchiveFormat},
     helpers::{convert_rel_path_to_forward_slash, rel_path_join},
     list::{BinaryList, OutputFormat, SerializableFormat},
     redact::Redactor,
-    reuse_build::{PathMapper, LIBDIRS_BASE_DIR},
+    reuse_build::{LIBDIRS_BASE_DIR, PathMapper},
 };
 use atomicwrites::{AtomicFile, OverwriteBehavior};
 use camino::{Utf8Path, Utf8PathBuf};
 use core::fmt;
-use guppy::{graph::PackageGraph, PackageId};
+use guppy::{PackageId, graph::PackageGraph};
 use std::{
     collections::HashSet,
     fs,
@@ -399,7 +399,9 @@ impl<'a, W: Write> Archiver<'a, W> {
 
             // Archive build script output in order to set environment variables from there
             let Some(out_dir_parent) = build_script_out_dir.parent() else {
-                warn!("could not determine parent directory of output directory {build_script_out_dir}");
+                warn!(
+                    "could not determine parent directory of output directory {build_script_out_dir}"
+                );
                 continue;
             };
             let out_file_path = out_dir_parent.join("output");

--- a/nextest-runner/src/reuse_build/unarchiver.rs
+++ b/nextest-runner/src/reuse_build/unarchiver.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use super::{
-    ArchiveEvent, ArchiveFormat, LibdirMapper, PlatformLibdirMapper, BINARIES_METADATA_FILE_NAME,
-    CARGO_METADATA_FILE_NAME, LIBDIRS_BASE_DIR,
+    ArchiveEvent, ArchiveFormat, BINARIES_METADATA_FILE_NAME, CARGO_METADATA_FILE_NAME,
+    LIBDIRS_BASE_DIR, LibdirMapper, PlatformLibdirMapper,
 };
 use crate::{
     errors::{ArchiveExtractError, ArchiveReadError},
@@ -12,7 +12,7 @@ use crate::{
 };
 use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
 use camino_tempfile::Utf8TempDir;
-use guppy::{graph::PackageGraph, CargoMetadata};
+use guppy::{CargoMetadata, graph::PackageGraph};
 use nextest_metadata::BinaryListSummary;
 use std::{
     fs,

--- a/nextest-runner/src/runner/dispatcher.rs
+++ b/nextest-runner/src/runner/dispatcher.rs
@@ -25,7 +25,7 @@ use debug_ignore::DebugIgnore;
 use quick_junit::ReportUuid;
 use std::{collections::BTreeMap, time::Duration};
 use tokio::sync::{
-    mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+    mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
     oneshot,
 };
 use tracing::debug;

--- a/nextest-runner/src/runner/executor.rs
+++ b/nextest-runner/src/runner/executor.rs
@@ -25,8 +25,9 @@ use crate::{
         TestInfoResponse, UnitKind, UnitState,
     },
     runner::{
-        parse_env_file, ExecutorEvent, InternalExecuteStatus, InternalSetupScriptExecuteStatus,
+        ExecutorEvent, InternalExecuteStatus, InternalSetupScriptExecuteStatus,
         InternalTerminateReason, RunUnitQuery, RunUnitRequest, SignalRequest, UnitExecuteStatus,
+        parse_env_file,
     },
     target_runner::TargetRunner,
     test_command::{ChildAccumulator, ChildFds},
@@ -36,7 +37,7 @@ use crate::{
 use future_queue::FutureQueueContext;
 use nextest_metadata::FilterMatch;
 use quick_junit::ReportUuid;
-use rand::{distr::OpenClosed01, Rng};
+use rand::{Rng, distr::OpenClosed01};
 use std::{
     num::NonZeroUsize,
     pin::Pin,

--- a/nextest-runner/src/runner/internal_events.rs
+++ b/nextest-runner/src/runner/internal_events.rs
@@ -12,11 +12,11 @@ use crate::{
     config::{ScriptConfig, ScriptId},
     list::TestInstance,
     reporter::{
+        TestOutputDisplay,
         events::{
             ExecuteStatus, ExecutionResult, InfoResponse, RetryData, SetupScriptEnvMap,
             SetupScriptExecuteStatus, UnitState,
         },
-        TestOutputDisplay,
     },
     signal::ShutdownEvent,
     test_output::ChildExecutionOutput,

--- a/nextest-runner/src/runner/script_helpers.rs
+++ b/nextest-runner/src/runner/script_helpers.rs
@@ -37,7 +37,7 @@ pub(super) async fn parse_env_file(
                 return Err(SetupScriptOutputError::EnvFileParse {
                     path: env_path.to_owned(),
                     line: line.to_owned(),
-                })
+                });
             }
         };
 

--- a/nextest-runner/src/runner/windows.rs
+++ b/nextest-runner/src/runner/windows.rs
@@ -17,7 +17,7 @@ use tokio::{process::Child, sync::mpsc::UnboundedReceiver};
 pub(super) use win32job::Job;
 use win32job::JobError;
 use windows_sys::Win32::{
-    Foundation::{SetHandleInformation, HANDLE_FLAG_INHERIT, INVALID_HANDLE_VALUE},
+    Foundation::{HANDLE_FLAG_INHERIT, INVALID_HANDLE_VALUE, SetHandleInformation},
     System::{
         Console::{GetStdHandle, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE},
         JobObjects::TerminateJobObject,

--- a/nextest-runner/src/signal.rs
+++ b/nextest-runner/src/signal.rs
@@ -61,8 +61,8 @@ impl SignalHandler {
 mod imp {
     use super::*;
     use std::io;
-    use tokio::signal::unix::{signal, SignalKind};
-    use tokio_stream::{wrappers::SignalStream, StreamExt, StreamMap};
+    use tokio::signal::unix::{SignalKind, signal};
+    use tokio_stream::{StreamExt, StreamMap, wrappers::SignalStream};
 
     #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
     enum SignalId {
@@ -173,7 +173,7 @@ mod imp {
 #[cfg(windows)]
 mod imp {
     use super::*;
-    use tokio::signal::windows::{ctrl_c, CtrlC};
+    use tokio::signal::windows::{CtrlC, ctrl_c};
 
     #[derive(Debug)]
     pub(super) struct Signals {

--- a/nextest-runner/src/time/pausable_sleep.rs
+++ b/nextest-runner/src/time/pausable_sleep.rs
@@ -47,7 +47,9 @@ impl PausableSleep {
                 *this.pause_state = SleepPauseState::Paused { remaining };
             }
             SleepPauseState::Paused { remaining } => {
-                panic!("illegal state transition: pause() called while sleep was paused (remaining = {remaining:?})");
+                panic!(
+                    "illegal state transition: pause() called while sleep was paused (remaining = {remaining:?})"
+                );
             }
         }
     }

--- a/nextest-runner/src/update.rs
+++ b/nextest-runner/src/update.rs
@@ -58,7 +58,7 @@ impl MuktiBackend {
                 return Err(UpdateError::MuktiProjectNotFound {
                     not_found: self.package_name.clone(),
                     known: releases_json.projects.keys().cloned().collect(),
-                })
+                });
             }
         };
 

--- a/nextest-runner/test-helpers/passthrough.rs
+++ b/nextest-runner/test-helpers/passthrough.rs
@@ -5,7 +5,7 @@ use std::{
     collections::BTreeMap,
     env,
     ffi::OsString,
-    process::{exit, Command},
+    process::{Command, exit},
 };
 
 fn main() {

--- a/nextest-runner/tests/integration/basic.rs
+++ b/nextest-runner/tests/integration/basic.rs
@@ -3,10 +3,10 @@
 
 use crate::fixtures::*;
 use cfg_if::cfg_if;
-use color_eyre::eyre::{ensure, Result};
+use color_eyre::eyre::{Result, ensure};
 use fixture_data::{
     models::{TestCaseFixtureStatus, TestSuiteFixture},
-    nextest_tests::{get_expected_test, EXPECTED_TEST_SUITES},
+    nextest_tests::{EXPECTED_TEST_SUITES, get_expected_test},
 };
 use nextest_filtering::{Filterset, FiltersetKind, ParseContext};
 use nextest_metadata::{FilterMatch, MismatchReason};
@@ -17,10 +17,10 @@ use nextest_runner::{
     list::BinaryList,
     platform::BuildPlatforms,
     reporter::{
+        UnitErrorDescription,
         events::{
             ExecutionDescription, ExecutionResult, FinalRunStats, RunStatsFailureKind, UnitKind,
         },
-        UnitErrorDescription,
     },
     runner::TestRunnerBuilder,
     signal::SignalHandlerKind,

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -2,16 +2,16 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use camino::{Utf8Path, Utf8PathBuf};
-use color_eyre::eyre::{ensure, Context, Result};
+use color_eyre::eyre::{Context, Result, ensure};
 use duct::cmd;
 use fixture_data::models::TestCaseFixtureStatus;
-use guppy::{graph::PackageGraph, MetadataCommand};
+use guppy::{MetadataCommand, graph::PackageGraph};
 use maplit::btreeset;
 use nextest_filtering::{CompiledExpr, EvalContext, ParseContext};
 use nextest_metadata::{MismatchReason, RustBinaryId};
 use nextest_runner::{
     cargo_config::{CargoConfigs, EnvironmentMap},
-    config::{get_num_cpus, ConfigExperimental, NextestConfig},
+    config::{ConfigExperimental, NextestConfig, get_num_cpus},
     double_spawn::DoubleSpawnInfo,
     list::{
         BinaryList, RustBuildMeta, RustTestArtifact, TestExecuteContext, TestList, TestListState,
@@ -19,7 +19,7 @@ use nextest_runner::{
     platform::BuildPlatforms,
     reporter::events::{AbortStatus, ExecutionResult, ExecutionStatuses, RunStats, TestEventKind},
     reuse_build::PathMapper,
-    runner::{configure_handle_inheritance, TestRunner},
+    runner::{TestRunner, configure_handle_inheritance},
     target_runner::TargetRunner,
     test_filter::{FilterBound, TestFilterBuilder},
     test_output::{ChildExecutionOutput, ChildOutput},

--- a/nextest-runner/tests/integration/target_runner.rs
+++ b/nextest-runner/tests/integration/target_runner.rs
@@ -3,9 +3,10 @@
 
 use crate::fixtures::*;
 use camino::Utf8Path;
-use color_eyre::{eyre::ensure, Result};
+use color_eyre::{Result, eyre::ensure};
 use fixture_data::nextest_tests::EXPECTED_TEST_SUITES;
 use nextest_runner::{
+    RustcCli,
     cargo_config::{CargoConfigs, TargetTriple},
     config::NextestConfig,
     double_spawn::DoubleSpawnInfo,
@@ -16,7 +17,6 @@ use nextest_runner::{
     signal::SignalHandlerKind,
     target_runner::{PlatformRunner, TargetRunner},
     test_filter::{RunIgnored, TestFilterBuilder},
-    RustcCli,
 };
 use std::env;
 use target_spec::Platform;
@@ -110,9 +110,11 @@ fn disregards_non_matching() {
         Vec::new(),
     )
     .unwrap();
-    assert!(PlatformRunner::find_config(&configs, &windows)
-        .unwrap()
-        .is_none());
+    assert!(
+        PlatformRunner::find_config(&configs, &windows)
+            .unwrap()
+            .is_none()
+    );
 }
 
 #[test]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2021"
+style_edition = "2024"


### PR DESCRIPTION
We can switch rustfmt over to the new edition while still staying on the 2021 edition otherwise.