### PR TITLE
Update documentation about Miri

### DIFF
--- a/site/src/docs/integrations/miri.md
+++ b/site/src/docs/integrations/miri.md
@@ -13,8 +13,6 @@ It can also run your tests for (almost) arbitrary targets.
 
 The main benefit of using nextest with Miri is that each test runs in its own process. This means that it's easier to [identify memory leaks](https://github.com/rust-lang/miri/issues/1481), for example.
 
-Miri can be very taxing on most computers. If nextest is run under Miri, it configures itself to use 1 thread by default. This mirrors `cargo miri test`. You can customize this with the `--test-threads`/`-j` option.
-
 ## Usage
 
 After [installing Miri](https://github.com/rust-lang/miri#using-miri), run:


### PR DESCRIPTION
We forgot about this in https://github.com/nextest-rs/nextest/pull/1347 :facepalm: 

This also mirrors https://github.com/rust-lang/miri/pull/4221, which removes the Miri version of this note.