### PR TITLE
[cargo-nextest] add an option to disable indentation of output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,8 +497,10 @@ version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
+ "anstyle",
  "heck",
  "proc-macro2",
+ "pulldown-cmark",
  "quote",
  "syn",
 ]
@@ -1991,6 +1993,7 @@ dependencies = [
  "backtrace",
  "bit-set",
  "bit-vec",
+ "bitflags",
  "camino",
  "cc",
  "clap",
@@ -2338,6 +2341,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ config = { version = "0.15.11", default-features = false, features = [
     "preserve_order",
 ] }
 chrono = "0.4.41"
-clap = { version = "4.5.37", features = ["derive"] }
+clap = { version = "4.5.37", features = ["derive", "unstable-markdown"] }
 console-subscriber = "0.4.1"
 cp_r = "0.5.2"
 crossterm = { version = "0.29.0", features = ["event-stream"] }

--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -996,6 +996,17 @@ struct ReporterOpts {
     #[arg(long, env = "NEXTEST_HIDE_PROGRESS_BAR", value_parser = BoolishValueParser::new())]
     hide_progress_bar: bool,
 
+    /// Do not indent captured test output.
+    ///
+    /// By default, test output produced by **--failure-output** and
+    /// **--success-output** is indented for visual clarity. This flag disables
+    /// that behavior.
+    ///
+    /// This option has no effect with **--no-capture**, since that passes
+    /// through standard output and standard error.
+    #[arg(long, env = "NEXTEST_NO_INDENT_OUTPUT", value_parser = BoolishValueParser::new())]
+    no_indent_output: bool,
+
     /// Disable handling of input keys from the terminal.
     ///
     /// By default, when running a terminal, nextest accepts the `t` key to dump
@@ -1079,6 +1090,7 @@ impl ReporterOpts {
             builder.set_final_status_level(final_status_level.into());
         }
         builder.set_hide_progress_bar(self.hide_progress_bar);
+        builder.set_no_indent_output(self.no_indent_output);
         builder
     }
 }

--- a/nextest-runner/src/reporter/imp.rs
+++ b/nextest-runner/src/reporter/imp.rs
@@ -41,6 +41,7 @@ pub struct ReporterBuilder {
 
     verbose: bool,
     hide_progress_bar: bool,
+    no_indent_output: bool,
 }
 
 impl ReporterBuilder {
@@ -95,6 +96,12 @@ impl ReporterBuilder {
         self.hide_progress_bar = hide_progress_bar;
         self
     }
+
+    /// Set to true to disable indentation of captured test output.
+    pub fn set_no_indent_output(&mut self, no_indent_output: bool) -> &mut Self {
+        self.no_indent_output = no_indent_output;
+        self
+    }
 }
 
 impl ReporterBuilder {
@@ -125,6 +132,7 @@ impl ReporterBuilder {
             should_colorize: self.should_colorize,
             no_capture: self.no_capture,
             hide_progress_bar: self.hide_progress_bar,
+            no_indent_output: self.no_indent_output,
         }
         .build(output);
 

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -20,7 +20,7 @@ backtrace = { version = "0.3.71", features = ["gimli-symbolize"] }
 bit-set = { version = "0.8.0" }
 bit-vec = { version = "0.8.0" }
 camino = { version = "1.1.9", default-features = false, features = ["serde1"] }
-clap = { version = "4.5.37", features = ["derive", "env", "unicode", "wrap_help"] }
+clap = { version = "4.5.37", features = ["derive", "env", "unicode", "unstable-markdown", "wrap_help"] }
 clap_builder = { version = "4.5.37", default-features = false, features = ["color", "env", "std", "suggestions", "unicode", "usage", "wrap_help"] }
 console = { version = "0.15.10" }
 either = { version = "1.13.0" }
@@ -47,12 +47,14 @@ zerocopy = { version = "0.7.35", features = ["derive", "simd"] }
 [build-dependencies]
 camino = { version = "1.1.9", default-features = false, features = ["serde1"] }
 cc = { version = "1.2.15", default-features = false, features = ["parallel"] }
+memchr = { version = "2.7.4" }
 proc-macro2 = { version = "1.0.93" }
 quote = { version = "1.0.38" }
 serde = { version = "1.0.219", features = ["alloc", "derive"] }
 syn = { version = "2.0.98", features = ["extra-traits", "full", "visit", "visit-mut"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
+bitflags = { version = "2.9.0", default-features = false, features = ["std"] }
 futures-channel = { version = "0.3.31", features = ["sink"] }
 futures-core = { version = "0.3.31" }
 futures-sink = { version = "0.3.31" }
@@ -65,9 +67,11 @@ smallvec = { version = "1.15.0", default-features = false, features = ["const_ne
 tokio = { version = "1.44.2", default-features = false, features = ["net"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
+bitflags = { version = "2.9.0", default-features = false, features = ["std"] }
 libc = { version = "0.2.172", features = ["extra_traits"] }
 
 [target.x86_64-apple-darwin.dependencies]
+bitflags = { version = "2.9.0", default-features = false, features = ["std"] }
 futures-channel = { version = "0.3.31", features = ["sink"] }
 futures-core = { version = "0.3.31" }
 futures-sink = { version = "0.3.31" }
@@ -79,6 +83,7 @@ smallvec = { version = "1.15.0", default-features = false, features = ["const_ne
 tokio = { version = "1.44.2", default-features = false, features = ["net"] }
 
 [target.x86_64-apple-darwin.build-dependencies]
+bitflags = { version = "2.9.0", default-features = false, features = ["std"] }
 libc = { version = "0.2.172", features = ["extra_traits"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]


### PR DESCRIPTION
Some use cases for this include copy/pasting output without block selection, and simple personal preference.

Also enable markdown parsing in clap help messages so bold text can be used.