### PR TITLE
move setup scripts to be nested inside `scripts`

### DIFF
--- a/fixtures/nextest-tests/.config/nextest.toml
+++ b/fixtures/nextest-tests/.config/nextest.toml
@@ -118,8 +118,8 @@ max-threads = 20
 [test-groups.serial]
 max-threads = 1
 
-[script.my-script-unix]
+[scripts.setup.my-script-unix]
 command = './scripts/my-script.sh'
 
-[script.my-script-windows]
+[scripts.setup.my-script-windows]
 command = 'cmd /c "scripts\\my-script.bat"'

--- a/nextest-runner/src/config/overrides.rs
+++ b/nextest-runner/src/config/overrides.rs
@@ -514,13 +514,13 @@ impl CompiledData<PreBuildPlatform> {
     pub(super) fn chain(self, other: Self) -> Self {
         let profile_default_filter = self.profile_default_filter.or(other.profile_default_filter);
         let mut overrides = self.overrides;
-        let mut setup_scripts = self.scripts;
+        let mut scripts = self.scripts;
         overrides.extend(other.overrides);
-        setup_scripts.extend(other.scripts);
+        scripts.extend(other.scripts);
         Self {
             profile_default_filter,
             overrides,
-            scripts: setup_scripts,
+            scripts,
         }
     }
 

--- a/nextest-runner/src/runner/dispatcher.rs
+++ b/nextest-runner/src/runner/dispatcher.rs
@@ -9,7 +9,7 @@
 
 use super::{RunUnitRequest, RunnerTaskState, ShutdownRequest};
 use crate::{
-    config::{MaxFail, ScriptConfig, ScriptId},
+    config::{MaxFail, ScriptId, SetupScriptConfig},
     input::{InputEvent, InputHandler},
     list::{TestInstance, TestInstanceId, TestList},
     reporter::events::{
@@ -551,7 +551,7 @@ where
     fn new_setup_script(
         &mut self,
         id: ScriptId,
-        config: &'a ScriptConfig,
+        config: &'a SetupScriptConfig,
         index: usize,
         total: usize,
         req_tx: UnboundedSender<RunUnitRequest<'a>>,
@@ -807,7 +807,7 @@ struct ContextSetupScript<'a> {
     id: ScriptId,
     // Store these details primarily for debugging.
     #[expect(dead_code)]
-    config: &'a ScriptConfig,
+    config: &'a SetupScriptConfig,
     #[expect(dead_code)]
     index: usize,
     #[expect(dead_code)]

--- a/nextest-runner/src/runner/executor.rs
+++ b/nextest-runner/src/runner/executor.rs
@@ -14,8 +14,9 @@
 use super::HandleSignalResult;
 use crate::{
     config::{
-        EvaluatableProfile, LeakTimeout, LeakTimeoutResult, RetryPolicy, ScriptConfig, ScriptId,
-        SetupScriptCommand, SetupScriptExecuteData, SlowTimeout, TestGroup, TestSettings,
+        EvaluatableProfile, LeakTimeout, LeakTimeoutResult, RetryPolicy, ScriptId,
+        SetupScriptCommand, SetupScriptConfig, SetupScriptExecuteData, SlowTimeout, TestGroup,
+        TestSettings,
     },
     double_spawn::DoubleSpawnInfo,
     errors::{ChildError, ChildFdError, ChildStartError, ErrorList},
@@ -1040,7 +1041,7 @@ impl fmt::Debug for TestPacket<'_> {
 #[derive(Clone, Debug)]
 pub(super) struct SetupScriptPacket<'a> {
     script_id: ScriptId,
-    config: &'a ScriptConfig,
+    config: &'a SetupScriptConfig,
 }
 
 impl<'a> SetupScriptPacket<'a> {

--- a/nextest-runner/src/runner/internal_events.rs
+++ b/nextest-runner/src/runner/internal_events.rs
@@ -9,7 +9,7 @@
 
 use super::{SetupScriptPacket, TestPacket};
 use crate::{
-    config::{ScriptConfig, ScriptId},
+    config::{ScriptId, SetupScriptConfig},
     list::TestInstance,
     reporter::{
         TestOutputDisplay,
@@ -41,7 +41,7 @@ use tokio::{
 pub(super) enum ExecutorEvent<'a> {
     SetupScriptStarted {
         script_id: ScriptId,
-        config: &'a ScriptConfig,
+        config: &'a SetupScriptConfig,
         index: usize,
         total: usize,
         // See the note in the `Started` variant.
@@ -49,13 +49,13 @@ pub(super) enum ExecutorEvent<'a> {
     },
     SetupScriptSlow {
         script_id: ScriptId,
-        config: &'a ScriptConfig,
+        config: &'a SetupScriptConfig,
         elapsed: Duration,
         will_terminate: Option<Duration>,
     },
     SetupScriptFinished {
         script_id: ScriptId,
-        config: &'a ScriptConfig,
+        config: &'a SetupScriptConfig,
         index: usize,
         total: usize,
         status: SetupScriptExecuteStatus,


### PR DESCRIPTION
Much of this has been adapted from #2018, with attention paid towards short-term back compat ("scripts.setup" instead of "script.setup").