### PR TITLE
[nextest-runner] support OSC 9 terminal status reporting

### DIFF
--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -1861,8 +1861,13 @@ impl App {
         )?;
 
         // Make the reporter.
-        let mut reporter =
-            reporter_builder.build(&test_list, &profile, output, structured_reporter);
+        let mut reporter = reporter_builder.build(
+            &test_list,
+            &profile,
+            &self.base.cargo_configs,
+            output,
+            structured_reporter,
+        );
 
         configure_handle_inheritance(no_capture)?;
         let run_stats = runner.try_execute(|event| {

--- a/nextest-runner/src/cargo_config/discovery.rs
+++ b/nextest-runner/src/cargo_config/discovery.rs
@@ -425,6 +425,8 @@ pub(crate) struct CargoConfig {
     pub(crate) target: Option<BTreeMap<String, CargoConfigRunner>>,
     #[serde(default)]
     pub(crate) env: BTreeMap<String, CargoConfigEnv>,
+    #[serde(default)]
+    pub(crate) term: CargoConfigTerm,
 }
 
 #[derive(Deserialize, Default, Debug)]
@@ -443,6 +445,20 @@ pub(crate) struct CargoConfigRunner {
 pub(crate) enum Runner {
     Simple(String),
     List(Vec<String>),
+}
+
+#[derive(Deserialize, Debug, Default)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) struct CargoConfigTerm {
+    #[serde(default)]
+    pub(crate) progress: CargoConfigTermProgress,
+}
+
+#[derive(Deserialize, Debug, Default)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) struct CargoConfigTermProgress {
+    #[serde(default)]
+    pub(crate) term_integration: Option<bool>,
 }
 
 #[cfg(test)]

--- a/nextest-runner/src/reporter/events.rs
+++ b/nextest-runner/src/reporter/events.rs
@@ -269,6 +269,9 @@ pub enum TestEventKind<'a> {
         /// The number of setup scripts still running.
         setup_scripts_running: usize,
 
+        /// Current statistics for number of tests so far.
+        current_stats: RunStats,
+
         /// The number of tests still running.
         running: usize,
 
@@ -280,6 +283,9 @@ pub enum TestEventKind<'a> {
     RunBeginKill {
         /// The number of setup scripts still running.
         setup_scripts_running: usize,
+
+        /// Current statistics for number of tests so far.
+        current_stats: RunStats,
 
         /// The number of tests still running.
         running: usize,

--- a/nextest-runner/src/reporter/imp.rs
+++ b/nextest-runner/src/reporter/imp.rs
@@ -10,6 +10,7 @@ use super::{
     displayer::{DisplayReporter, DisplayReporterBuilder, StatusLevels},
 };
 use crate::{
+    cargo_config::CargoConfigs,
     config::EvaluatableProfile,
     errors::WriteEventError,
     list::TestList,
@@ -110,6 +111,7 @@ impl ReporterBuilder {
         &self,
         test_list: &TestList,
         profile: &EvaluatableProfile<'a>,
+        cargo_configs: &CargoConfigs,
         output: ReporterStderr<'a>,
         structured_reporter: StructuredReporter<'a>,
     ) -> Reporter<'a> {
@@ -134,7 +136,7 @@ impl ReporterBuilder {
             hide_progress_bar: self.hide_progress_bar,
             no_output_indent: self.no_output_indent,
         }
-        .build(output);
+        .build(cargo_configs, output);
 
         Reporter {
             display_reporter,

--- a/nextest-runner/src/runner/dispatcher.rs
+++ b/nextest-runner/src/runner/dispatcher.rs
@@ -764,6 +764,7 @@ where
             // signal.
             self.basic_callback(TestEventKind::RunBeginKill {
                 setup_scripts_running: self.setup_scripts_running(),
+                current_stats: self.run_stats,
                 running: self.running(),
                 // This is always a second signal.
                 reason: CancelReason::SecondSignal,
@@ -773,6 +774,7 @@ where
             self.cancel_state = Some(reason);
             self.basic_callback(TestEventKind::RunBeginCancel {
                 setup_scripts_running: self.setup_scripts_running(),
+                current_stats: self.run_stats,
                 running: self.running(),
                 reason,
             });
@@ -933,6 +935,7 @@ mod tests {
             let event = events.pop().unwrap();
             let TestEventKind::RunBeginCancel {
                 setup_scripts_running,
+                current_stats: _,
                 running,
                 reason,
             } = event.kind
@@ -977,6 +980,7 @@ mod tests {
                     let event = events.pop().unwrap();
                     let TestEventKind::RunBeginCancel {
                         setup_scripts_running,
+                        current_stats: _,
                         running,
                         reason,
                     } = event.kind
@@ -1005,6 +1009,7 @@ mod tests {
                     let event = events.pop().unwrap();
                     let TestEventKind::RunBeginKill {
                         setup_scripts_running,
+                        current_stats: _,
                         running,
                         reason,
                     } = event.kind


### PR DESCRIPTION
Piggyback on Cargo 1.87's support for the same: https://github.com/rust-lang/cargo/pull/14615

It would be nice to have a standard Rust crate to detect this in the future, but using the same logic as Cargo will do for now.