### PR TITLE
[site] update CI action `baptiste0928/cargo-install`: v1 -> v3

### DIFF
--- a/site/src/docs/installation/from-source.md
+++ b/site/src/docs/installation/from-source.md
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v3
       # Install a Rust toolchain here.
       - name: Install cargo-nextest
-        uses: baptiste0928/cargo-install@v1
+        uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-nextest
           locked: true


### PR DESCRIPTION
v1 and v2 of [baptiste0928/cargo-install](https://github.com/baptiste0928/cargo-install) use a [deprecated cache API](https://github.com/baptiste0928/cargo-install/issues/32#issuecomment-2979676159).


