### PR TITLE
Add global-timeout option

### DIFF
--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -2459,7 +2459,7 @@ fn log_platform_runner(prefix: &str, runner: &PlatformRunner, styles: &StderrSty
     )
 }
 
-fn warn_on_err(thing: &str, err: &(dyn std::error::Error), styles: &StderrStyles) {
+fn warn_on_err(thing: &str, err: &dyn std::error::Error, styles: &StderrStyles) {
     let mut s = String::with_capacity(256);
     swrite!(s, "could not determine {thing}: {err}");
     let mut next_error = err.source();

--- a/nextest-runner/default-config.toml
+++ b/nextest-runner/default-config.toml
@@ -97,6 +97,11 @@ slow-timeout = { period = "60s" }
 # See <https://nexte.st/docs/features/leaky-tests> for more information.
 leak-timeout = "100ms"
 
+# Stop all tests after the configured global timeout.
+# Defaults to 30 year, which is a large enough value to feel "infinite" without
+# running into overflows on various platforms.
+global-timeout = "30y"
+
 # `nextest archive` automatically includes any build output required by a standard build.
 # However sometimes extra non-standard files are required.
 # To address this, "archive.include" specifies additional paths that will be included in the archive.

--- a/nextest-runner/src/config/global_timeout.rs
+++ b/nextest-runner/src/config/global_timeout.rs
@@ -1,0 +1,120 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use serde::{Deserialize, Deserializer};
+use std::time::Duration;
+
+/// Type for the global-timeout config key.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GlobalTimeout {
+    pub(crate) period: Duration,
+}
+
+impl<'de> Deserialize<'de> for GlobalTimeout {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(GlobalTimeout {
+            period: humantime_serde::deserialize(deserializer)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{
+        NextestConfig,
+        test_helpers::{build_platforms, temp_workspace},
+    };
+    use camino_tempfile::tempdir;
+    use indoc::indoc;
+    use nextest_filtering::ParseContext;
+    use test_case::test_case;
+
+    #[test_case(
+        "",
+        Ok(GlobalTimeout { period: Duration::from_secs(946728000) }),
+        None
+
+        ; "empty config is expected to use the hardcoded values"
+    )]
+    #[test_case(
+        indoc! {r#"
+            [profile.default]
+            global-timeout = "30s"
+        "#},
+        Ok(GlobalTimeout { period: Duration::from_secs(30) }),
+        None
+
+        ; "overrides the default profile"
+    )]
+    #[test_case(
+        indoc! {r#"
+            [profile.default]
+            global-timeout = "30s"
+
+            [profile.ci]
+            global-timeout = "60s"
+        "#},
+        Ok(GlobalTimeout { period: Duration::from_secs(30) }),
+        Some(GlobalTimeout { period: Duration::from_secs(60) })
+
+        ; "adds a custom profile 'ci'"
+    )]
+    fn globaltimeout_adheres_to_hierarchy(
+        config_contents: &str,
+        expected_default: Result<GlobalTimeout, &str>,
+        maybe_expected_ci: Option<GlobalTimeout>,
+    ) {
+        let workspace_dir = tempdir().unwrap();
+
+        let graph = temp_workspace(&workspace_dir, config_contents);
+
+        let pcx = ParseContext::new(&graph);
+
+        let nextest_config_result = NextestConfig::from_sources(
+            graph.workspace().root(),
+            &pcx,
+            None,
+            &[][..],
+            &Default::default(),
+        );
+
+        match expected_default {
+            Ok(expected_default) => {
+                let nextest_config = nextest_config_result.expect("config file should parse");
+
+                assert_eq!(
+                    nextest_config
+                        .profile("default")
+                        .expect("default profile should exist")
+                        .apply_build_platforms(&build_platforms())
+                        .global_timeout(),
+                    expected_default,
+                );
+
+                if let Some(expected_ci) = maybe_expected_ci {
+                    assert_eq!(
+                        nextest_config
+                            .profile("ci")
+                            .expect("ci profile should exist")
+                            .apply_build_platforms(&build_platforms())
+                            .global_timeout(),
+                        expected_ci,
+                    );
+                }
+            }
+
+            Err(expected_err_str) => {
+                let err_str = format!("{:?}", nextest_config_result.unwrap_err());
+
+                assert!(
+                    err_str.contains(expected_err_str),
+                    "expected error string not found: {err_str}",
+                )
+            }
+        }
+    }
+}

--- a/nextest-runner/src/config/mod.rs
+++ b/nextest-runner/src/config/mod.rs
@@ -21,6 +21,7 @@
 
 mod archive;
 mod config_impl;
+mod global_timeout;
 mod helpers;
 mod identifier;
 mod junit;
@@ -40,6 +41,7 @@ mod track_default;
 
 pub use archive::*;
 pub use config_impl::*;
+pub use global_timeout::*;
 pub use identifier::*;
 pub use junit::*;
 pub use leak_timeout::*;

--- a/nextest-runner/src/config/slow_timeout.rs
+++ b/nextest-runner/src/config/slow_timeout.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use crate::time::far_future_duration;
 use serde::{Deserialize, de::IntoDeserializer};
 use std::{fmt, num::NonZeroUsize, time::Duration};
 
@@ -19,8 +20,7 @@ pub struct SlowTimeout {
 impl SlowTimeout {
     /// A reasonable value for "maximum slow timeout".
     pub(crate) const VERY_LARGE: Self = Self {
-        // See far_future() in pausable_sleep.rs for why this is roughly 30 years.
-        period: Duration::from_secs(86400 * 365 * 30),
+        period: far_future_duration(),
         terminate_after: None,
         grace_period: Duration::from_secs(10),
     };

--- a/nextest-runner/src/reporter/displayer/progress.rs
+++ b/nextest-runner/src/reporter/displayer/progress.rs
@@ -482,6 +482,7 @@ fn progress_bar_cancel_prefix(reason: CancelReason, styles: &Styles) -> String {
         CancelReason::SetupScriptFailure
         | CancelReason::TestFailure
         | CancelReason::ReportError
+        | CancelReason::GlobalTimeout
         | CancelReason::Signal
         | CancelReason::Interrupt => "Cancelling",
         CancelReason::SecondSignal => "Killing",

--- a/nextest-runner/src/reporter/events.rs
+++ b/nextest-runner/src/reporter/events.rs
@@ -904,6 +904,9 @@ pub enum CancelReason {
     /// An error occurred while reporting results.
     ReportError,
 
+    /// The global timeout was exceeded.
+    GlobalTimeout,
+
     /// A termination signal (on Unix, SIGTERM or SIGHUP) was received.
     Signal,
 
@@ -922,6 +925,7 @@ impl CancelReason {
             CancelReason::ReportError => "reporting error",
             CancelReason::Signal => "signal",
             CancelReason::Interrupt => "interrupt",
+            CancelReason::GlobalTimeout => "timeout",
             CancelReason::SecondSignal => "second signal",
         }
     }

--- a/nextest-runner/src/runner/imp.rs
+++ b/nextest-runner/src/runner/imp.rs
@@ -255,6 +255,7 @@ impl<'a> TestRunnerInner<'a> {
             self.cli_args.clone(),
             self.test_list.run_count(),
             self.max_fail,
+            self.profile.global_timeout().period,
         );
 
         let executor_cx = ExecutorContext::new(

--- a/nextest-runner/src/time/pausable_sleep.rs
+++ b/nextest-runner/src/time/pausable_sleep.rs
@@ -126,11 +126,15 @@ enum SleepPauseState {
 
 // Cribbed from tokio.
 fn far_future() -> Instant {
+    Instant::now() + far_future_duration()
+}
+
+pub(crate) const fn far_future_duration() -> Duration {
     // Roughly 30 years from now.
     // API does not provide a way to obtain max `Instant`
     // or convert specific date in the future to instant.
     // 1000 years overflows on macOS, 100 years overflows on FreeBSD.
-    Instant::now() + Duration::from_secs(86400 * 365 * 30)
+    Duration::from_secs(86400 * 365 * 30)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The global-timeout option gives an upper bound to how long a test run can last. When this limit is reached, the run is cancelled (similar to sending a signal to the process) and the results we got so far are displayed.

This is an implementation of the feature discussed in https://github.com/nextest-rs/nextest/discussions/1898.