### PR TITLE
[ci] add a 60s test timeout

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -24,6 +24,7 @@ setup = "build-seed-archive"
 [profile.ci]
 # Don't fail fast in CI to run the full test suite.
 fail-fast = false
+slow-timeout = { period = "60s", terminate-after = 1 }
 
 [profile.ci.junit]
 path = 'junit.xml'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,7 +2206,6 @@ dependencies = [
  "tokio",
  "toml_edit",
  "tracing-core",
- "tracing-subscriber",
  "windows-sys 0.52.0",
  "windows-sys 0.59.0",
  "xxhash-rust",

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -147,6 +147,7 @@ pretty_assertions.workspace = true
 proptest.workspace = true
 test-strategy.workspace = true
 test-case.workspace = true
+tracing-subscriber.workspace = true
 
 [[bin]]
 name = "passthrough"

--- a/nextest-runner/tests/integration/basic.rs
+++ b/nextest-runner/tests/integration/basic.rs
@@ -35,7 +35,7 @@ use test_case::test_case;
 
 #[test]
 fn test_list_binaries() -> Result<()> {
-    set_env_vars();
+    test_init();
 
     let graph = &*PACKAGE_GRAPH;
     let build_platforms = BuildPlatforms::new_with_no_target()?;
@@ -70,7 +70,7 @@ fn test_list_binaries() -> Result<()> {
 
 #[test]
 fn test_list_tests() -> Result<()> {
-    set_env_vars();
+    test_init();
 
     let test_filter = TestFilterBuilder::default_set(RunIgnored::Default);
     let test_list = FIXTURE_TARGETS.make_test_list(
@@ -116,7 +116,7 @@ fn test_list_tests() -> Result<()> {
 
 #[test]
 fn test_run() -> Result<()> {
-    set_env_vars();
+    test_init();
 
     let test_filter = TestFilterBuilder::default_set(RunIgnored::Default);
     let test_list = FIXTURE_TARGETS.make_test_list(
@@ -240,7 +240,7 @@ fn test_run() -> Result<()> {
 
 #[test]
 fn test_run_ignored() -> Result<()> {
-    set_env_vars();
+    test_init();
 
     let pcx = ParseContext::new(&PACKAGE_GRAPH);
     let expr = Filterset::parse(
@@ -340,7 +340,7 @@ fn test_run_ignored() -> Result<()> {
 /// Test that filtersets with regular substring filters behave as expected.
 #[test]
 fn test_filter_expr_with_string_filters() -> Result<()> {
-    set_env_vars();
+    test_init();
 
     let pcx = ParseContext::new(&PACKAGE_GRAPH);
     let expr = Filterset::parse(
@@ -412,7 +412,7 @@ fn test_filter_expr_with_string_filters() -> Result<()> {
 /// Test that filtersets without regular substring filters behave as expected.
 #[test]
 fn test_filter_expr_without_string_filters() -> Result<()> {
-    set_env_vars();
+    test_init();
 
     let pcx = ParseContext::new(&PACKAGE_GRAPH);
     let expr = Filterset::parse(
@@ -453,7 +453,7 @@ fn test_filter_expr_without_string_filters() -> Result<()> {
 
 #[test]
 fn test_string_filters_without_filter_expr() -> Result<()> {
-    set_env_vars();
+    test_init();
 
     let test_filter = TestFilterBuilder::new(
         RunIgnored::Default,
@@ -498,7 +498,7 @@ fn test_string_filters_without_filter_expr() -> Result<()> {
     ; "retry overrides ignored"
 )]
 fn test_retries(retries: Option<RetryPolicy>) -> Result<()> {
-    set_env_vars();
+    test_init();
 
     let test_filter = TestFilterBuilder::default_set(RunIgnored::Default);
     let test_list = FIXTURE_TARGETS.make_test_list(
@@ -663,7 +663,7 @@ fn test_retries(retries: Option<RetryPolicy>) -> Result<()> {
 
 #[test]
 fn test_termination() -> Result<()> {
-    set_env_vars();
+    test_init();
 
     let pcx = ParseContext::new(&PACKAGE_GRAPH);
     let expr = Filterset::parse(

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -154,7 +154,11 @@ pub(crate) fn ensure_execution_result(
 }
 
 #[track_caller]
-pub(crate) fn set_env_vars() {
+pub(crate) fn test_init() {
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::DEBUG)
+        .init();
+
     // The dynamic library tests require this flag.
     // SAFETY:
     // https://nexte.st/docs/configuration/env-vars/#altering-the-environment-within-tests

--- a/nextest-runner/tests/integration/target_runner.rs
+++ b/nextest-runner/tests/integration/target_runner.rs
@@ -50,7 +50,7 @@ fn runner_for_target(triple: Option<&str>) -> Result<(BuildPlatforms, TargetRunn
 
 #[test]
 fn parses_cargo_env() {
-    set_env_vars();
+    test_init();
     // SAFETY:
     // https://nexte.st/docs/configuration/env-vars/#altering-the-environment-within-tests
     unsafe { std::env::set_var(current_runner_env_var(), "cargo_with_default --arg --arg2") };
@@ -188,7 +188,7 @@ fn current_runner_env_var() -> String {
 
 #[test]
 fn test_listing_with_target_runner() -> Result<()> {
-    set_env_vars();
+    test_init();
 
     let test_filter = TestFilterBuilder::default_set(RunIgnored::Default);
     let test_list = FIXTURE_TARGETS.make_test_list(
@@ -233,7 +233,7 @@ fn test_listing_with_target_runner() -> Result<()> {
 
 #[test]
 fn test_run_with_target_runner() -> Result<()> {
-    set_env_vars();
+    test_init();
 
     let test_filter = TestFilterBuilder::default_set(RunIgnored::Default);
 

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -42,7 +42,6 @@ target-spec-miette = { version = "0.4.4", default-features = false, features = [
 tokio = { version = "1.46.1", features = ["fs", "io-std", "io-util", "macros", "process", "rt-multi-thread", "signal", "sync", "time", "tracing"] }
 toml_edit = { version = "0.22.27", features = ["serde"] }
 tracing-core = { version = "0.1.33" }
-tracing-subscriber = { version = "0.3.19", default-features = false, features = ["fmt", "tracing-log"] }
 xxhash-rust = { version = "0.8.15", default-features = false, features = ["xxh3", "xxh64"] }
 
 [build-dependencies]


### PR DESCRIPTION
According to [this log] and https://github.com/nextest-rs/nextest/discussions/2458, we seem to be timing tests out in a way that's quite concerning. Add a per-test timeout to see if this can be repro'd.


[this log]: https://buildomat.eng.oxide.computer/wg/0/details/01JZVTRXR8AJWRZVDES5QK9J0K/esYopA09hCnsAeXx3gX7e5wdUJV5qOSWgyxvebirpHLEZVsy/01JZVTSDCJC5N7A41FAXAQX0WB