### PR TITLE
[meta] set far-future durations to 1 year instead

### DIFF
--- a/nextest-runner/src/config/slow_timeout.rs
+++ b/nextest-runner/src/config/slow_timeout.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::time::far_future_duration;
+use crate::time::one_year_duration;
 use serde::{Deserialize, de::IntoDeserializer};
 use std::{fmt, num::NonZeroUsize, time::Duration};
 
@@ -20,7 +20,7 @@ pub struct SlowTimeout {
 impl SlowTimeout {
     /// A reasonable value for "maximum slow timeout".
     pub(crate) const VERY_LARGE: Self = Self {
-        period: far_future_duration(),
+        period: one_year_duration(),
         terminate_after: None,
         grace_period: Duration::from_secs(10),
     };

--- a/nextest-runner/src/runner/dispatcher.rs
+++ b/nextest-runner/src/runner/dispatcher.rs
@@ -947,7 +947,7 @@ mod tests {
             vec![],
             0,
             MaxFail::All,
-            crate::time::far_future_duration(),
+            crate::time::one_year_duration(),
         );
 
         cx.disable_signal_3_times_panic = true;

--- a/nextest-runner/src/time/pausable_sleep.rs
+++ b/nextest-runner/src/time/pausable_sleep.rs
@@ -40,7 +40,7 @@ impl PausableSleep {
             SleepPauseState::Running => {
                 // Figure out how long there is until the deadline.
                 let deadline = this.sleep.deadline();
-                this.sleep.reset(far_future());
+                this.sleep.reset(one_year());
                 // This will return 0 if the deadline has passed. That's fine because we'll just
                 // reset the timer back to 0 in resume, which will behave correctly.
                 let remaining = deadline.duration_since(Instant::now());
@@ -124,17 +124,14 @@ enum SleepPauseState {
     Paused { remaining: Duration },
 }
 
-// Cribbed from tokio.
-fn far_future() -> Instant {
-    Instant::now() + far_future_duration()
+fn one_year() -> Instant {
+    Instant::now() + one_year_duration()
 }
 
-pub(crate) const fn far_future_duration() -> Duration {
-    // Roughly 30 years from now.
-    // API does not provide a way to obtain max `Instant`
-    // or convert specific date in the future to instant.
-    // 1000 years overflows on macOS, 100 years overflows on FreeBSD.
-    Duration::from_secs(86400 * 365 * 30)
+pub(crate) const fn one_year_duration() -> Duration {
+    // 365 days from now. Tokio's timer wheel's top level goes to 2 years, so 1
+    // year is half of that which should be suitable for this use case.
+    Duration::from_secs(86400 * 365)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
A possible but unlikely cause behind https://github.com/nextest-rs/nextest/discussions/2458 -- set these durations to be 1 year long to be half of Tokio's max timer wheel resolution. Hopefully no one will leave a copy of nextest suspended for a whole year.