### PR TITLE
[nextest-runner] add --verbose --verbose to cargo command execution + run tests

### DIFF
--- a/.github/buildomat/build-and-test.sh
+++ b/.github/buildomat/build-and-test.sh
@@ -38,7 +38,8 @@ banner doctests
 ptime -m cargo test --doc
 
 banner local-nt
-ptime -m cargo local-nt run --profile ci
+# Run tests in a loop until failure.
+while cargo local-nt run --profile ci; do sleep 1; rm -r fixtures/nextest-tests/target && echo "Running tests"; done
 
 banner release
 ptime -m cargo nextest run --profile ci

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -260,6 +260,8 @@ fn init_fixture_raw_cargo_test_output() -> Vec<u8> {
         "--message-format",
         "json-render-diagnostics",
         "--all-targets",
+        "--verbose",
+        "--verbose",
     )
     // This environment variable is required to test the #[bench] fixture. Note that THIS IS FOR
     // TEST CODE ONLY. NEVER USE THIS IN PRODUCTION.


### PR DESCRIPTION
See #2463 -- this might be a hang in Cargo similar to
rust-lang/cargo#15032. Try running cargo with
`--verbose --verbose`.