### PR TITLE
Make `--reporter libtest-json-plus` output test results immediately

### DIFF
--- a/nextest-runner/src/reporter/error_description.rs
+++ b/nextest-runner/src/reporter/error_description.rs
@@ -340,7 +340,7 @@ fn heuristic_error_str(stderr: &[u8]) -> Option<ByteSubslice<'_>> {
 
 // This regex works for the default panic handler for Rust -- other panic handlers may not work,
 // which is why this is heuristic.
-static PANICKED_AT_REGEX_STR: &str = "^thread '([^']+)' panicked at ";
+static PANICKED_AT_REGEX_STR: &str = "^thread '([^']+)' (\\(\\d+\\) )?panicked at ";
 static PANICKED_AT_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     let mut builder = RegexBuilder::new(PANICKED_AT_REGEX_STR);
     builder.multi_line(true);

--- a/nextest-runner/src/reporter/structured/libtest.rs
+++ b/nextest-runner/src/reporter/structured/libtest.rs
@@ -431,10 +431,10 @@ impl<'cfg> LibtestReporter<'cfg> {
             stdout.flush().map_err(WriteEventError::Io)?;
             out.clear();
 
-            if test_suite.running == 0
-                && let Some(test_suite) = self.test_suites.remove(suite_info.binary_id.as_str())
-            {
-                self.finalize(test_suite)?;
+            if test_suite.running == 0 {
+                if let Some(test_suite) = self.test_suites.remove(suite_info.binary_id.as_str()) {
+                    self.finalize(test_suite)?;
+                }
             }
         } else {
             // If this is the last test of the suite, emit the test suite summary

--- a/nextest-runner/src/reporter/structured/libtest.rs
+++ b/nextest-runner/src/reporter/structured/libtest.rs
@@ -423,14 +423,29 @@ impl<'cfg> LibtestReporter<'cfg> {
 
         out.extend_from_slice(b"}\n");
 
-        // If this is the last test of the suite, emit the test suite summary
-        // before emitting the entire block
-        if test_suite.running > 0 {
-            return Ok(());
-        }
+        if self.emit_nextest_obj {
+            use std::io::Write as _;
 
-        if let Some(test_suite) = self.test_suites.remove(suite_info.binary_id.as_str()) {
-            self.finalize(test_suite)?;
+            let mut stdout = std::io::stdout().lock();
+            stdout.write_all(out).map_err(WriteEventError::Io)?;
+            stdout.flush().map_err(WriteEventError::Io)?;
+            out.clear();
+
+            if test_suite.running == 0
+                && let Some(test_suite) = self.test_suites.remove(suite_info.binary_id.as_str())
+            {
+                self.finalize(test_suite)?;
+            }
+        } else {
+            // If this is the last test of the suite, emit the test suite summary
+            // before emitting the entire block
+            if test_suite.running > 0 {
+                return Ok(());
+            }
+
+            if let Some(test_suite) = self.test_suites.remove(suite_info.binary_id.as_str()) {
+                self.finalize(test_suite)?;
+            }
         }
 
         Ok(())

--- a/nextest-runner/src/reporter/structured/libtest.rs
+++ b/nextest-runner/src/reporter/structured/libtest.rs
@@ -424,12 +424,14 @@ impl<'cfg> LibtestReporter<'cfg> {
         out.extend_from_slice(b"}\n");
 
         if self.emit_nextest_obj {
-            use std::io::Write as _;
+            {
+                use std::io::Write as _;
 
-            let mut stdout = std::io::stdout().lock();
-            stdout.write_all(out).map_err(WriteEventError::Io)?;
-            stdout.flush().map_err(WriteEventError::Io)?;
-            out.clear();
+                let mut stdout = std::io::stdout().lock();
+                stdout.write_all(out).map_err(WriteEventError::Io)?;
+                stdout.flush().map_err(WriteEventError::Io)?;
+                out.clear();
+            }
 
             if test_suite.running == 0 {
                 if let Some(test_suite) = self.test_suites.remove(suite_info.binary_id.as_str()) {


### PR DESCRIPTION
Given that it is possible to distinguish between different suites in the structured reporter through the `nextest` property, this patch outputs test results as soon as they happen, when using `--reporter libtest-json-plus`.

`--reporter libtest-json` output is unaffected.

Maybe fixes #1256 ?