### PR TITLE
Add support for silencing only one of the outputs of a test (cont.)

### DIFF
--- a/cargo-nextest/src/dispatch.rs
+++ b/cargo-nextest/src/dispatch.rs
@@ -37,6 +37,7 @@ use nextest_runner::{
     redact::Redactor,
     reporter::{
         FinalStatusLevel, ReporterBuilder, StatusLevel, TestOutputDisplay, TestOutputErrorSlice,
+        displayer::TestOutputDisplayStreams,
         events::{FinalRunStats, RunStatsFailureKind},
         highlight_end, structured,
     },
@@ -57,6 +58,7 @@ use std::{
     env::VarError,
     fmt,
     io::{Cursor, Write},
+    str::FromStr,
     sync::{Arc, OnceLock},
 };
 use swrite::{SWrite, swrite};
@@ -973,13 +975,19 @@ enum MessageFormat {
 #[derive(Debug, Default, Args)]
 #[command(next_help_heading = "Reporter options")]
 struct ReporterOpts {
-    /// Output stdout and stderr on failure
+    /// Output stdout and/or stderr on failure
+    ///
+    /// Takes the form of: '{value}' or 'stdout={value}' or 'stdout={value},stderr={value}'
+    /// where {value} is one of: 'immediate', 'immediate-final', 'final', 'never'
     #[arg(long, value_enum, value_name = "WHEN", env = "NEXTEST_FAILURE_OUTPUT")]
-    failure_output: Option<TestOutputDisplayOpt>,
+    failure_output: Option<TestOutputDisplayStreamsOpt>,
 
-    /// Output stdout and stderr on success
+    /// Output stdout and/or stderr on success
+    ///
+    /// Takes the form of: '{value}' or 'stdout={value}' or 'stdout={value},stderr={value}'
+    /// where {value} is one of: 'immediate', 'immediate-final', 'final', 'never'
     #[arg(long, value_enum, value_name = "WHEN", env = "NEXTEST_SUCCESS_OUTPUT")]
-    success_output: Option<TestOutputDisplayOpt>,
+    success_output: Option<TestOutputDisplayStreamsOpt>,
 
     // status_level does not conflict with --no-capture because pass vs skip still makes sense.
     /// Test statuses to output
@@ -1095,6 +1103,68 @@ impl ReporterOpts {
         builder.set_hide_progress_bar(self.hide_progress_bar);
         builder.set_no_output_indent(self.no_output_indent);
         builder
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TestOutputDisplayStreamsOpt {
+    stdout: Option<TestOutputDisplayOpt>,
+    stderr: Option<TestOutputDisplayOpt>,
+}
+
+impl FromStr for TestOutputDisplayStreamsOpt {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // expected input has three forms
+        // - "{value}":                         where value is one of [immediate, immediate-final, final, never]
+        // - "{stream}={value}":                where {stream} is one of [stdout, stderr]
+        // - "{stream}={value},{stream=value}": where the two {stream} keys cannot be the same
+        let (stdout, stderr) = if let Some((left, right)) = s.split_once(',') {
+            // the "{stream}={value},{stream=value}" case
+            let left = left
+                .split_once('=')
+                .map(|l| (l.0, TestOutputDisplayOpt::from_str(l.1, false)));
+            let right = right
+                .split_once('=')
+                .map(|r| (r.0, TestOutputDisplayOpt::from_str(r.1, false)));
+            match (left, right) {
+                (Some(("stderr", Ok(stderr))), Some(("stdout", Ok(stdout)))) => (Some(stdout), Some(stderr)),
+                (Some(("stdout", Ok(stdout))), Some(("stderr", Ok(stderr)))) => (Some(stdout), Some(stderr)),
+                (Some((stream @ "stdout" | stream @ "stderr", Err(_))), _) => return Err(format!("\n  unrecognized setting for {stream}: [possible values: immediate, immediate-final, final, never]")),
+                (_, Some((stream @ "stdout" | stream @ "stderr", Err(_)))) => return Err(format!("\n  unrecognized setting for {stream}: [possible values: immediate, immediate-final, final, never]")),
+                (Some(("stdout", _)), Some(("stdout", _))) => return Err("\n  stdout specified twice".to_string()),
+                (Some(("stderr", _)), Some(("stderr", _))) => return Err("\n  stderr specified twice".to_string()),
+                (Some((stream, _)), Some(("stdout" | "stderr", _))) => return Err(format!("\n  unrecognized output stream '{stream}': [possible values: stdout, stderr]")),
+                (Some(("stdout" | "stderr", _)), Some((stream, _))) => return Err(format!("\n  unrecognized output stream '{stream}': [possible values: stdout, stderr]")),
+                (_, _) => return Err("\n  [possible values: immediate, immediate-final, final, never], or specify one or both output streams: stdout={}, stderr={}, stdout={},stderr={}".to_string()),
+            }
+        } else if let Some((stream, right)) = s.split_once('=') {
+            // the "{stream}={value}" case
+            let value = TestOutputDisplayOpt::from_str(right, false);
+            match (stream, value) {
+                ("stderr", Ok(stderr)) => (None, Some(stderr)),
+                ("stdout", Ok(stdout)) => (Some(stdout), None),
+                ("stdout" | "stderr", Err(_)) => return Err(format!("\n  unrecognized setting for {stream}: [possible values: immediate, immediate-final, final, never]")),
+                (_, _) => return Err("\n  unrecognized output stream, possible values: [stdout={}, stderr={}, stdout={},stderr={}]".to_string())
+            }
+        } else if let Ok(value) = TestOutputDisplayOpt::from_str(s, false) {
+            // the "{value}" case
+            (Some(value), Some(value))
+        } else {
+            // did not recognize one of the three cases
+            return Err("\n  [possible values: immediate, immediate-final, final, never], or specify one or both output streams: stdout={}, stderr={}, stdout={},stderr={}".to_string());
+        };
+        Ok(Self { stdout, stderr })
+    }
+}
+
+impl From<TestOutputDisplayStreamsOpt> for TestOutputDisplayStreams {
+    fn from(value: TestOutputDisplayStreamsOpt) -> Self {
+        Self {
+            stdout: value.stdout.map(TestOutputDisplay::from),
+            stderr: value.stderr.map(TestOutputDisplay::from),
+        }
     }
 }
 

--- a/nextest-runner/src/config/core/imp.rs
+++ b/nextest-runner/src/config/core/imp.rs
@@ -28,7 +28,9 @@ use crate::{
     helpers::plural,
     list::TestList,
     platform::BuildPlatforms,
-    reporter::{FinalStatusLevel, StatusLevel, TestOutputDisplay},
+    reporter::{
+        FinalStatusLevel, StatusLevel, TestOutputDisplay, displayer::TestOutputDisplayStreams,
+    },
 };
 use camino::{Utf8Path, Utf8PathBuf};
 use config::{
@@ -1049,14 +1051,14 @@ impl<'cfg> EvaluatableProfile<'cfg> {
     }
 
     /// Returns the failure output config for this profile.
-    pub fn failure_output(&self) -> TestOutputDisplay {
+    pub fn failure_output(&self) -> TestOutputDisplayStreams {
         self.custom_profile
             .and_then(|profile| profile.failure_output)
             .unwrap_or(self.default_profile.failure_output)
     }
 
     /// Returns the failure output config for this profile.
-    pub fn success_output(&self) -> TestOutputDisplay {
+    pub fn success_output(&self) -> TestOutputDisplayStreams {
         self.custom_profile
             .and_then(|profile| profile.success_output)
             .unwrap_or(self.default_profile.success_output)
@@ -1225,8 +1227,8 @@ pub(in crate::config) struct DefaultProfileImpl {
     retries: RetryPolicy,
     status_level: StatusLevel,
     final_status_level: FinalStatusLevel,
-    failure_output: TestOutputDisplay,
-    success_output: TestOutputDisplay,
+    failure_output: TestOutputDisplayStreams,
+    success_output: TestOutputDisplayStreams,
     max_fail: MaxFail,
     slow_timeout: SlowTimeout,
     global_timeout: GlobalTimeout,
@@ -1314,9 +1316,9 @@ pub(in crate::config) struct CustomProfileImpl {
     #[serde(default)]
     final_status_level: Option<FinalStatusLevel>,
     #[serde(default)]
-    failure_output: Option<TestOutputDisplay>,
+    failure_output: Option<TestOutputDisplayStreams>,
     #[serde(default)]
-    success_output: Option<TestOutputDisplay>,
+    success_output: Option<TestOutputDisplayStreams>,
     #[serde(
         default,
         rename = "fail-fast",

--- a/nextest-runner/src/reporter/displayer/status_level.rs
+++ b/nextest-runner/src/reporter/displayer/status_level.rs
@@ -6,7 +6,10 @@
 //! Status levels play a role that's similar to log levels in typical loggers.
 
 use super::TestOutputDisplay;
-use crate::reporter::events::CancelReason;
+use crate::reporter::{
+    displayer::{DisplayOutput, TestOutputDisplayStreams},
+    events::CancelReason,
+};
 use serde::Deserialize;
 
 /// Status level to show in the reporter output.
@@ -89,17 +92,18 @@ pub(crate) struct StatusLevels {
 impl StatusLevels {
     pub(super) fn compute_output_on_test_finished(
         &self,
-        display: TestOutputDisplay,
+        display: TestOutputDisplayStreams,
         cancel_status: Option<CancelReason>,
         test_status_level: StatusLevel,
         test_final_status_level: FinalStatusLevel,
     ) -> OutputOnTestFinished {
         let write_status_line = self.status_level >= test_status_level;
 
-        let is_immediate = display.is_immediate();
+        let is_immediate = display.display_output_immediate();
         // We store entries in the final output map if either the final status level is high enough or
         // if `display` says we show the output at the end.
-        let is_final = display.is_final() || self.final_status_level >= test_final_status_level;
+        let is_final = display.display_output_final().is_some()
+            || self.final_status_level >= test_final_status_level;
 
         // This table is tested below. The basic invariant is that we generally follow what
         // is_immediate and is_final suggests, except:
@@ -124,19 +128,24 @@ impl StatusLevels {
         //
         // [2] If there's a signal, we shouldn't display output twice at the end since it's
         // redundant -- instead, just show the output as part of the immediate display.
-        let show_immediate = is_immediate && cancel_status <= Some(CancelReason::Signal);
+        let show_immediate = if cancel_status <= Some(CancelReason::Signal) {
+            is_immediate
+        } else {
+            None
+        };
 
         let store_final = if is_final && cancel_status < Some(CancelReason::Signal)
-            || !is_immediate && is_final && cancel_status == Some(CancelReason::Signal)
+            || is_immediate.is_none() && is_final && cancel_status == Some(CancelReason::Signal)
         {
             OutputStoreFinal::Yes {
-                display_output: display.is_final(),
+                display_output: display.display_output_final(),
             }
-        } else if is_immediate && is_final && cancel_status == Some(CancelReason::Signal) {
+        } else if is_immediate.is_some() && is_final && cancel_status == Some(CancelReason::Signal)
+        {
             // In this special case, we already display the output once as the test is being
             // cancelled, so don't display it again at the end since that's redundant.
             OutputStoreFinal::Yes {
-                display_output: false,
+                display_output: None,
             }
         } else {
             OutputStoreFinal::No
@@ -153,7 +162,7 @@ impl StatusLevels {
 #[derive(Debug, PartialEq, Eq)]
 pub(super) struct OutputOnTestFinished {
     pub(super) write_status_line: bool,
-    pub(super) show_immediate: bool,
+    pub(super) show_immediate: Option<DisplayOutput>,
     pub(super) store_final: OutputStoreFinal,
 }
 
@@ -164,7 +173,9 @@ pub(super) enum OutputStoreFinal {
 
     /// Store the output. display_output controls whether stdout and stderr should actually be
     /// displayed at the end.
-    Yes { display_output: bool },
+    Yes {
+        display_output: Option<DisplayOutput>,
+    },
 }
 
 #[cfg(test)]
@@ -179,7 +190,7 @@ mod tests {
 
     #[proptest(cases = 64)]
     fn on_test_finished_dont_write_status_line(
-        display: TestOutputDisplay,
+        display: TestOutputDisplayStreams,
         cancel_status: Option<CancelReason>,
         #[filter(StatusLevel::Pass < #test_status_level)] test_status_level: StatusLevel,
         test_final_status_level: FinalStatusLevel,
@@ -201,7 +212,7 @@ mod tests {
 
     #[proptest(cases = 64)]
     fn on_test_finished_write_status_line(
-        display: TestOutputDisplay,
+        display: TestOutputDisplayStreams,
         cancel_status: Option<CancelReason>,
         #[filter(StatusLevel::Pass >= #test_status_level)] test_status_level: StatusLevel,
         test_final_status_level: FinalStatusLevel,
@@ -223,7 +234,7 @@ mod tests {
     #[proptest(cases = 64)]
     fn on_test_finished_with_interrupt(
         // We always hide output on interrupt.
-        display: TestOutputDisplay,
+        display: TestOutputDisplayStreams,
         // cancel_status is fixed to Interrupt.
 
         // In this case, the status levels are not relevant for is_immediate and is_final.
@@ -241,13 +252,13 @@ mod tests {
             test_status_level,
             test_final_status_level,
         );
-        assert!(!actual.show_immediate);
+        assert!(actual.show_immediate.is_none());
         assert_eq!(actual.store_final, OutputStoreFinal::No);
     }
 
     #[proptest(cases = 64)]
     fn on_test_finished_dont_show_immediate(
-        #[filter(!#display.is_immediate())] display: TestOutputDisplay,
+        #[filter(#display.display_output_immediate().is_none())] display: TestOutputDisplayStreams,
         cancel_status: Option<CancelReason>,
         // The status levels are not relevant for show_immediate.
         test_status_level: StatusLevel,
@@ -264,12 +275,12 @@ mod tests {
             test_status_level,
             test_final_status_level,
         );
-        assert!(!actual.show_immediate);
+        assert!(actual.show_immediate.is_none());
     }
 
     #[proptest(cases = 64)]
     fn on_test_finished_show_immediate(
-        #[filter(#display.is_immediate())] display: TestOutputDisplay,
+        #[filter(#display.display_output_immediate().is_none())] display: TestOutputDisplayStreams,
         #[filter(#cancel_status <= Some(CancelReason::Signal))] cancel_status: Option<CancelReason>,
         // The status levels are not relevant for show_immediate.
         test_status_level: StatusLevel,
@@ -286,14 +297,14 @@ mod tests {
             test_status_level,
             test_final_status_level,
         );
-        assert!(actual.show_immediate);
+        assert!(actual.show_immediate.is_some());
     }
 
     // Where we don't store final output: if display.is_final() is false, and if the test final
     // status level is too high.
     #[proptest(cases = 64)]
     fn on_test_finished_dont_store_final(
-        #[filter(!#display.is_final())] display: TestOutputDisplay,
+        #[filter(#display.display_output_final().is_none())] display: TestOutputDisplayStreams,
         cancel_status: Option<CancelReason>,
         // The status level is not relevant for store_final.
         test_status_level: StatusLevel,
@@ -330,7 +341,7 @@ mod tests {
         };
 
         let actual = status_levels.compute_output_on_test_finished(
-            TestOutputDisplay::Final,
+            TestOutputDisplayStreams::create_final(),
             cancel_status,
             test_status_level,
             test_final_status_level,
@@ -338,7 +349,10 @@ mod tests {
         assert_eq!(
             actual.store_final,
             OutputStoreFinal::Yes {
-                display_output: true
+                display_output: Some(DisplayOutput {
+                    stdout: true,
+                    stderr: true,
+                })
             }
         );
     }
@@ -357,7 +371,7 @@ mod tests {
         };
 
         let actual = status_levels.compute_output_on_test_finished(
-            TestOutputDisplay::ImmediateFinal,
+            TestOutputDisplayStreams::create_immediate_final(),
             cancel_status,
             test_status_level,
             test_final_status_level,
@@ -365,7 +379,7 @@ mod tests {
         assert_eq!(
             actual.store_final,
             OutputStoreFinal::Yes {
-                display_output: true
+                display_output: None,
             }
         );
     }
@@ -383,7 +397,7 @@ mod tests {
         };
 
         let actual = status_levels.compute_output_on_test_finished(
-            TestOutputDisplay::ImmediateFinal,
+            TestOutputDisplayStreams::create_immediate_final(),
             Some(CancelReason::Signal),
             test_status_level,
             test_final_status_level,
@@ -391,7 +405,7 @@ mod tests {
         assert_eq!(
             actual.store_final,
             OutputStoreFinal::Yes {
-                display_output: false,
+                display_output: None,
             }
         );
     }
@@ -399,7 +413,7 @@ mod tests {
     // Case 4: if display.is_final() is *false* but the test_final_status_level is low enough.
     #[proptest(cases = 64)]
     fn on_test_finished_store_final_4(
-        #[filter(!#display.is_final())] display: TestOutputDisplay,
+        #[filter(#display.display_output_final().is_none())] display: TestOutputDisplayStreams,
         #[filter(#cancel_status <= Some(CancelReason::Signal))] cancel_status: Option<CancelReason>,
         // The status level is not relevant for store_final.
         test_status_level: StatusLevel,
@@ -421,7 +435,7 @@ mod tests {
         assert_eq!(
             actual.store_final,
             OutputStoreFinal::Yes {
-                display_output: false,
+                display_output: None,
             }
         );
     }

--- a/nextest-runner/src/reporter/events.rs
+++ b/nextest-runner/src/reporter/events.rs
@@ -10,6 +10,7 @@ use super::{FinalStatusLevel, StatusLevel, TestOutputDisplay};
 use crate::{
     config::{elements::LeakTimeoutResult, scripts::ScriptId},
     list::{TestInstance, TestInstanceId, TestList},
+    reporter::displayer::TestOutputDisplayStreams,
     test_output::ChildExecutionOutput,
 };
 use chrono::{DateTime, FixedOffset};
@@ -171,7 +172,7 @@ pub enum TestEventKind<'a> {
         delay_before_next_attempt: Duration,
 
         /// Whether failure outputs are printed out.
-        failure_output: TestOutputDisplay,
+        failure_output: TestOutputDisplayStreams,
     },
 
     /// A retry has started.
@@ -189,10 +190,10 @@ pub enum TestEventKind<'a> {
         test_instance: TestInstance<'a>,
 
         /// Test setting for success output.
-        success_output: TestOutputDisplay,
+        success_output: TestOutputDisplayStreams,
 
         /// Test setting for failure output.
-        failure_output: TestOutputDisplay,
+        failure_output: TestOutputDisplayStreams,
 
         /// Whether the JUnit report should store success output for this test.
         junit_store_success_output: bool,

--- a/nextest-runner/src/reporter/imp.rs
+++ b/nextest-runner/src/reporter/imp.rs
@@ -14,7 +14,10 @@ use crate::{
     config::core::EvaluatableProfile,
     errors::WriteEventError,
     list::TestList,
-    reporter::{aggregator::EventAggregator, events::*, structured::StructuredReporter},
+    reporter::{
+        aggregator::EventAggregator, displayer::TestOutputDisplayStreams, events::*,
+        structured::StructuredReporter,
+    },
 };
 
 /// Standard error destination for the reporter.
@@ -35,8 +38,8 @@ pub enum ReporterStderr<'a> {
 pub struct ReporterBuilder {
     no_capture: bool,
     should_colorize: bool,
-    failure_output: Option<TestOutputDisplay>,
-    success_output: Option<TestOutputDisplay>,
+    failure_output: TestOutputDisplayStreams,
+    success_output: TestOutputDisplayStreams,
     status_level: Option<StatusLevel>,
     final_status_level: Option<FinalStatusLevel>,
 
@@ -62,14 +65,14 @@ impl ReporterBuilder {
     }
 
     /// Sets the conditions under which test failures are output.
-    pub fn set_failure_output(&mut self, failure_output: TestOutputDisplay) -> &mut Self {
-        self.failure_output = Some(failure_output);
+    pub fn set_failure_output(&mut self, failure_output: TestOutputDisplayStreams) -> &mut Self {
+        self.failure_output = failure_output;
         self
     }
 
     /// Sets the conditions under which test successes are output.
-    pub fn set_success_output(&mut self, success_output: TestOutputDisplay) -> &mut Self {
-        self.success_output = Some(success_output);
+    pub fn set_success_output(&mut self, success_output: TestOutputDisplayStreams) -> &mut Self {
+        self.success_output = success_output;
         self
     }
 

--- a/nextest-runner/src/reporter/mod.rs
+++ b/nextest-runner/src/reporter/mod.rs
@@ -6,7 +6,7 @@
 //! The main type here is [`Reporter`], which is constructed via a [`ReporterBuilder`].
 
 mod aggregator;
-mod displayer;
+pub mod displayer;
 mod error_description;
 pub mod events;
 mod helpers;

--- a/nextest-runner/src/runner/internal_events.rs
+++ b/nextest-runner/src/runner/internal_events.rs
@@ -13,6 +13,7 @@ use crate::{
     list::TestInstance,
     reporter::{
         TestOutputDisplay,
+        displayer::TestOutputDisplayStreams,
         events::{
             ExecuteStatus, ExecutionResult, InfoResponse, RetryData, SetupScriptEnvMap,
             SetupScriptExecuteStatus, UnitState,
@@ -85,7 +86,7 @@ pub(super) enum ExecutorEvent<'a> {
     },
     AttemptFailedWillRetry {
         test_instance: TestInstance<'a>,
-        failure_output: TestOutputDisplay,
+        failure_output: TestOutputDisplayStreams,
         run_status: ExecuteStatus,
         delay_before_next_attempt: Duration,
     },
@@ -97,8 +98,8 @@ pub(super) enum ExecutorEvent<'a> {
     },
     Finished {
         test_instance: TestInstance<'a>,
-        success_output: TestOutputDisplay,
-        failure_output: TestOutputDisplay,
+        success_output: TestOutputDisplayStreams,
+        failure_output: TestOutputDisplayStreams,
         junit_store_success_output: bool,
         junit_store_failure_output: bool,
         last_run_status: ExecuteStatus,


### PR DESCRIPTION
A port of the implementation #1707 to resolve the merge conflicts, of which there were many. It currently does not compile, because I'm unfamiliar with the codebase, but it is something.