### PR TITLE
Add a counter to the status line with each test

### DIFF
--- a/integration-tests/tests/integration/fixtures.rs
+++ b/integration-tests/tests/integration/fixtures.rs
@@ -153,13 +153,23 @@ impl CheckResult {
     fn make_status_line_regex(self, name: &str) -> Regex {
         let name = regex::escape(name);
         match self {
-            CheckResult::Pass => Regex::new(&format!(r"PASS \[.*\] *{name}")).unwrap(),
-            CheckResult::Leak => Regex::new(&format!(r"LEAK \[.*\] *{name}")).unwrap(),
-            CheckResult::LeakFail => Regex::new(&format!(r"LEAK-FAIL \[.*\] *{name}")).unwrap(),
-            CheckResult::Fail => Regex::new(&format!(r"FAIL \[.*\] *{name}")).unwrap(),
-            CheckResult::FailLeak => Regex::new(&format!(r"FAIL \+ LEAK \[.*\] *{name}")).unwrap(),
+            CheckResult::Pass => {
+                Regex::new(&format!(r"PASS \[[^\]]+\] \([^\)]+\) *{name}")).unwrap()
+            }
+            CheckResult::Leak => {
+                Regex::new(&format!(r"LEAK \[[^\]]+\] \([^\)]+\) *{name}")).unwrap()
+            }
+            CheckResult::LeakFail => {
+                Regex::new(&format!(r"LEAK-FAIL \[[^\]]+\] \([^\)]+\) *{name}")).unwrap()
+            }
+            CheckResult::Fail => {
+                Regex::new(&format!(r"FAIL \[[^\]]+\] \([^\)]+\) *{name}")).unwrap()
+            }
+            CheckResult::FailLeak => {
+                Regex::new(&format!(r"FAIL \+ LEAK \[[^\]]+\] \([^\)]+\) *{name}")).unwrap()
+            }
             CheckResult::Abort => {
-                Regex::new(&format!(r"(ABORT|SIGSEGV|SIGABRT) \[.*\] *{name}")).unwrap()
+                Regex::new(&format!(r"(ABORT|SIGSEGV|SIGABRT) \[[^\]]+\] *{name}")).unwrap()
             }
         }
     }

--- a/nextest-runner/src/reporter/displayer/mod.rs
+++ b/nextest-runner/src/reporter/displayer/mod.rs
@@ -10,5 +10,6 @@ mod status_level;
 mod unit_output;
 
 pub(crate) use imp::*;
+pub use progress::ShowProgress;
 pub use status_level::*;
 pub use unit_output::*;

--- a/nextest-runner/src/reporter/displayer/progress.rs
+++ b/nextest-runner/src/reporter/displayer/progress.rs
@@ -15,6 +15,23 @@ use std::{
 use swrite::{SWrite, swrite};
 use tracing::debug;
 
+/// How to show progress.
+#[derive(Default, Clone, Copy, Debug)]
+pub enum ShowProgress {
+    /// Automatically decide based on environment.
+    #[default]
+    Auto,
+
+    /// No progress display.
+    None,
+
+    /// Show a progress bar.
+    Bar,
+
+    /// Show a counter on each line.
+    Counter,
+}
+
 #[derive(Debug)]
 pub(super) struct ProgressBarState {
     bar: ProgressBar,
@@ -182,6 +199,10 @@ impl ProgressBarState {
             || self.hidden_run_paused
             || self.hidden_info_response
             || self.hidden_between_sub_runs
+    }
+
+    pub(super) fn is_hidden(&self) -> bool {
+        self.bar.is_hidden()
     }
 }
 

--- a/nextest-runner/src/reporter/imp.rs
+++ b/nextest-runner/src/reporter/imp.rs
@@ -14,7 +14,10 @@ use crate::{
     config::core::EvaluatableProfile,
     errors::WriteEventError,
     list::TestList,
-    reporter::{aggregator::EventAggregator, events::*, structured::StructuredReporter},
+    reporter::{
+        aggregator::EventAggregator, displayer::ShowProgress, events::*,
+        structured::StructuredReporter,
+    },
 };
 
 /// Standard error destination for the reporter.
@@ -41,7 +44,7 @@ pub struct ReporterBuilder {
     final_status_level: Option<FinalStatusLevel>,
 
     verbose: bool,
-    hide_progress_bar: bool,
+    show_progress: ShowProgress,
     no_output_indent: bool,
 }
 
@@ -91,10 +94,9 @@ impl ReporterBuilder {
         self
     }
 
-    /// Sets visibility of the progress bar.
-    /// The progress bar is also hidden if `no_capture` is set.
-    pub fn set_hide_progress_bar(&mut self, hide_progress_bar: bool) -> &mut Self {
-        self.hide_progress_bar = hide_progress_bar;
+    /// Sets the way of displaying progress.
+    pub fn set_show_progress(&mut self, show_progress: ShowProgress) -> &mut Self {
+        self.show_progress = show_progress;
         self
     }
 
@@ -133,7 +135,7 @@ impl ReporterBuilder {
             failure_output: self.failure_output,
             should_colorize: self.should_colorize,
             no_capture: self.no_capture,
-            hide_progress_bar: self.hide_progress_bar,
+            show_progress: self.show_progress,
             no_output_indent: self.no_output_indent,
         }
         .build(cargo_configs, output);

--- a/nextest-runner/src/reporter/mod.rs
+++ b/nextest-runner/src/reporter/mod.rs
@@ -13,7 +13,7 @@ mod helpers;
 mod imp;
 pub mod structured;
 
-pub use displayer::{FinalStatusLevel, StatusLevel, TestOutputDisplay};
+pub use displayer::{FinalStatusLevel, ShowProgress, StatusLevel, TestOutputDisplay};
 pub use error_description::*;
 pub use helpers::highlight_end;
 pub use imp::*;


### PR DESCRIPTION
This adds a counter to each status line, so that one doesn't have to guess how many tests are remaining when the progress bar is not visible (think in CI):

<img width="1552" height="981" alt="image" src="https://github.com/user-attachments/assets/07c230f9-c43d-4c56-8694-824077794a87" />

It's been a long requested feature: #526. As a casual observer of test runs with 5000+ tests, this would be nice to have.

As is, it shows the counter unconditionally. In #526 @sunshowers suggested a more complicated heuristic (see https://github.com/nextest-rs/nextest/issues/526#issuecomment-1254332115), which I can probably take a stab at next, if it still makes sense.