### PR TITLE
[nextest-runner] Add "breakaway OK" to Windows job object limits

### DIFF
--- a/nextest-runner/src/runner/executor.rs
+++ b/nextest-runner/src/runner/executor.rs
@@ -369,7 +369,7 @@ impl<'a> ExecutorContext<'a> {
 
         // If creating a job fails, we might be on an old system. Ignore this -- job objects are a
         // best-effort thing.
-        let job = super::os::Job::create().ok();
+        let job = super::os::create_job().ok();
 
         // The --no-capture CLI argument overrides the config.
         if self.capture_strategy != CaptureStrategy::None {
@@ -689,7 +689,7 @@ impl<'a> ExecutorContext<'a> {
 
         // If creating a job fails, we might be on an old system. Ignore this -- job objects are a
         // best-effort thing.
-        let job = super::os::Job::create().ok();
+        let job = super::os::create_job().ok();
 
         let crate::test_command::Child {
             mut child,

--- a/nextest-runner/src/runner/unix.rs
+++ b/nextest-runner/src/runner/unix.rs
@@ -34,10 +34,8 @@ pub(super) fn set_process_group(cmd: &mut std::process::Command) {
 #[derive(Debug)]
 pub(super) struct Job(());
 
-impl Job {
-    pub(super) fn create() -> Result<Self, Infallible> {
-        Ok(Self(()))
-    }
+pub(super) fn create_job() -> Result<Job, Infallible> {
+    Ok(Job(()))
 }
 
 pub(super) fn assign_process_to_job(

--- a/nextest-runner/src/runner/windows.rs
+++ b/nextest-runner/src/runner/windows.rs
@@ -24,6 +24,10 @@ use windows_sys::Win32::{
     },
 };
 
+pub(super) fn create_job() -> Result<Job, JobError> {
+    Job::create_with_limit_info(win32job::ExtendedLimitInfo::new().limit_breakaway_ok())
+}
+
 pub(super) fn configure_handle_inheritance_impl(
     no_capture: bool,
 ) -> Result<(), ConfigureHandleInheritanceError> {


### PR DESCRIPTION
This is the minimalist fix for https://github.com/nextest-rs/nextest/issues/2620.

With this changes my use-case works.

I only added `JOB_OBJECT_LIMIT_BREAKAWAY_OK`. `JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK` is closely related, I didn't need it but was wondering if I should also add it in good measure. 