### PR TITLE
[nextest-runner] set biased, increase leak timeout to 200ms

### DIFF
--- a/nextest-runner/default-config.toml
+++ b/nextest-runner/default-config.toml
@@ -95,7 +95,7 @@ slow-timeout = { period = "60s" }
 # handles, but doesn't clean the child process up (especially when it fails).
 #
 # See <https://nexte.st/docs/features/leaky-tests> for more information.
-leak-timeout = "100ms"
+leak-timeout = "200ms"
 
 # Stop all tests after the configured global timeout.
 # Defaults to 30 year, which is a large enough value to feel "infinite" without

--- a/nextest-runner/src/config/elements/leak_timeout.rs
+++ b/nextest-runner/src/config/elements/leak_timeout.rs
@@ -92,7 +92,7 @@ mod tests {
 
     #[test_case(
         "",
-        Ok(LeakTimeout { period: Duration::from_millis(100), result: LeakTimeoutResult::Pass}),
+        Ok(LeakTimeout { period: Duration::from_millis(200), result: LeakTimeoutResult::Pass}),
         None
 
         ; "empty config is expected to use the hardcoded values"

--- a/nextest-runner/src/runner/executor.rs
+++ b/nextest-runner/src/runner/executor.rs
@@ -1285,6 +1285,8 @@ async fn detect_fd_leaks<'a>(
         let waiting_stopwatch = crate::time::stopwatch();
 
         tokio::select! {
+            biased;
+
             // All of the branches here need to check for
             // `!child_acc.fds.is_done()`, because if child_fds is done we want
             // to hit the `else` block right away.

--- a/site/src/docs/configuration/reference.md
+++ b/site/src/docs/configuration/reference.md
@@ -399,7 +399,7 @@ For detailed information, see [_Setup scripts_](setup-scripts.md).
 
 - **Type**: String (duration) or object
 - **Description**: Leak timeout for the setup script
-- **Default**: `100ms`
+- **Default**: `200ms`
 - **Examples**:
   ```toml
   leak-timeout = "500ms"


### PR DESCRIPTION
We've noticed some recent flakiness around leaky tests in CI under overloaded circumstances. I think `biased` is appropriate, and 200ms is a reasonable leak timeout.