### PR TITLE
[nextest-runner] make the Tokio executor do ticks

### DIFF
--- a/nextest-runner/src/reporter/aggregator/imp.rs
+++ b/nextest-runner/src/reporter/aggregator/imp.rs
@@ -24,7 +24,10 @@ impl<'cfg> EventAggregator<'cfg> {
         }
     }
 
-    pub(crate) fn write_event(&mut self, event: TestEvent<'cfg>) -> Result<(), WriteEventError> {
+    pub(crate) fn write_event(
+        &mut self,
+        event: Box<TestEvent<'cfg>>,
+    ) -> Result<(), WriteEventError> {
         if let Some(junit) = &mut self.junit {
             junit.write_event(event)?;
         }

--- a/nextest-runner/src/reporter/aggregator/junit.rs
+++ b/nextest-runner/src/reporter/aggregator/junit.rs
@@ -46,7 +46,10 @@ impl<'cfg> MetadataJunit<'cfg> {
         }
     }
 
-    pub(super) fn write_event(&mut self, event: TestEvent<'cfg>) -> Result<(), WriteEventError> {
+    pub(super) fn write_event(
+        &mut self,
+        event: Box<TestEvent<'cfg>>,
+    ) -> Result<(), WriteEventError> {
         match event.kind {
             TestEventKind::RunStarted { .. }
             | TestEventKind::StressSubRunStarted { .. }

--- a/nextest-runner/src/reporter/displayer/progress.rs
+++ b/nextest-runner/src/reporter/displayer/progress.rs
@@ -108,8 +108,6 @@ impl ProgressBarState {
                 .template(&template)
                 .expect("template is known to be valid"),
         );
-        // Enable a steady tick 10 times a second.
-        bar.enable_steady_tick(Duration::from_millis(100));
 
         let test_bars = show_running.then_some(IdHashMap::new());
 
@@ -122,6 +120,16 @@ impl ProgressBarState {
             hidden_run_paused: false,
             hidden_info_response: false,
             hidden_between_sub_runs: false,
+        }
+    }
+
+    pub(super) fn tick(&mut self) {
+        self.bar.tick();
+        // Also tick all test bars.
+        if let Some(test_bars) = &mut self.test_bars {
+            for bar in test_bars {
+                bar.progress_bar.tick();
+            }
         }
     }
 
@@ -308,7 +316,7 @@ impl ProgressBarState {
                 )
                 .to_string(),
             );
-            tb.enable_steady_tick(Duration::from_millis(1000));
+            // tb.enable_steady_tick(Duration::from_millis(1000));
 
             let tb = self.multi_progress.add(tb);
 

--- a/nextest-runner/src/reporter/events.rs
+++ b/nextest-runner/src/reporter/events.rs
@@ -18,6 +18,15 @@ use nextest_metadata::MismatchReason;
 use quick_junit::ReportUuid;
 use std::{collections::BTreeMap, fmt, num::NonZero, process::ExitStatus, time::Duration};
 
+/// A reporter event.
+#[derive(Clone, Debug)]
+pub enum ReporterEvent<'a> {
+    /// A periodic tick.
+    Tick,
+
+    /// A test event.
+    Test(Box<TestEvent<'a>>),
+}
 /// A test event.
 ///
 /// Events are produced by a [`TestRunner`](crate::runner::TestRunner) and

--- a/nextest-runner/src/reporter/imp.rs
+++ b/nextest-runner/src/reporter/imp.rs
@@ -161,8 +161,14 @@ pub struct Reporter<'a> {
 
 impl<'a> Reporter<'a> {
     /// Report a test event.
-    pub fn report_event(&mut self, event: TestEvent<'a>) -> Result<(), WriteEventError> {
-        self.write_event(event)
+    pub fn report_event(&mut self, event: ReporterEvent<'a>) -> Result<(), WriteEventError> {
+        match event {
+            ReporterEvent::Tick => {
+                self.tick();
+                Ok(())
+            }
+            ReporterEvent::Test(event) => self.write_event(event),
+        }
     }
 
     /// Mark the reporter done.
@@ -174,8 +180,13 @@ impl<'a> Reporter<'a> {
     // Helper methods
     // ---
 
+    /// Tick the reporter, updating displayed state.
+    fn tick(&mut self) {
+        self.display_reporter.tick();
+    }
+
     /// Report this test event to the given writer.
-    fn write_event(&mut self, event: TestEvent<'a>) -> Result<(), WriteEventError> {
+    fn write_event(&mut self, event: Box<TestEvent<'a>>) -> Result<(), WriteEventError> {
         // TODO: write to all of these even if one of them fails?
         self.display_reporter.write_event(&event)?;
         self.structured_reporter.write_event(&event)?;

--- a/nextest-runner/tests/integration/fixtures.rs
+++ b/nextest-runner/tests/integration/fixtures.rs
@@ -26,7 +26,8 @@ use nextest_runner::{
     },
     platform::BuildPlatforms,
     reporter::events::{
-        AbortStatus, ExecutionResult, ExecutionStatuses, FailureStatus, RunStats, TestEventKind,
+        AbortStatus, ExecutionResult, ExecutionStatuses, FailureStatus, ReporterEvent, RunStats,
+        TestEventKind,
     },
     reuse_build::PathMapper,
     runner::{TestRunner, configure_handle_inheritance},
@@ -449,6 +450,10 @@ pub(crate) fn execute_collect(
     configure_handle_inheritance(false).expect("configuring handle inheritance on Windows failed");
     let run_stats = runner
         .execute(|event| {
+            let event = match event {
+                ReporterEvent::Tick => return,
+                ReporterEvent::Test(event) => event,
+            };
             let (test_instance, status) = match event.kind {
                 TestEventKind::TestSkipped {
                     stress_index: _,


### PR DESCRIPTION
Now that we have lots of progress bars, we should make the Tokio executor do ticks rather than each progress bar thread doing its own.