### PR TITLE
[nextest-runner] with --show-progress=running, avoid output jumps up and down

### DIFF
--- a/nextest-runner/src/runner/dispatcher.rs
+++ b/nextest-runner/src/runner/dispatcher.rs
@@ -119,7 +119,7 @@ where
             std::pin::pin!(crate::time::pausable_sleep(self.global_timeout));
 
         // This is the interval at which tick events are sent to the reporter.
-        let mut tick_interval = tokio::time::interval(Duration::from_millis(100));
+        let mut tick_interval = tokio::time::interval(Duration::from_millis(200));
         tick_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         loop {

--- a/nextest-runner/src/runner/executor.rs
+++ b/nextest-runner/src/runner/executor.rs
@@ -768,7 +768,7 @@ impl<'a> ExecutorContext<'a> {
         // Use an event that happens shortly after the test starts to avoid
         // overwhelming progress bar display code.
         let mut show_progress_sleep =
-            std::pin::pin!(crate::time::pausable_sleep(Duration::from_millis(100)));
+            std::pin::pin!(crate::time::pausable_sleep(Duration::from_millis(10)));
         let mut show_progress_sleep_done = false;
 
         let mut timeout_hit = 0;


### PR DESCRIPTION
Use a free list of empty bars to provide padding corresponding to the number of formerly-used rows. This means that the overall progress bar slides up rapidly, but never slides down.