### PR TITLE
Ghostty supports OSC 9;4

### DIFF
--- a/nextest-runner/src/reporter/displayer/progress.rs
+++ b/nextest-runner/src/reporter/displayer/progress.rs
@@ -505,15 +505,15 @@ fn supports_osc_9_4(stream: &dyn IsTerminal) -> bool {
         );
         return false;
     }
-    if std::env::var("WT_SESSION").is_ok() {
+    if std::env::var_os("WT_SESSION").is_some() {
         debug!("autodetect terminal progress reporting: enabling since WT_SESSION is set");
         return true;
     };
-    if std::env::var("ConEmuANSI").ok() == Some("ON".into()) {
+    if std::env::var_os("ConEmuANSI").is_some_and(|term| term == "ON") {
         debug!("autodetect terminal progress reporting: enabling since ConEmuANSI is ON");
         return true;
     }
-    if std::env::var("TERM_PROGRAM").ok() == Some("WezTerm".into()) {
+    if std::env::var_os("TERM_PROGRAM").is_some_and(|term| term == "WezTerm") {
         debug!("autodetect terminal progress reporting: enabling since TERM_PROGRAM is WezTerm");
         return true;
     }


### PR DESCRIPTION
This enables the new in-terminal progress bar (which uses OSC 9;4) if nextest is running inside the Ghostty terminal.

See https://github.com/nextest-rs/nextest/discussions/2715

Here's a video of it working, with my local nextest build.

https://github.com/user-attachments/assets/bd5c7918-7335-45c9-95a2-21108ece2493

It also does a tiny incidental refactor, making the other terminal-specific checks use `var_os` instead of `var` to use fewer allocations.

