### PR TITLE
[nextest-runner] reduce progress bar refresh rate to 10hz

### DIFF
--- a/nextest-runner/src/reporter/displayer/imp.rs
+++ b/nextest-runner/src/reporter/displayer/imp.rs
@@ -43,6 +43,12 @@ use std::{
     time::Duration,
 };
 
+/// The duration after which ticks are generated.
+pub const TICK_INTERVAL: Duration = Duration::from_millis(200);
+
+/// The refresh rate for the progress bar, set to half the tick interval in hz.
+pub const PROGRESS_REFRESH_RATE_HZ: u8 = 10;
+
 pub(crate) struct DisplayReporterBuilder {
     pub(crate) default_filter: CompiledDefaultFilter,
     pub(crate) status_levels: StatusLevels,

--- a/nextest-runner/src/reporter/displayer/mod.rs
+++ b/nextest-runner/src/reporter/displayer/mod.rs
@@ -9,7 +9,7 @@ mod progress;
 mod status_level;
 mod unit_output;
 
-pub(crate) use imp::*;
+pub use imp::*;
 pub use progress::ShowProgress;
 pub use status_level::*;
 pub use unit_output::*;

--- a/nextest-runner/src/reporter/displayer/progress.rs
+++ b/nextest-runner/src/reporter/displayer/progress.rs
@@ -5,7 +5,10 @@ use crate::{
     cargo_config::{CargoConfigs, DiscoveredConfig},
     helpers::DisplayTestInstance,
     list::TestInstanceId,
-    reporter::{displayer::formatters::DisplayBracketedHhMmSs, events::*, helpers::Styles},
+    reporter::{
+        PROGRESS_REFRESH_RATE_HZ, displayer::formatters::DisplayBracketedHhMmSs, events::*,
+        helpers::Styles,
+    },
 };
 use iddqd::{IdHashItem, IdHashMap, id_upcast};
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
@@ -454,10 +457,7 @@ impl ProgressBarState {
     }
 
     fn stderr_target() -> ProgressDrawTarget {
-        // This used to be unbuffered, but that option went away from indicatif
-        // 0.17.0. The refresh rate is now 20hz so that it's double the steady
-        // tick rate.
-        ProgressDrawTarget::stderr_with_hz(20)
+        ProgressDrawTarget::stderr_with_hz(PROGRESS_REFRESH_RATE_HZ)
     }
 
     fn hidden_target() -> ProgressDrawTarget {

--- a/nextest-runner/src/reporter/mod.rs
+++ b/nextest-runner/src/reporter/mod.rs
@@ -13,7 +13,10 @@ mod helpers;
 mod imp;
 pub mod structured;
 
-pub use displayer::{FinalStatusLevel, ShowProgress, StatusLevel, TestOutputDisplay};
+pub use displayer::{
+    FinalStatusLevel, PROGRESS_REFRESH_RATE_HZ, ShowProgress, StatusLevel, TICK_INTERVAL,
+    TestOutputDisplay,
+};
 pub use error_description::*;
 pub use helpers::highlight_end;
 pub use imp::*;

--- a/nextest-runner/src/runner/dispatcher.rs
+++ b/nextest-runner/src/runner/dispatcher.rs
@@ -15,10 +15,13 @@ use crate::{
     },
     input::{InputEvent, InputHandler},
     list::{TestInstance, TestInstanceId, TestList},
-    reporter::events::{
-        CancelReason, ExecuteStatus, ExecutionStatuses, FinalRunStats, InfoResponse, ReporterEvent,
-        RunFinishedStats, RunStats, StressIndex, StressProgress, StressRunStats, TestEvent,
-        TestEventKind,
+    reporter::{
+        TICK_INTERVAL,
+        events::{
+            CancelReason, ExecuteStatus, ExecutionStatuses, FinalRunStats, InfoResponse,
+            ReporterEvent, RunFinishedStats, RunStats, StressIndex, StressProgress, StressRunStats,
+            TestEvent, TestEventKind,
+        },
     },
     runner::{ExecutorEvent, RunUnitQuery, SignalRequest, StressCondition, StressCount},
     signal::{JobControlEvent, ShutdownEvent, SignalEvent, SignalHandler, SignalInfoEvent},
@@ -119,7 +122,7 @@ where
             std::pin::pin!(crate::time::pausable_sleep(self.global_timeout));
 
         // This is the interval at which tick events are sent to the reporter.
-        let mut tick_interval = tokio::time::interval(Duration::from_millis(200));
+        let mut tick_interval = tokio::time::interval(TICK_INTERVAL);
         tick_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         loop {


### PR DESCRIPTION
Noticed by @glehmann in #2720 -- since we bumped down our tick rate to 200ms, we can set the progress bar refresh rate to twice that (100ms or 10hz) while still providing a good experience.

This seems to noticeably reduce flickering in some of our tests.