### PR TITLE
[nextest-runner] add --max-progress-running, cap to 8 by default

### DIFF
--- a/cargo-nextest/src/dispatch/cli.rs
+++ b/cargo-nextest/src/dispatch/cli.rs
@@ -29,7 +29,10 @@ use nextest_runner::{
     },
     partition::PartitionerBuilder,
     platform::BuildPlatforms,
-    reporter::{FinalStatusLevel, ReporterBuilder, ShowProgress, StatusLevel, TestOutputDisplay},
+    reporter::{
+        FinalStatusLevel, MaxProgressRunning, ReporterBuilder, ShowProgress, StatusLevel,
+        TestOutputDisplay,
+    },
     reuse_build::ReuseBuildInfo,
     runner::{StressCondition, StressCount, TestRunnerBuilder},
     test_filter::{FilterBound, RunIgnored, TestFilterBuilder, TestFilterPatterns},
@@ -865,6 +868,20 @@ pub(super) struct ReporterOpts {
     #[arg(long, env = "NEXTEST_NO_INPUT_HANDLER", value_parser = BoolishValueParser::new())]
     pub(super) no_input_handler: bool,
 
+    /// Maximum number of running tests to display progress for.
+    ///
+    /// When more tests are running than this limit, the progress bar will show
+    /// the first N tests and a summary of remaining tests (e.g. "... and 24
+    /// more tests running"). Set to **infinite** for unlimited. This only
+    /// applies when using `--show-progress=running` or `only`.
+    #[arg(
+        long = "max-progress-running",
+        value_name = "N",
+        env = "NEXTEST_MAX_PROGRESS_RUNNING",
+        default_value = "8"
+    )]
+    max_progress_running: MaxProgressRunning,
+
     /// Format to use for test results (experimental).
     #[arg(
         long,
@@ -964,6 +981,7 @@ impl ReporterOpts {
         }
         builder.set_show_progress(show_progress.into());
         builder.set_no_output_indent(self.no_output_indent);
+        builder.set_max_progress_running(self.max_progress_running);
         builder
     }
 }

--- a/nextest-runner/src/reporter/displayer/mod.rs
+++ b/nextest-runner/src/reporter/displayer/mod.rs
@@ -10,6 +10,6 @@ mod status_level;
 mod unit_output;
 
 pub use imp::*;
-pub use progress::ShowProgress;
+pub use progress::{MaxProgressRunning, ShowProgress};
 pub use status_level::*;
 pub use unit_output::*;

--- a/nextest-runner/src/reporter/events.rs
+++ b/nextest-runner/src/reporter/events.rs
@@ -184,6 +184,9 @@ pub enum TestEventKind<'a> {
 
         /// The test instance that was started.
         test_instance: TestInstance<'a>,
+
+        /// The number of tests currently running, including this one.
+        running: usize,
     },
 
     /// A test was slower than a configured soft timeout.
@@ -222,6 +225,9 @@ pub enum TestEventKind<'a> {
 
         /// Whether failure outputs are printed out.
         failure_output: TestOutputDisplay,
+
+        /// The current number of running tests.
+        running: usize,
     },
 
     /// A retry has started.
@@ -234,6 +240,9 @@ pub enum TestEventKind<'a> {
 
         /// Data related to retries.
         retry_data: RetryData,
+
+        /// The current number of running tests.
+        running: usize,
     },
 
     /// A test finished running.

--- a/nextest-runner/src/reporter/imp.rs
+++ b/nextest-runner/src/reporter/imp.rs
@@ -6,7 +6,7 @@
 //! The main structure in this module is [`TestReporter`].
 
 use super::{
-    FinalStatusLevel, StatusLevel, TestOutputDisplay,
+    FinalStatusLevel, MaxProgressRunning, StatusLevel, TestOutputDisplay,
     displayer::{DisplayReporter, DisplayReporterBuilder, StatusLevels},
 };
 use crate::{
@@ -46,6 +46,7 @@ pub struct ReporterBuilder {
     verbose: bool,
     show_progress: ShowProgress,
     no_output_indent: bool,
+    max_progress_running: MaxProgressRunning,
 }
 
 impl ReporterBuilder {
@@ -105,6 +106,18 @@ impl ReporterBuilder {
         self.no_output_indent = no_output_indent;
         self
     }
+
+    /// Sets the maximum number of running tests to display in the progress bar.
+    ///
+    /// When more tests are running than this limit, only the first N tests are shown
+    /// with a summary line indicating how many more tests are running.
+    pub fn set_max_progress_running(
+        &mut self,
+        max_progress_running: MaxProgressRunning,
+    ) -> &mut Self {
+        self.max_progress_running = max_progress_running;
+        self
+    }
 }
 
 impl ReporterBuilder {
@@ -137,6 +150,7 @@ impl ReporterBuilder {
             no_capture: self.no_capture,
             show_progress: self.show_progress,
             no_output_indent: self.no_output_indent,
+            max_progress_running: self.max_progress_running,
         }
         .build(cargo_configs, output);
 

--- a/nextest-runner/src/reporter/mod.rs
+++ b/nextest-runner/src/reporter/mod.rs
@@ -14,8 +14,8 @@ mod imp;
 pub mod structured;
 
 pub use displayer::{
-    FinalStatusLevel, PROGRESS_REFRESH_RATE_HZ, ShowProgress, StatusLevel, TICK_INTERVAL,
-    TestOutputDisplay,
+    FinalStatusLevel, MaxProgressRunning, PROGRESS_REFRESH_RATE_HZ, ShowProgress, StatusLevel,
+    TICK_INTERVAL, TestOutputDisplay,
 };
 pub use error_description::*;
 pub use helpers::highlight_end;

--- a/nextest-runner/src/runner/dispatcher.rs
+++ b/nextest-runner/src/runner/dispatcher.rs
@@ -681,6 +681,7 @@ where
                 stress_index,
                 retry_data,
                 test_instance,
+                running: self.running_tests.len(),
             }),
             InternalEvent::Executor(ExecutorEvent::Slow {
                 stress_index,
@@ -730,6 +731,7 @@ where
                     failure_output,
                     run_status,
                     delay_before_next_attempt,
+                    running: self.running_tests.len(),
                 })
             }
             InternalEvent::Executor(ExecutorEvent::RetryStarted {
@@ -757,6 +759,7 @@ where
                     stress_index,
                     test_instance,
                     retry_data,
+                    running: self.running_tests.len(),
                 })
             }
             InternalEvent::Executor(ExecutorEvent::Finished {


### PR DESCRIPTION
More polish work for #2720 -- empirically, terminals struggle to keep up with 16+ tests, so cap the maximum number of tests.

Show the overflow count in a summary bar at the bottom.