### PR TITLE
[nextest-runner] support immediately terminating tests on test failure

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,15 +1,19 @@
 {
     "permissions": {
         "allow": [
-            "Bash(jj s:*)",
-            "WebSearch",
+            "Bash(cargo build:*)",
             "Bash(cargo check:*)",
             "Bash(cargo clippy:*)",
-            "Bash(cargo build:*)",
+            "Bash(cargo fmt:*)",
             "Bash(cargo nextest run:*)",
+            "Bash(cargo test:*)",
+            "Bash(cargo xfmt:*)",
+            "Bash(gh pr view:*)",
             "Bash(git log:*)",
             "Bash(git show:*)",
-            "Bash(gh pr view:*)"
+            "Bash(jj diff:*)",
+            "Bash(jj s:*)",
+            "WebSearch"
         ],
         "deny": [],
         "ask": []

--- a/cargo-nextest/src/dispatch/cli.rs
+++ b/cargo-nextest/src/dispatch/cli.rs
@@ -660,11 +660,17 @@ pub struct TestRunnerOpts {
     )]
     no_fail_fast: bool,
 
-    /// Number of tests that can fail before exiting test run [possible values: integer or "all"]
+    /// Number of tests that can fail before exiting test run
+    ///
+    /// To control whether currently running tests are waited for or terminated
+    /// immediately, append ':wait' (default) or ':immediate' to the number
+    /// (e.g., '5:immediate').
+    ///
+    /// [possible values: integer, "all", "N:wait", "N:immediate"]
     #[arg(
         long,
         name = "max-fail",
-        value_name = "N",
+        value_name = "N[:MODE]",
         conflicts_with_all = &["no-run", "fail-fast", "no-fail-fast"],
     )]
     max_fail: Option<MaxFail>,

--- a/nextest-runner/default-config.toml
+++ b/nextest-runner/default-config.toml
@@ -73,9 +73,11 @@ success-output = "never"
 # Cancel the test run on the first failure. For CI runs, consider setting this
 # to false.
 # Accepted values are
-# * true: cancel the test run on the first failure
+# * true: cancel the test run on the first failure (waits for running tests to complete)
 # * false: continue running tests even after a failure
-# * { max-fail = 10 }: cancel the test run after the specified number of failures
+# * { max-fail = 10 }: cancel the test run after 10 failures (waits for running tests)
+# * { max-fail = 10, terminate = "wait" }: same as above (explicit)
+# * { max-fail = 10, terminate = "immediate" }: cancel and terminate running tests immediately
 # * { max-fail = "all" }: continue running tests even after a failure
 fail-fast = true
 

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -684,18 +684,16 @@ pub enum ToolConfigFileParseError {
 
 /// Error returned while parsing a [`MaxFail`](crate::config::elements::MaxFail) input.
 #[derive(Clone, Debug, Error)]
-#[error(
-    "unrecognized value for max-fail: {input}\n(hint: expected either a positive integer or \"all\")"
-)]
+#[error("unrecognized value for max-fail: {reason}")]
 pub struct MaxFailParseError {
-    /// The input that failed to parse.
-    pub input: String,
+    /// The reason parsing failed.
+    pub reason: String,
 }
 
 impl MaxFailParseError {
-    pub(crate) fn new(input: impl Into<String>) -> Self {
+    pub(crate) fn new(reason: impl Into<String>) -> Self {
         Self {
-            input: input.into(),
+            reason: reason.into(),
         }
     }
 }

--- a/nextest-runner/src/reporter/displayer/formatters.rs
+++ b/nextest-runner/src/reporter/displayer/formatters.rs
@@ -226,36 +226,39 @@ fn write_final_warnings_for_failure(
     styles: &Styles,
     writer: &mut dyn Write,
 ) -> io::Result<()> {
-    if reason == Some(CancelReason::TestFailure) {
-        writeln!(
-            writer,
-            "{}: {}/{} {} {} not run due to {} (run with {} to run all tests, or run with {})",
-            "warning".style(styles.skip),
-            not_run.style(styles.count),
-            initial_run_count.style(styles.count),
-            plural::tests_plural_if(initial_run_count != 1 || not_run != 1),
-            plural::were_plural_if(initial_run_count != 1 || not_run != 1),
-            CancelReason::TestFailure.to_static_str().style(styles.skip),
-            "--no-fail-fast".style(styles.count),
-            "--max-fail".style(styles.count),
-        )?;
-    } else {
-        let due_to_reason = match reason {
-            Some(reason) => {
-                format!(" due to {}", reason.to_static_str().style(styles.skip))
-            }
-            None => "".to_string(),
-        };
-        writeln!(
-            writer,
-            "{}: {}/{} {} {} not run{}",
-            "warning".style(styles.skip),
-            not_run.style(styles.count),
-            initial_run_count.style(styles.count),
-            plural::tests_plural_if(initial_run_count != 1 || not_run != 1),
-            plural::were_plural_if(initial_run_count != 1 || not_run != 1),
-            due_to_reason,
-        )?;
+    match reason {
+        Some(reason @ CancelReason::TestFailure | reason @ CancelReason::TestFailureImmediate) => {
+            writeln!(
+                writer,
+                "{}: {}/{} {} {} not run due to {} (run with {} to run all tests, or run with {})",
+                "warning".style(styles.skip),
+                not_run.style(styles.count),
+                initial_run_count.style(styles.count),
+                plural::tests_plural_if(initial_run_count != 1 || not_run != 1),
+                plural::were_plural_if(initial_run_count != 1 || not_run != 1),
+                reason.to_static_str().style(styles.skip),
+                "--no-fail-fast".style(styles.count),
+                "--max-fail".style(styles.count),
+            )?;
+        }
+        _ => {
+            let due_to_reason = match reason {
+                Some(reason) => {
+                    format!(" due to {}", reason.to_static_str().style(styles.skip))
+                }
+                None => "".to_string(),
+            };
+            writeln!(
+                writer,
+                "{}: {}/{} {} {} not run{}",
+                "warning".style(styles.skip),
+                not_run.style(styles.count),
+                initial_run_count.style(styles.count),
+                plural::tests_plural_if(initial_run_count != 1 || not_run != 1),
+                plural::were_plural_if(initial_run_count != 1 || not_run != 1),
+                due_to_reason,
+            )?;
+        }
     }
 
     Ok(())

--- a/nextest-runner/src/reporter/displayer/imp.rs
+++ b/nextest-runner/src/reporter/displayer/imp.rs
@@ -786,6 +786,7 @@ impl<'a> DisplayReporterImpl<'a> {
                     self.cancel_status,
                     describe.status_level(),
                     describe.final_status_level(),
+                    last_status.result,
                 );
 
                 let counter = TestInstanceCounter::Counter {
@@ -852,19 +853,26 @@ impl<'a> DisplayReporterImpl<'a> {
                     )?;
                 }
 
+                let immediately_terminating_text =
+                    if current_stats.cancel_reason == Some(CancelReason::TestFailureImmediate) {
+                        format!("immediately {} ", "terminating".style(self.styles.fail))
+                    } else {
+                        String::new()
+                    };
+
                 // At the moment, we can have either setup scripts or tests running, but not both.
                 if *setup_scripts_running > 0 {
                     let s = plural::setup_scripts_str(*setup_scripts_running);
                     write!(
                         writer,
-                        "{} {s} still running",
+                        "{immediately_terminating_text}{} {s} still running",
                         setup_scripts_running.style(self.styles.count),
                     )?;
                 } else if *running > 0 {
                     let tests_str = plural::tests_str(*running);
                     write!(
                         writer,
-                        "{} {tests_str} still running",
+                        "{immediately_terminating_text}{} {tests_str} still running",
                         running.style(self.styles.count),
                     )?;
                 }

--- a/nextest-runner/src/reporter/displayer/progress.rs
+++ b/nextest-runner/src/reporter/displayer/progress.rs
@@ -1086,6 +1086,7 @@ fn progress_bar_cancel_prefix(reason: Option<CancelReason>, styles: &Styles) -> 
         | Some(CancelReason::TestFailure)
         | Some(CancelReason::ReportError)
         | Some(CancelReason::GlobalTimeout)
+        | Some(CancelReason::TestFailureImmediate)
         | Some(CancelReason::Signal)
         | Some(CancelReason::Interrupt)
         | None => "Cancelling",

--- a/site/src/docs/configuration/reference.md
+++ b/site/src/docs/configuration/reference.md
@@ -200,13 +200,22 @@ Profiles are configured under `[profile.<name>]`. The default profile is called 
 - **Type**: Boolean or object
 - **Description**: Controls when to stop running tests after failures
 - **Documentation**: [_Failing fast_](../running.md#failing-fast)
+- **Default**: `true` (stop after first failure, wait for running tests to complete)
 - **Examples**:
   ```toml
-  fail-fast = true  # Stop after first failure
+  fail-fast = true  # Stop after first failure (waits for running tests)
   fail-fast = false # Run all tests
-  fail-fast = { max-fail = 5 }  # Stop after 5 failures
+  fail-fast = { max-fail = 5 }  # Stop after 5 failures (waits for running tests)
   fail-fast = { max-fail = "all" }  # Run all tests
+
+  # With termination mode (since 0.9.111)
+  fail-fast = { max-fail = 1, terminate = "wait" }  # Wait for running tests (default)
+  fail-fast = { max-fail = 1, terminate = "immediate" }  # Terminate running tests immediately
   ```
+
+When `max-fail` is exceeded:
+- **`terminate = "wait"`** (default): Nextest stops scheduling new tests but waits for currently running tests to finish naturally
+- **`terminate = "immediate"`** <!-- md:version 0.9.111 -->: Nextest sends termination signals to running tests (respecting the grace period configured via `slow-timeout.terminate-after`)
 
 ### Test grouping
 


### PR DESCRIPTION
Add an optional mode that, rather than waiting on currently-running tests to finish, immediately terminates runs on failure. This is useful for several purposes, including #2482.