### PR TITLE
[nextest-runner] switch reporter to WriteStr

### DIFF
--- a/cargo-nextest/src/dispatch/execution.rs
+++ b/cargo-nextest/src/dispatch/execution.rs
@@ -47,7 +47,6 @@ use owo_colors::OwoColorize;
 use semver::Version;
 use std::{
     env::VarError,
-    io::Write,
     sync::{Arc, OnceLock},
 };
 use tracing::{Level, info, warn};
@@ -805,7 +804,7 @@ impl ArchiveApp {
             output_file,
             |event| {
                 reporter.report_event(event, &mut writer)?;
-                writer.flush()
+                writer.write_str_flush()
             },
             redactor.clone(),
         )

--- a/cargo-nextest/src/reuse_build.rs
+++ b/cargo-nextest/src/reuse_build.rs
@@ -12,8 +12,8 @@ use nextest_runner::{
         ArchiveFormat, ArchiveReporter, ExtractDestination, MetadataKind, MetadataWithRemap,
         PathMapper, ReuseBuildInfo, ReusedBinaryList, ReusedCargoMetadata,
     },
+    write_str::WriteStr,
 };
-use std::io::Write;
 use tracing::warn;
 
 #[derive(Debug, Default, Args)]
@@ -168,7 +168,7 @@ impl ReuseBuildOpts {
                 dest,
                 |event| {
                     reporter.report_event(event, &mut writer)?;
-                    writer.flush()
+                    writer.write_str_flush()
                 },
                 workspace_remap.as_deref(),
             )

--- a/nextest-runner/src/indenter.rs
+++ b/nextest-runner/src/indenter.rs
@@ -100,6 +100,15 @@ impl<'a, D: ?Sized> Indented<'a, D> {
         self
     }
 
+    /// Skip indenting the initial line.
+    ///
+    /// This is useful when you've already written some content on the current line
+    /// and want to start indenting only from the next line onwards.
+    pub fn skip_initial(mut self) -> Self {
+        self.needs_indent = false;
+        self
+    }
+
     /// Returns the inner writer.
     pub fn into_inner(self) -> &'a mut D {
         self.inner

--- a/nextest-runner/src/reporter/displayer/formatters.rs
+++ b/nextest-runner/src/reporter/displayer/formatters.rs
@@ -11,13 +11,10 @@ use crate::{
         events::{CancelReason, FinalRunStats, RunStatsFailureKind},
         helpers::Styles,
     },
+    write_str::WriteStr,
 };
 use owo_colors::OwoColorize;
-use std::{
-    fmt,
-    io::{self, Write},
-    time::Duration,
-};
+use std::{fmt, io, time::Duration};
 
 pub(super) struct DisplayBracketedHhMmSs(pub(super) Duration);
 
@@ -102,7 +99,7 @@ pub(super) fn write_skip_counts(
     skip_counts: &SkipCounts,
     default_filter: &CompiledDefaultFilter,
     styles: &Styles,
-    writer: &mut dyn Write,
+    writer: &mut dyn WriteStr,
 ) -> io::Result<()> {
     if skip_counts.skipped_tests > 0 || skip_counts.skipped_binaries > 0 {
         write!(writer, " (")?;
@@ -154,7 +151,7 @@ fn write_skip_counts_impl(
     skipped_tests: usize,
     skipped_binaries: usize,
     styles: &Styles,
-    writer: &mut dyn Write,
+    writer: &mut dyn WriteStr,
 ) -> io::Result<()> {
     // X tests and Y binaries skipped, or X tests skipped, or Y binaries skipped.
     if skipped_tests > 0 && skipped_binaries > 0 {
@@ -188,7 +185,7 @@ fn write_skip_counts_impl(
 pub(super) fn write_final_warnings(
     final_stats: FinalRunStats,
     styles: &Styles,
-    writer: &mut dyn Write,
+    writer: &mut dyn WriteStr,
 ) -> io::Result<()> {
     match final_stats {
         FinalRunStats::Failed(RunStatsFailureKind::Test {
@@ -224,7 +221,7 @@ fn write_final_warnings_for_failure(
     not_run: usize,
     reason: Option<CancelReason>,
     styles: &Styles,
-    writer: &mut dyn Write,
+    writer: &mut dyn WriteStr,
 ) -> io::Result<()> {
     match reason {
         Some(reason @ CancelReason::TestFailure | reason @ CancelReason::TestFailureImmediate) => {
@@ -379,7 +376,7 @@ mod tests {
     }
 
     fn skip_counts_str(skip_counts: &SkipCounts, override_section: bool) -> String {
-        let mut buf = Vec::new();
+        let mut buf = String::new();
         write_skip_counts(
             skip_counts,
             &CompiledDefaultFilter {
@@ -395,7 +392,7 @@ mod tests {
             &mut buf,
         )
         .unwrap();
-        String::from_utf8(buf).unwrap()
+        buf
     }
 
     #[test]
@@ -449,9 +446,9 @@ mod tests {
     }
 
     fn final_warnings_for(stats: FinalRunStats) -> String {
-        let mut buf: Vec<u8> = Vec::new();
+        let mut buf = String::new();
         let styles = Styles::default();
         write_final_warnings(stats, &styles, &mut buf).unwrap();
-        String::from_utf8(buf).unwrap()
+        buf
     }
 }

--- a/nextest-runner/src/reporter/displayer/progress.rs
+++ b/nextest-runner/src/reporter/displayer/progress.rs
@@ -9,6 +9,7 @@ use crate::{
         PROGRESS_REFRESH_RATE_HZ, displayer::formatters::DisplayBracketedHhMmSs, events::*,
         helpers::Styles,
     },
+    write_str::WriteStr,
 };
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use nextest_metadata::RustBinaryId;
@@ -455,8 +456,8 @@ impl ProgressBarState {
         }
     }
 
-    pub(super) fn write_buf(&mut self, buf: &[u8]) {
-        self.buffer.extend_from_slice(buf);
+    pub(super) fn write_buf(&mut self, buf: &str) {
+        self.buffer.extend_from_slice(buf.as_bytes());
     }
 
     #[inline]
@@ -548,7 +549,7 @@ impl TerminalProgress {
     pub(super) fn update_progress(
         &self,
         event: &TestEvent<'_>,
-        writer: &mut dyn Write,
+        writer: &mut dyn WriteStr,
     ) -> Result<(), io::Error> {
         let value = match &event.kind {
             TestEventKind::RunStarted { .. }

--- a/nextest-runner/src/reporter/imp.rs
+++ b/nextest-runner/src/reporter/imp.rs
@@ -30,7 +30,7 @@ pub enum ReporterStderr<'a> {
     Terminal,
 
     /// Write output to a buffer.
-    Buffer(&'a mut Vec<u8>),
+    Buffer(&'a mut String),
 }
 
 /// Test reporter builder.

--- a/nextest-runner/src/show_config/nextest_version.rs
+++ b/nextest-runner/src/show_config/nextest_version.rs
@@ -1,10 +1,13 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::config::core::{NextestVersionConfig, NextestVersionEval, NextestVersionReq};
+use crate::{
+    config::core::{NextestVersionConfig, NextestVersionEval, NextestVersionReq},
+    write_str::WriteStr,
+};
 use owo_colors::{OwoColorize, Style};
 use semver::Version;
-use std::io::{self, Write};
+use std::io;
 
 /// Show version-related configuration.
 pub struct ShowNextestVersion<'a> {
@@ -28,7 +31,7 @@ impl<'a> ShowNextestVersion<'a> {
     }
 
     /// Write the version configuration in human-readable form.
-    pub fn write_human(&self, writer: &mut dyn Write, colorize: bool) -> io::Result<()> {
+    pub fn write_human(&self, writer: &mut dyn WriteStr, colorize: bool) -> io::Result<()> {
         let mut styles = Styles::default();
         if colorize {
             styles.colorize();

--- a/nextest-runner/src/write_str.rs
+++ b/nextest-runner/src/write_str.rs
@@ -9,7 +9,10 @@
 //! This is similar to [`std::fmt::Write`], but it returns [`std::io::Error`] instead for better
 //! error handling.
 
-use std::{fmt, io};
+use std::{
+    fmt,
+    io::{self, BufWriter, Write},
+};
 
 /// A trait that abstracts over writing strings to a writer.
 ///
@@ -82,6 +85,20 @@ impl WriteStr for String {
     fn write_char(&mut self, c: char) -> io::Result<()> {
         self.push(c);
         Ok(())
+    }
+}
+
+impl<W: Write> WriteStr for BufWriter<W> {
+    fn write_str(&mut self, s: &str) -> io::Result<()> {
+        self.write_all(s.as_bytes())
+    }
+
+    fn write_str_flush(&mut self) -> io::Result<()> {
+        self.flush()
+    }
+
+    fn write_char(&mut self, c: char) -> io::Result<()> {
+        self.write_all(c.encode_utf8(&mut [0; 4]).as_bytes())
     }
 }
 


### PR DESCRIPTION
I'd like to try using indicatif's println, which requires a string. Complete this long-standing migration.