### PR TITLE
[nextest-runner] use indicatif's println to print statuses

### DIFF
--- a/nextest-runner/src/reporter/displayer/mod.rs
+++ b/nextest-runner/src/reporter/displayer/mod.rs
@@ -9,7 +9,7 @@ mod progress;
 mod status_level;
 mod unit_output;
 
-pub use imp::*;
+pub(crate) use imp::*;
 pub use progress::{MaxProgressRunning, ShowProgress};
 pub use status_level::*;
 pub use unit_output::*;

--- a/nextest-runner/src/reporter/helpers.rs
+++ b/nextest-runner/src/reporter/helpers.rs
@@ -48,6 +48,81 @@ impl Styles {
     }
 }
 
+// Port of std::str::floor_char_boundary to Rust < 1.91.0. Remove after MSRV
+// has been bumped to 1.91 or above.
+pub(crate) const fn floor_char_boundary(s: &str, index: usize) -> usize {
+    if index >= s.len() {
+        s.len()
+    } else {
+        let mut i = index;
+        while i > 0 {
+            if is_utf8_char_boundary(s.as_bytes()[i]) {
+                break;
+            }
+            i -= 1;
+        }
+
+        //  The character boundary will be within four bytes of the index
+        debug_assert!(i >= index.saturating_sub(3));
+
+        i
+    }
+}
+
+#[inline]
+const fn is_utf8_char_boundary(b: u8) -> bool {
+    // This is bit magic equivalent to: b < 128 || b >= 192
+    (b as i8) >= -0x40
+}
+
+/// Calls the provided callback with chunks of text, breaking at newline
+/// boundaries when possible.
+///
+/// This function processes text in chunks to avoid performance issues when
+/// printing large amounts of text at once. It attempts to break chunks at
+/// newline boundaries within the specified maximum chunk size, but will
+/// handle lines longer than the maximum by searching forward for the next
+/// newline.
+///
+/// # Parameters
+/// - `text`: The text to process
+/// - `max_chunk_bytes`: Maximum size of each chunk in bytes
+/// - `callback`: Function called with each chunk of text (includes trailing newlines)
+pub(crate) fn print_lines_in_chunks(
+    text: &str,
+    max_chunk_bytes: usize,
+    mut callback: impl FnMut(&str),
+) {
+    let mut remaining = text;
+    while !remaining.is_empty() {
+        // Find the maximum index to search for the last newline, respecting
+        // UTF-8 character boundaries.
+        let max = floor_char_boundary(remaining, max_chunk_bytes);
+
+        // Search backwards for the last \n within the chunk.
+        let last_newline = remaining[..max].rfind('\n');
+
+        if let Some(index) = last_newline {
+            // Found a newline within max_chunk_bytes. Include it in the chunk.
+            callback(&remaining[..=index]);
+            remaining = &remaining[index + 1..];
+        } else {
+            // No newline within max_chunk_bytes. Search forward for the next newline.
+            let next_newline = remaining[max..].find('\n');
+
+            if let Some(index) = next_newline {
+                // Found a newline after max_chunk_bytes. Include it in the chunk.
+                callback(&remaining[..=index + max]);
+                remaining = &remaining[index + max + 1..];
+            } else {
+                // No more newlines, so print everything that's left.
+                callback(remaining);
+                remaining = "";
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -71,6 +146,98 @@ mod tests {
                 highlight_end(input.as_bytes()),
                 *output,
                 "for input {input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_print_lines_in_chunks() {
+        let tests: &[(&str, &str, usize, &[&str])] = &[
+            // (description, input, chunk_size, expected_chunks)
+            ("empty string", "", 1024, &[]),
+            ("single line no newline", "hello", 1024, &["hello"]),
+            ("single line with newline", "hello\n", 1024, &["hello\n"]),
+            (
+                "multiple lines small",
+                "line1\nline2\nline3\n",
+                1024,
+                &["line1\nline2\nline3\n"],
+            ),
+            (
+                "breaks at newline",
+                "line1\nline2\nline3\n",
+                10,
+                &["line1\n", "line2\n", "line3\n"],
+            ),
+            (
+                "multiple lines per chunk",
+                "line1\nline2\nline3\n",
+                13,
+                &["line1\nline2\n", "line3\n"],
+            ),
+            (
+                "long line with newline",
+                &format!("{}\n", "a".repeat(2000)),
+                1024,
+                &[&format!("{}\n", "a".repeat(2000))],
+            ),
+            (
+                "long line no newline",
+                &"a".repeat(2000),
+                1024,
+                &[&"a".repeat(2000)],
+            ),
+            ("exact boundary", "123456789\n", 10, &["123456789\n"]),
+            (
+                "newline at boundary",
+                "12345678\nabcdefgh\n",
+                10,
+                &["12345678\n", "abcdefgh\n"],
+            ),
+            (
+                "utf8 emoji",
+                "hello😀\nworld\n",
+                10,
+                &["hello😀\n", "world\n"],
+            ),
+            (
+                "utf8 near boundary",
+                "1234😀\nabcd\n",
+                7,
+                &["1234😀\n", "abcd\n"],
+            ),
+            (
+                "consecutive newlines",
+                "line1\n\n\nline2\n",
+                10,
+                &["line1\n\n\n", "line2\n"],
+            ),
+            (
+                "no trailing newline",
+                "line1\nline2\nline3",
+                10,
+                &["line1\n", "line2\n", "line3"],
+            ),
+            (
+                "mixed lengths",
+                "short\nvery_long_line_that_exceeds_chunk_size\nmedium_line\nok\n",
+                20,
+                &[
+                    "short\n",
+                    "very_long_line_that_exceeds_chunk_size\n",
+                    "medium_line\nok\n",
+                ],
+            ),
+        ];
+
+        for (description, input, chunk_size, expected) in tests {
+            let mut chunks = Vec::new();
+            print_lines_in_chunks(input, *chunk_size, |chunk| chunks.push(chunk.to_string()));
+            assert_eq!(
+                chunks,
+                expected.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+                "test case: {}",
+                description
             );
         }
     }

--- a/nextest-runner/src/reporter/mod.rs
+++ b/nextest-runner/src/reporter/mod.rs
@@ -14,8 +14,7 @@ mod imp;
 pub mod structured;
 
 pub use displayer::{
-    FinalStatusLevel, MaxProgressRunning, PROGRESS_REFRESH_RATE_HZ, ShowProgress, StatusLevel,
-    TICK_INTERVAL, TestOutputDisplay,
+    FinalStatusLevel, MaxProgressRunning, ShowProgress, StatusLevel, TestOutputDisplay,
 };
 pub use error_description::*;
 pub use helpers::highlight_end;


### PR DESCRIPTION
The `println` function causes notably less flicker than `suspend` -- we arrange things such that message updates and newlines are part of the same terminal flush. (Spent some time in gdb walking over this code.)

Also bump up the default tick rate to 20/sec, which feels much nicer than 10/sec. Make this configurable via a semi-hidden environment variable.