### PR TITLE
[nextest-runner] make --show-progress=running an alias for bar

### DIFF
--- a/cargo-nextest/src/dispatch/cli.rs
+++ b/cargo-nextest/src/dispatch/cli.rs
@@ -878,8 +878,9 @@ pub(super) struct ReporterOpts {
     ///
     /// When more tests are running than this limit, the progress bar will show
     /// the first N tests and a summary of remaining tests (e.g. "... and 24
-    /// more tests running"). Set to **infinite** for unlimited. This only
-    /// applies when using `--show-progress=running` or `only`.
+    /// more tests running"). Set to **0** to hide running tests, or
+    /// **infinite** for unlimited. This applies when using
+    /// `--show-progress=bar` or `--show-progress=only`.
     #[arg(
         long = "max-progress-running",
         value_name = "N",
@@ -1074,16 +1075,15 @@ enum ShowProgressOpt {
     /// Do not display a progress bar or counter.
     None,
 
-    /// Display a progress bar: default for interactive terminals.
+    /// Display a progress bar with running tests: default for interactive
+    /// terminals.
+    #[clap(alias = "running")]
     Bar,
 
     /// Display a counter next to each completed test.
     Counter,
 
-    /// Display each running test on a separate line.
-    Running,
-
-    /// Display each running test on a separate line, and hide successful test
+    /// Display a progress bar with running tests, and hide successful test
     /// output; equivalent to `--show-progress=running --status-level=slow
     /// --final-status-level=none`.
     Only,
@@ -1094,9 +1094,8 @@ impl From<ShowProgressOpt> for ShowProgress {
         match opt {
             ShowProgressOpt::Auto => ShowProgress::Auto,
             ShowProgressOpt::None => ShowProgress::None,
-            ShowProgressOpt::Bar => ShowProgress::Bar,
+            ShowProgressOpt::Bar => ShowProgress::Running,
             ShowProgressOpt::Counter => ShowProgress::Counter,
-            ShowProgressOpt::Running => ShowProgress::Running,
             ShowProgressOpt::Only => ShowProgress::Running,
         }
     }

--- a/nextest-runner/src/reporter/displayer/imp.rs
+++ b/nextest-runner/src/reporter/displayer/imp.rs
@@ -123,7 +123,7 @@ impl DisplayReporterBuilder {
 
         let show_counter = match self.show_progress {
             ShowProgress::Auto => is_ci::uncached() || !show_progress_bar,
-            ShowProgress::Bar | ShowProgress::Running | ShowProgress::None => false,
+            ShowProgress::Running | ShowProgress::None => false,
             ShowProgress::Counter => true,
         };
         let counter_width = show_counter.then_some(usize_decimal_char_width(self.test_count));
@@ -180,23 +180,14 @@ impl DisplayReporterBuilder {
             return None;
         }
 
-        let show_running = match self.show_progress {
-            ShowProgress::None | ShowProgress::Counter => return None,
-            // For auto we enable progress bar if not in CI and not a terminal.
-            // Both of these conditions are checked above.
-            ShowProgress::Auto | ShowProgress::Bar => false,
-            ShowProgress::Running => true,
-        };
-
-        let state = ProgressBarState::new(
-            self.test_count,
-            progress_chars,
-            show_running,
-            max_progress_running,
-        );
-        // Note: even if we create a progress bar here, if stderr is
-        // piped, indicatif will not show it.
-        Some(state)
+        match self.show_progress {
+            ShowProgress::None | ShowProgress::Counter => None,
+            ShowProgress::Auto | ShowProgress::Running => {
+                let state =
+                    ProgressBarState::new(self.test_count, progress_chars, max_progress_running);
+                Some(state)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Also display running tests by default, capped to `max_running_progress` -- and allow setting this to 0 for behavior identical to current versions of nextest.