### PR TITLE
[integration-tests] assert on expected and actual output

### DIFF
--- a/integration-tests/tests/integration/main.rs
+++ b/integration-tests/tests/integration/main.rs
@@ -23,7 +23,7 @@
 //! `NEXTEST_BIN_EXE_cargo-nextest-dup`.
 
 use camino::{Utf8Path, Utf8PathBuf};
-use fixture_data::nextest_tests::EXPECTED_TEST_SUITES;
+use fixture_data::{models::RunProperty, nextest_tests::EXPECTED_TEST_SUITES};
 use integration_tests::{
     env::set_env_vars,
     nextest_cli::{CargoNextestCli, CargoNextestOutput},


### PR DESCRIPTION
For ease of maintainability, ensure that we build up expected and actual maps, and compare that the two produce the same results.