### PR TITLE
[nextest-runner] use Debug impl for lines that failed to parse

### DIFF
--- a/nextest-runner/src/list/snapshots/nextest_runner__list__test_list__tests__control_character_error.snap
+++ b/nextest-runner/src/list/snapshots/nextest_runner__list__test_list__tests__control_character_error.snap
@@ -1,0 +1,10 @@
+---
+source: nextest-runner/src/list/test_list.rs
+expression: result.unwrap_err()
+snapshot_kind: text
+---
+for `test-package::test-binary`, line "\rinvalid_line" did not end with the string ": test" or ": benchmark"
+full output:
+valid_test: test
+invalid_line
+another_valid: benchmark

--- a/nextest-runner/src/list/snapshots/nextest_runner__list__test_list__tests__empty_input.snap
+++ b/nextest-runner/src/list/snapshots/nextest_runner__list__test_list__tests__empty_input.snap
@@ -1,0 +1,6 @@
+---
+source: nextest-runner/src/list/test_list.rs
+expression: results
+snapshot_kind: text
+---
+[]

--- a/nextest-runner/src/list/snapshots/nextest_runner__list__test_list__tests__invalid_suffix_error.snap
+++ b/nextest-runner/src/list/snapshots/nextest_runner__list__test_list__tests__invalid_suffix_error.snap
@@ -1,0 +1,8 @@
+---
+source: nextest-runner/src/list/test_list.rs
+expression: result.unwrap_err()
+snapshot_kind: text
+---
+for `test-package::test-binary`, line "invalid_test: wrong_suffix" did not end with the string ": test" or ": benchmark"
+full output:
+invalid_test: wrong_suffix

--- a/nextest-runner/src/list/snapshots/nextest_runner__list__test_list__tests__missing_suffix_error.snap
+++ b/nextest-runner/src/list/snapshots/nextest_runner__list__test_list__tests__missing_suffix_error.snap
@@ -1,0 +1,8 @@
+---
+source: nextest-runner/src/list/test_list.rs
+expression: result.unwrap_err()
+snapshot_kind: text
+---
+for `test-package::test-binary`, line "test_without_suffix" did not end with the string ": test" or ": benchmark"
+full output:
+test_without_suffix

--- a/nextest-runner/src/list/snapshots/nextest_runner__list__test_list__tests__mixed_tests_and_benchmarks.snap
+++ b/nextest-runner/src/list/snapshots/nextest_runner__list__test_list__tests__mixed_tests_and_benchmarks.snap
@@ -1,0 +1,11 @@
+---
+source: nextest-runner/src/list/test_list.rs
+expression: results
+snapshot_kind: text
+---
+[
+    "test_one",
+    "bench_one",
+    "test_two",
+    "bench_two",
+]

--- a/nextest-runner/src/list/snapshots/nextest_runner__list__test_list__tests__partial_valid_error.snap
+++ b/nextest-runner/src/list/snapshots/nextest_runner__list__test_list__tests__partial_valid_error.snap
@@ -1,0 +1,10 @@
+---
+source: nextest-runner/src/list/test_list.rs
+expression: result.unwrap_err()
+snapshot_kind: text
+---
+for `test-package::test-binary`, line "invalid_line" did not end with the string ": test" or ": benchmark"
+full output:
+valid_test: test
+invalid_line
+another_valid: benchmark

--- a/nextest-runner/src/list/snapshots/nextest_runner__list__test_list__tests__special_characters.snap
+++ b/nextest-runner/src/list/snapshots/nextest_runner__list__test_list__tests__special_characters.snap
@@ -1,0 +1,10 @@
+---
+source: nextest-runner/src/list/test_list.rs
+expression: results
+snapshot_kind: text
+---
+[
+    "test_with_underscore_123",
+    "test::with::colons",
+    "test_with_numbers_42",
+]

--- a/nextest-runner/src/list/snapshots/nextest_runner__list__test_list__tests__valid_benchmarks.snap
+++ b/nextest-runner/src/list/snapshots/nextest_runner__list__test_list__tests__valid_benchmarks.snap
@@ -1,0 +1,9 @@
+---
+source: nextest-runner/src/list/test_list.rs
+expression: results
+snapshot_kind: text
+---
+[
+    "simple_bench",
+    "benches::module::my_benchmark",
+]

--- a/nextest-runner/src/list/snapshots/nextest_runner__list__test_list__tests__valid_tests.snap
+++ b/nextest-runner/src/list/snapshots/nextest_runner__list__test_list__tests__valid_tests.snap
@@ -1,0 +1,10 @@
+---
+source: nextest-runner/src/list/test_list.rs
+expression: results
+snapshot_kind: text
+---
+[
+    "simple_test",
+    "module::nested_test",
+    "deeply::nested::module::test_name",
+]


### PR DESCRIPTION
If a line has a weird control character in it, escape that character via the Debug impl.