### PR TITLE
[nextest-runner] set NEXTEST_BIN_EXE_ env vars also with underscores

### DIFF
--- a/fixtures/nextest-tests/src/lib.rs
+++ b/fixtures/nextest-tests/src/lib.rs
@@ -10,6 +10,9 @@ use std::path::Path;
 pub fn test_execute_bin_helper() {
     let binary_path = std::env::var("NEXTEST_BIN_EXE_nextest-tests")
         .expect("NEXTEST_BIN_EXE_nextest-tests should be present");
+    let with_underscores = std::env::var("NEXTEST_BIN_EXE_nextest_tests")
+        .expect("NEXTEST_BIN_EXE_nextest_tests (with underscores) should be present");
+    assert_eq!(binary_path, with_underscores);
     assert!(
         Path::new(&binary_path).is_absolute(),
         "binary path {} is absolute",

--- a/site/src/docs/configuration/env-vars.md
+++ b/site/src/docs/configuration/env-vars.md
@@ -111,6 +111,8 @@ Nextest exposes these environment variables to your tests _at runtime only_. The
     Binaries are automatically built when the test is built, unless the binary has required features that are not enabled.
 
     When [reusing builds](../ci-features/archiving.md) from an archive, this is set to the remapped path within the target directory.
+    
+    <!-- md:version 0.9.112 --> Because some shells and [debuggers](../integrations/debuggers.md) drop [environment variables with hyphens in their names](https://unix.stackexchange.com/a/23714), nextest also sets an alternative form of these variables where hyphens in the name are replaced with underscores. For example, for a binary named `my-program`, the environment variable `NEXTEST_BIN_EXE_my_program` is also set to the absolute path of the executable.
 
 `NEXTEST_LD_*` and `NEXTEST_DYLD_*`
 : Replicate the values of any environment variables that start with the prefixes `LD_` or `DYLD_`, such as `LD_PRELOAD` or `DYLD_FALLBACK_LIBRARY_PATH`.


### PR DESCRIPTION
Turns out that some shells and debuggers just drop any environment variables with hyphens in them. Provide an alternative that replaces hyphens with underscores.