### PR TITLE
[meta] use NEXTEST_BIN_EXE_ with underscores in tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,4 +1,4 @@
-nextest-version = "0.9.98"
+nextest-version = "0.9.113"
 experimental = ["setup-scripts"]
 
 [profile.default]

--- a/integration-tests/src/nextest_cli.rs
+++ b/integration-tests/src/nextest_cli.rs
@@ -35,7 +35,7 @@ pub struct CargoNextestCli {
 
 impl CargoNextestCli {
     pub fn for_test() -> Self {
-        let bin = std::env::var("NEXTEST_BIN_EXE_cargo-nextest-dup")
+        let bin = std::env::var("NEXTEST_BIN_EXE_cargo_nextest_dup")
             .expect("unable to find cargo-nextest-dup");
         Self {
             bin: bin.into(),
@@ -47,7 +47,7 @@ impl CargoNextestCli {
 
     /// Creates a new CargoNextestCli instance for use in a setup script.
     ///
-    /// Scripts don't have access to the `NEXTEST_BIN_EXE_cargo-nextest-dup` environment variable,
+    /// Scripts don't have access to the `NEXTEST_BIN_EXE_cargo_nextest_dup` environment variable,
     /// so we run `cargo run --bin cargo-nextest-dup nextest debug current-exe` instead.
     pub fn for_script() -> Result<Self> {
         let cargo_bin = cargo_bin();

--- a/integration-tests/tests/integration/debugger.rs
+++ b/integration-tests/tests/integration/debugger.rs
@@ -8,9 +8,8 @@ use integration_tests::{env::set_env_vars, nextest_cli::CargoNextestCli};
 use nextest_metadata::NextestExitCode;
 
 fn fake_debugger_path() -> String {
-    // This env var is set by nextest when running tests
-    std::env::var("NEXTEST_BIN_EXE_fake-debugger")
-        .expect("NEXTEST_BIN_EXE_fake-debugger should be set by nextest")
+    std::env::var("NEXTEST_BIN_EXE_fake_debugger")
+        .expect("NEXTEST_BIN_EXE_fake_debugger should be set by nextest")
 }
 
 #[test]

--- a/integration-tests/tests/integration/main.rs
+++ b/integration-tests/tests/integration/main.rs
@@ -20,7 +20,7 @@
 //!
 //! To solve this issue, we introduce a "cargo-nextest-dup" binary which is exactly the same as
 //! cargo-nextest, except it isn't used as the actual test runner. We refer to it with
-//! `NEXTEST_BIN_EXE_cargo-nextest-dup`.
+//! `NEXTEST_BIN_EXE_cargo_nextest_dup`.
 
 use camino::{Utf8Path, Utf8PathBuf};
 use fixture_data::{models::RunProperty, nextest_tests::EXPECTED_TEST_SUITES};
@@ -1681,7 +1681,7 @@ fn test_rustc_version_verbose_errors() {
     set_env_vars();
 
     // Set RUSTC to the shim.
-    let shim_rustc = std::env::var("NEXTEST_BIN_EXE_rustc-shim").unwrap();
+    let shim_rustc = std::env::var("NEXTEST_BIN_EXE_rustc_shim").unwrap();
 
     let mut command = CargoNextestCli::for_test();
     command


### PR DESCRIPTION
Newly added with nextest 0.9.113.