### PR TITLE
Add environment variables for test executions

### DIFF
--- a/fixtures/nextest-tests/tests/basic.rs
+++ b/fixtures/nextest-tests/tests/basic.rs
@@ -23,11 +23,11 @@ fn test_failure_error() -> Result<(), String> {
 }
 
 fn nextest_attempt() -> usize {
-    static NEXTEST_ATTEMPT_ENV: &str = "__NEXTEST_ATTEMPT";
+    static NEXTEST_ATTEMPT_ENV: &str = "NEXTEST_ATTEMPT";
     match env::var(NEXTEST_ATTEMPT_ENV) {
         Ok(var) => var
             .parse()
-            .expect("__NEXTEST_ATTEMPT should be a positive integer"),
+            .expect("NEXTEST_ATTEMPT should be a positive integer"),
         Err(_) => 1,
     }
 }
@@ -176,11 +176,8 @@ fn test_cargo_env_vars() {
         "NEXTEST_EXECUTION_MODE set to process-per-test"
     );
 
-    assert_eq!(
-        check_env("NEXTEST_ATTEMPT"),
-        nextest_attempt().to_string(),
-        "NEXTEST_ATTEMPT and __NEXTEST_ATTEMPT must be equal"
-    );
+    // Assert NEXTEST_ATTEMPT is defined and is a positive integer
+    assert!(check_env("NEXTEST_ATTEMPT").parse::<usize>().is_ok());
 
     let test_name = "test_cargo_env_vars";
     assert_eq!(check_env("NEXTEST_TEST_NAME"), test_name);

--- a/nextest-runner/src/runner/executor.rs
+++ b/nextest-runner/src/runner/executor.rs
@@ -680,9 +680,7 @@ impl<'a> ExecutorContext<'a> {
         let command_mut = cmd.command_mut();
 
         // Debug environment variable for testing.
-        let attempt = format!("{}", test.retry_data.attempt);
-        command_mut.env("__NEXTEST_ATTEMPT", &attempt);
-        command_mut.env("NEXTEST_ATTEMPT", attempt);
+        command_mut.env("NEXTEST_ATTEMPT", test.retry_data.attempt.to_string());
 
         command_mut.env("NEXTEST_RUN_ID", format!("{}", self.run_id));
 


### PR DESCRIPTION
This PR Adds the following environment variables for each test execution:

- NEXTEST_TEST_NAME
- NEXTET_ATTEMPT
- NEXTEST_BINARY_ID
- NEXTEST_ATTEMPT_ID
- NEXTEST_TOTAL_ATTEMPTS
- NEXTEST_STRESS_CURRENT
- NEXTEST_STRESS_TOTAL

It also removes the environment variable:
- __NEXTEST_ATTEMPT