### PR TITLE
[nextest-runner] use TestInstanceId within TestEventKind variants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ This document captures code conventions for the nextest project. It is intended 
 
 - Use inline comments to explain "why," not just "what".
 - Module-level documentation should explain purpose and responsibilities.
+- **Always** use periods at the end of code comments.
 
 ## Code style
 

--- a/nextest-runner/src/list/test_list.rs
+++ b/nextest-runner/src/list/test_list.rs
@@ -518,6 +518,11 @@ impl<'g> TestList<'g> {
         self.rust_suites.iter()
     }
 
+    /// Looks up a test suite by binary ID.
+    pub fn get_suite(&self, binary_id: &RustBinaryId) -> Option<&RustTestSuite<'_>> {
+        self.rust_suites.get(binary_id)
+    }
+
     /// Iterates over the list of tests, returning the path and test name.
     pub fn iter_tests(&self) -> impl Iterator<Item = TestInstance<'_>> + '_ {
         self.rust_suites.iter().flat_map(|test_suite| {

--- a/nextest-runner/src/reporter/aggregator/junit.rs
+++ b/nextest-runner/src/reporter/aggregator/junit.rs
@@ -130,7 +130,7 @@ impl<'cfg> MetadataJunit<'cfg> {
                 junit_store_failure_output,
                 ..
             } => {
-                let testsuite = self.testsuite_for_test(stress_index, test_instance.id());
+                let testsuite = self.testsuite_for_test(stress_index, test_instance);
 
                 let (mut testcase_status, main_status, reruns) = match run_statuses.describe() {
                     ExecutionDescription::Success { single_status } => {
@@ -171,9 +171,9 @@ impl<'cfg> MetadataJunit<'cfg> {
                     testcase_status.add_rerun(test_rerun);
                 }
 
-                let mut testcase = TestCase::new(test_instance.name, testcase_status);
+                let mut testcase = TestCase::new(test_instance.test_name, testcase_status);
                 testcase
-                    .set_classname(test_instance.suite_info.binary_id.as_str())
+                    .set_classname(test_instance.binary_id.as_str())
                     .set_timestamp(main_status.start_time)
                     .set_time(main_status.time_taken);
 

--- a/nextest-runner/src/reporter/displayer/progress.rs
+++ b/nextest-runner/src/reporter/displayer/progress.rs
@@ -346,8 +346,8 @@ impl ProgressBarState {
 
                 if let Some(running_tests) = &mut self.running_tests {
                     running_tests.push(RunningTest {
-                        binary_id: test_instance.id().binary_id.clone(),
-                        test_name: test_instance.id().test_name.to_owned(),
+                        binary_id: test_instance.binary_id.clone(),
+                        test_name: test_instance.test_name.to_owned(),
                         status: RunningTestStatus::Running,
                         start_time: Instant::now(),
                         paused_for: Duration::ZERO,
@@ -361,7 +361,7 @@ impl ProgressBarState {
                 ..
             } => {
                 self.running = *running;
-                self.remove_test(&test_instance.id());
+                self.remove_test(test_instance);
 
                 self.bar.set_prefix(progress_bar_prefix(
                     current_stats,
@@ -378,11 +378,11 @@ impl ProgressBarState {
                 delay_before_next_attempt,
                 ..
             } => {
-                self.remove_test(&test_instance.id());
+                self.remove_test(test_instance);
                 if let Some(running_tests) = &mut self.running_tests {
                     running_tests.push(RunningTest {
-                        binary_id: test_instance.id().binary_id.clone(),
-                        test_name: test_instance.id().test_name.to_owned(),
+                        binary_id: test_instance.binary_id.clone(),
+                        test_name: test_instance.test_name.to_owned(),
                         status: RunningTestStatus::Delay(*delay_before_next_attempt),
                         start_time: Instant::now(),
                         paused_for: Duration::ZERO,
@@ -390,11 +390,11 @@ impl ProgressBarState {
                 }
             }
             TestEventKind::TestRetryStarted { test_instance, .. } => {
-                self.remove_test(&test_instance.id());
+                self.remove_test(test_instance);
                 if let Some(running_tests) = &mut self.running_tests {
                     running_tests.push(RunningTest {
-                        binary_id: test_instance.id().binary_id.clone(),
-                        test_name: test_instance.id().test_name.to_owned(),
+                        binary_id: test_instance.binary_id.clone(),
+                        test_name: test_instance.test_name.to_owned(),
                         status: RunningTestStatus::Retry,
                         start_time: Instant::now(),
                         paused_for: Duration::ZERO,
@@ -406,8 +406,8 @@ impl ProgressBarState {
                     running_tests
                         .iter_mut()
                         .find(|rt| {
-                            &rt.binary_id == test_instance.id().binary_id
-                                && rt.test_name == test_instance.id().test_name
+                            &rt.binary_id == test_instance.binary_id
+                                && rt.test_name == test_instance.test_name
                         })
                         .expect("a slow test to be already running")
                         .status = RunningTestStatus::Slow;

--- a/nextest-runner/src/reporter/events.rs
+++ b/nextest-runner/src/reporter/events.rs
@@ -12,7 +12,7 @@ use crate::{
         elements::{LeakTimeoutResult, SlowTimeoutResult},
         scripts::ScriptId,
     },
-    list::{TestInstance, TestInstanceId, TestList},
+    list::{TestInstanceId, TestList},
     runner::{StressCondition, StressCount},
     test_output::ChildExecutionOutput,
 };
@@ -164,7 +164,7 @@ pub enum TestEventKind<'a> {
         stress_index: Option<StressIndex>,
 
         /// The test instance that was started.
-        test_instance: TestInstance<'a>,
+        test_instance: TestInstanceId<'a>,
 
         /// Current run statistics so far.
         current_stats: RunStats,
@@ -179,7 +179,7 @@ pub enum TestEventKind<'a> {
         stress_index: Option<StressIndex>,
 
         /// The test instance that was slow.
-        test_instance: TestInstance<'a>,
+        test_instance: TestInstanceId<'a>,
 
         /// Retry data.
         retry_data: RetryData,
@@ -199,7 +199,7 @@ pub enum TestEventKind<'a> {
         stress_index: Option<StressIndex>,
 
         /// The test instance that is being retried.
-        test_instance: TestInstance<'a>,
+        test_instance: TestInstanceId<'a>,
 
         /// The status of this attempt to run the test. Will never be success.
         run_status: ExecuteStatus,
@@ -220,7 +220,7 @@ pub enum TestEventKind<'a> {
         stress_index: Option<StressIndex>,
 
         /// The test instance that is being retried.
-        test_instance: TestInstance<'a>,
+        test_instance: TestInstanceId<'a>,
 
         /// Data related to retries.
         retry_data: RetryData,
@@ -235,7 +235,7 @@ pub enum TestEventKind<'a> {
         stress_index: Option<StressIndex>,
 
         /// The test instance that finished running.
-        test_instance: TestInstance<'a>,
+        test_instance: TestInstanceId<'a>,
 
         /// Test setting for success output.
         success_output: TestOutputDisplay,
@@ -265,7 +265,7 @@ pub enum TestEventKind<'a> {
         stress_index: Option<StressIndex>,
 
         /// The test instance that was skipped.
-        test_instance: TestInstance<'a>,
+        test_instance: TestInstanceId<'a>,
 
         /// The reason this test was skipped.
         reason: MismatchReason,

--- a/nextest-runner/src/runner/dispatcher.rs
+++ b/nextest-runner/src/runner/dispatcher.rs
@@ -675,7 +675,7 @@ where
                 self.new_test(test_instance, req_tx);
                 self.callback_none_response(TestEventKind::TestStarted {
                     stress_index,
-                    test_instance,
+                    test_instance: test_instance.id(),
                     current_stats: self.run_stats,
                     running: self.running_tests.len(),
                 })
@@ -707,7 +707,7 @@ where
 
                 self.callback_none_response(TestEventKind::TestSlow {
                     stress_index,
-                    test_instance,
+                    test_instance: test_instance.id(),
                     retry_data,
                     elapsed,
                     will_terminate: will_terminate.is_some(),
@@ -724,7 +724,7 @@ where
                 instance.attempt_failed_will_retry(run_status.clone());
                 self.callback_none_response(TestEventKind::TestAttemptFailedWillRetry {
                     stress_index,
-                    test_instance,
+                    test_instance: test_instance.id(),
                     failure_output,
                     run_status,
                     delay_before_next_attempt,
@@ -754,7 +754,7 @@ where
 
                 self.callback_none_response(TestEventKind::TestRetryStarted {
                     stress_index,
-                    test_instance,
+                    test_instance: test_instance.id(),
                     retry_data,
                     running: self.running_tests.len(),
                 })
@@ -777,7 +777,7 @@ where
 
                 self.basic_callback(TestEventKind::TestFinished {
                     stress_index,
-                    test_instance,
+                    test_instance: test_instance.id(),
                     success_output,
                     failure_output,
                     junit_store_success_output,
@@ -821,7 +821,7 @@ where
                 self.run_stats.skipped += 1;
                 self.callback_none_response(TestEventKind::TestSkipped {
                     stress_index,
-                    test_instance,
+                    test_instance: test_instance.id(),
                     reason,
                 })
             }


### PR DESCRIPTION
TestInstance is too hard to construct when unit testing events. Use TestInstanceId which provides just enough information.