### PR TITLE
[nextest-runner] show `TRY n START` for retries with --verbose

### DIFF
--- a/nextest-runner/src/reporter/displayer/snapshots/nextest_runner__reporter__displayer__imp__tests__verbose_command_line.snap
+++ b/nextest-runner/src/reporter/displayer/snapshots/nextest_runner__reporter__displayer__imp__tests__verbose_command_line.snap
@@ -9,3 +9,7 @@ snapshot_kind: text
              command: /path/to/binary --exact 'test with spaces' '--flag=value'
        START [         ] ( 1/10) my-binary-id test_special_chars
              command: /path/to/binary 'test"with"quotes' 'test'\''with'\''single'
+ TRY 2 START [         ] (─────────) my-binary-id test_retry
+             command: /path/to/binary --exact test_retry
+ TRY 3 START [         ] (─────────) my-binary-id test_retry
+             command: /path/to/binary --exact test_retry

--- a/nextest-runner/src/reporter/events.rs
+++ b/nextest-runner/src/reporter/events.rs
@@ -230,6 +230,9 @@ pub enum TestEventKind<'a> {
 
         /// The current number of running tests.
         running: usize,
+
+        /// The command line that will be used to run this test.
+        command_line: Vec<String>,
     },
 
     /// A test finished running.

--- a/nextest-runner/src/runner/dispatcher.rs
+++ b/nextest-runner/src/runner/dispatcher.rs
@@ -737,6 +737,7 @@ where
                 stress_index,
                 test_instance,
                 retry_data,
+                command_line,
                 tx,
             }) => {
                 if self.run_stats.cancel_reason.is_some() {
@@ -759,6 +760,7 @@ where
                     test_instance: test_instance.id(),
                     retry_data,
                     running: self.running_tests.len(),
+                    command_line,
                 })
             }
             InternalEvent::Executor(ExecutorEvent::Finished {

--- a/nextest-runner/src/runner/executor.rs
+++ b/nextest-runner/src/runner/executor.rs
@@ -231,7 +231,7 @@ impl<'a> ExecutorContext<'a> {
         _ = resp_tx.send(ExecutorEvent::Started {
             stress_index,
             test_instance: test.instance,
-            command_line,
+            command_line: command_line.clone(),
             req_rx_tx,
         });
         let mut req_rx = match req_rx_rx.await {
@@ -262,6 +262,7 @@ impl<'a> ExecutorContext<'a> {
                     stress_index,
                     test_instance: test.instance,
                     retry_data,
+                    command_line: command_line.clone(),
                     tx,
                 });
 

--- a/nextest-runner/src/runner/internal_events.rs
+++ b/nextest-runner/src/runner/internal_events.rs
@@ -100,6 +100,7 @@ pub(super) enum ExecutorEvent<'a> {
         stress_index: Option<StressIndex>,
         test_instance: TestInstance<'a>,
         retry_data: RetryData,
+        command_line: Vec<String>,
         // This is used to indicate that the dispatcher still wants to run the test.
         tx: oneshot::Sender<()>,
     },


### PR DESCRIPTION
Similar to the START added for --verbose, show `TRY n START` for retries.