### PR TITLE
[ci] fix flaky test_flaky_slow_timeout_mod_3

### DIFF
--- a/fixtures/nextest-tests/.config/nextest.toml
+++ b/fixtures/nextest-tests/.config/nextest.toml
@@ -89,7 +89,7 @@ slow-timeout = { period = "500ms", terminate-after = 2 }
 test-group = '@global'
 
 [profile.with-timeout-success]
-slow-timeout = { period = "10ms", terminate-after = 2, on-timeout = "pass" }
+slow-timeout = { period = "500ms", terminate-after = 2, on-timeout = "pass" }
 
 [[profile.with-timeout-success.overrides]]
 filter = 'test(=test_slow_timeout_2)'
@@ -98,10 +98,10 @@ test-group = '@global'
 
 [[profile.with-timeout-success.overrides]]
 filter = 'test(=test_slow_timeout_subprocess)'
-slow-timeout = { period = "10ms", terminate-after = 2, on-timeout = "fail" }
+slow-timeout = { period = "500ms", terminate-after = 2, on-timeout = "fail" }
 
 [profile.with-timeout-retries-success]
-slow-timeout = { period = "10ms", terminate-after = 2, on-timeout = "pass" }
+slow-timeout = { period = "500ms", terminate-after = 2, on-timeout = "pass" }
 retries = 2
 
 [profile.with-junit]

--- a/fixtures/nextest-tests/tests/basic.rs
+++ b/fixtures/nextest-tests/tests/basic.rs
@@ -337,7 +337,8 @@ fn test_slow_timeout() {
 #[test]
 #[ignore]
 fn test_slow_timeout_2() {
-    // There's a per-test override for the with-termination profile for this test: it is set to 1 second.
+    // There's a per-test override for the with-termination profile for this
+    // test: it is set to 1 second.
     std::thread::sleep(std::time::Duration::from_millis(1500));
 }
 
@@ -345,9 +346,9 @@ fn test_slow_timeout_2() {
 #[test]
 #[ignore]
 fn test_slow_timeout_subprocess() {
-    // Set a time greater than 5 seconds (that's the maximum amount the with_termination tests
-    // thinks tests should run for). Without job objects on Windows, the test wouldn't return until
-    // the sleep command exits.
+    // Set a time greater than 5 seconds (that's the maximum amount the
+    // with_termination tests thinks tests should run for). Without job objects
+    // on Windows, the test wouldn't return until the sleep command exits.
     let mut cmd = sleep_cmd(15);
     cmd.output().unwrap();
 }
@@ -359,8 +360,8 @@ fn test_flaky_slow_timeout_mod_3() {
     if nextest_attempt % 3 != 0 {
         panic!("Failed because attempt {} % 3 != 0", nextest_attempt)
     }
-    // The timeout for the with-timeout-success profile is set to 2 seconds.
-    std::thread::sleep(std::time::Duration::from_secs(4));
+    // The timeout for the with-timeout-retries-success profile is set to 1 second.
+    std::thread::sleep(std::time::Duration::from_millis(1500));
 }
 
 #[test]

--- a/nextest-runner/tests/integration/basic.rs
+++ b/nextest-runner/tests/integration/basic.rs
@@ -122,7 +122,7 @@ fn test_timeout_with_retries() -> Result<()> {
 
     let (instance_statuses, _run_stats) = execute_collect(runner);
 
-    // With retries and on-timeout=pass, timed out tests should not be retried
+    // With retries and on-timeout=pass, timed out tests should not be retried.
     for test_name in [
         "test_slow_timeout",
         "test_slow_timeout_2",
@@ -148,7 +148,8 @@ fn test_timeout_with_retries() -> Result<()> {
                     status.result,
                     ExecutionResult::Timeout {
                         result: SlowTimeoutResult::Pass
-                    }
+                    },
+                    "{test_name} should have timed out with on-timeout=pass"
                 );
             }
         };


### PR DESCRIPTION
Previously, the 10ms timeout wasn't even enough time to start the process under overloaded conditions like CI, which meant that test_flaky_slow_timeout_mod_3 wouldn't even get to the point where it was run (so it would always just hit a timeout-pass). Increase timeouts to 1s.