### PR TITLE
[fixture-data] use bitflags to manage bitflags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,11 +257,11 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1038,6 +1038,7 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 name = "fixture-data"
 version = "0.1.0"
 dependencies = [
+ "bitflags",
  "iddqd",
  "nextest-metadata",
  "nextest-workspace-hack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ aho-corasick = "1.1.4"
 async-scoped = { version = "0.9.0", features = ["use-tokio"] }
 atomicwrites = "0.4.4"
 bstr = { version = "1.12.1", default-features = false, features = ["std"] }
+bitflags = "2.10.0"
 bytes = "1.11.0"
 camino = "1.2.2"
 camino-tempfile = "1.4.1"

--- a/fixture-data/Cargo.toml
+++ b/fixture-data/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 publish = false
 
 [dependencies]
+bitflags.workspace = true
 iddqd.workspace = true
 nextest-metadata.workspace = true
 nextest-workspace-hack.workspace = true

--- a/fixture-data/src/nextest_tests.rs
+++ b/fixture-data/src/nextest_tests.rs
@@ -6,8 +6,8 @@
 //! TODO: need a better name than "nextest-tests".
 
 use crate::models::{
-    TestCaseFixture, TestCaseFixtureProperty, TestCaseFixtureStatus, TestSuiteFixture,
-    TestSuiteFixtureProperty,
+    TestCaseFixture, TestCaseFixtureProperties, TestCaseFixtureStatus, TestSuiteFixture,
+    TestSuiteFixtureProperties,
 };
 use iddqd::{IdOrdMap, id_ord_map};
 use nextest_metadata::{BuildPlatform, RustBinaryId};
@@ -22,7 +22,7 @@ pub static EXPECTED_TEST_SUITES: LazyLock<IdOrdMap<TestSuiteFixture>> = LazyLock
             BuildPlatform::Target,
             id_ord_map! {
                 TestCaseFixture::new("test_cargo_env_vars", TestCaseFixtureStatus::Pass)
-                    .with_property(TestCaseFixtureProperty::NotInDefaultSetUnix),
+                    .with_property(TestCaseFixtureProperties::NOT_IN_DEFAULT_SET_UNIX),
                 TestCaseFixture::new("test_cwd", TestCaseFixtureStatus::Pass),
                 TestCaseFixture::new("test_execute_bin", TestCaseFixtureStatus::Pass),
                 TestCaseFixture::new("test_failure_assert", TestCaseFixtureStatus::Fail),
@@ -32,12 +32,12 @@ pub static EXPECTED_TEST_SUITES: LazyLock<IdOrdMap<TestSuiteFixture>> = LazyLock
                     "test_flaky_mod_4",
                     TestCaseFixtureStatus::Flaky { pass_attempt: 4 },
                 )
-                .with_property(TestCaseFixtureProperty::NotInDefaultSet),
+                .with_property(TestCaseFixtureProperties::NOT_IN_DEFAULT_SET),
                 TestCaseFixture::new(
                     "test_flaky_mod_6",
                     TestCaseFixtureStatus::Flaky { pass_attempt: 6 },
                 )
-                .with_property(TestCaseFixtureProperty::NotInDefaultSet),
+                .with_property(TestCaseFixtureProperties::NOT_IN_DEFAULT_SET),
                 TestCaseFixture::new("test_ignored", TestCaseFixtureStatus::IgnoredPass),
                 TestCaseFixture::new("test_ignored_fail", TestCaseFixtureStatus::IgnoredFail),
                 TestCaseFixture::new("test_result_failure", TestCaseFixtureStatus::Fail),
@@ -136,14 +136,14 @@ pub static EXPECTED_TEST_SUITES: LazyLock<IdOrdMap<TestSuiteFixture>> = LazyLock
             BuildPlatform::Target,
             id_ord_map! {
                 TestCaseFixture::new("bench_add_two", TestCaseFixtureStatus::Pass)
-                    .with_property(TestCaseFixtureProperty::IsBenchmark),
+                    .with_property(TestCaseFixtureProperties::IS_BENCHMARK),
                 TestCaseFixture::new("bench_ignored", TestCaseFixtureStatus::IgnoredPass)
-                    .with_property(TestCaseFixtureProperty::IsBenchmark),
+                    .with_property(TestCaseFixtureProperties::IS_BENCHMARK),
                 TestCaseFixture::new("bench_slow_timeout", TestCaseFixtureStatus::IgnoredPass)
-                    .with_property(TestCaseFixtureProperty::IsBenchmark)
-                    .with_property(TestCaseFixtureProperty::BenchOverrideTimeout)
-                    .with_property(TestCaseFixtureProperty::BenchTermination)
-                    .with_property(TestCaseFixtureProperty::BenchIgnoresTestTimeout),
+                    .with_property(TestCaseFixtureProperties::IS_BENCHMARK)
+                    .with_property(TestCaseFixtureProperties::BENCH_OVERRIDE_TIMEOUT)
+                    .with_property(TestCaseFixtureProperties::BENCH_TERMINATION)
+                    .with_property(TestCaseFixtureProperties::BENCH_IGNORES_TEST_TIMEOUT),
                 TestCaseFixture::new("tests::test_execute_bin", TestCaseFixtureStatus::Pass),
             },
         ),
@@ -163,7 +163,7 @@ pub static EXPECTED_TEST_SUITES: LazyLock<IdOrdMap<TestSuiteFixture>> = LazyLock
             BuildPlatform::Target,
             id_ord_map! {
                 TestCaseFixture::new("test_multiply_two", TestCaseFixtureStatus::Pass)
-                    .with_property(TestCaseFixtureProperty::MatchesTestMultiplyTwo),
+                    .with_property(TestCaseFixtureProperties::MATCHES_TEST_MULTIPLY_TWO),
             },
         ),
         TestSuiteFixture::new(
@@ -178,12 +178,12 @@ pub static EXPECTED_TEST_SUITES: LazyLock<IdOrdMap<TestSuiteFixture>> = LazyLock
             BuildPlatform::Target,
             id_ord_map! {
                 TestCaseFixture::new("tests::test_multiply_two_cdylib", TestCaseFixtureStatus::Pass)
-                    .with_property(TestCaseFixtureProperty::MatchesCdylib)
-                    .with_property(TestCaseFixtureProperty::MatchesTestMultiplyTwo),
+                    .with_property(TestCaseFixtureProperties::MATCHES_CDYLIB)
+                    .with_property(TestCaseFixtureProperties::MATCHES_TEST_MULTIPLY_TWO),
             },
         )
-        .with_property(TestSuiteFixtureProperty::NotInDefaultSet)
-        .with_property(TestSuiteFixtureProperty::MatchesCdylibExample),
+        .with_property(TestSuiteFixtureProperties::NOT_IN_DEFAULT_SET)
+        .with_property(TestSuiteFixtureProperties::MATCHES_CDYLIB_EXAMPLE),
         // Build script tests
         TestSuiteFixture::new(
             "with-build-script",

--- a/integration-tests/tests/integration/main.rs
+++ b/integration-tests/tests/integration/main.rs
@@ -23,7 +23,7 @@
 //! `NEXTEST_BIN_EXE_cargo_nextest_dup`.
 
 use camino::{Utf8Path, Utf8PathBuf};
-use fixture_data::{models::RunProperty, nextest_tests::EXPECTED_TEST_SUITES};
+use fixture_data::{models::RunProperties, nextest_tests::EXPECTED_TEST_SUITES};
 use integration_tests::{
     env::set_env_vars,
     nextest_cli::{CargoNextestCli, CargoNextestOutput},
@@ -447,7 +447,11 @@ fn test_run() {
         Some(NextestExitCode::TEST_RUN_FAILED),
         "correct exit code for command\n{output}"
     );
-    check_run_output_with_junit(&output.stderr, &p.junit_path("default"), 0);
+    check_run_output_with_junit(
+        &output.stderr,
+        &p.junit_path("default"),
+        RunProperties::empty(),
+    );
 
     // --exact with nothing else should be the same as above.
     let output = CargoNextestCli::for_test()
@@ -468,7 +472,11 @@ fn test_run() {
         Some(NextestExitCode::TEST_RUN_FAILED),
         "correct exit code for command\n{output}"
     );
-    check_run_output_with_junit(&output.stderr, &p.junit_path("default"), 0);
+    check_run_output_with_junit(
+        &output.stderr,
+        &p.junit_path("default"),
+        RunProperties::empty(),
+    );
 
     // Check the output with --skip.
     let output = CargoNextestCli::for_test()
@@ -492,7 +500,7 @@ fn test_run() {
     check_run_output_with_junit(
         &output.stderr,
         &p.junit_path("default"),
-        RunProperty::WithSkipCdylibFilter as u64,
+        RunProperties::WITH_SKIP_CDYLIB_FILTER,
     );
 
     // Equivalent filterset to the above.
@@ -516,7 +524,7 @@ fn test_run() {
     check_run_output_with_junit(
         &output.stderr,
         &p.junit_path("default"),
-        RunProperty::WithSkipCdylibFilter as u64,
+        RunProperties::WITH_SKIP_CDYLIB_FILTER,
     );
 
     // Check the output with --exact.
@@ -537,7 +545,7 @@ fn test_run() {
     check_run_output_with_junit(
         &output.stderr,
         &p.junit_path("default"),
-        RunProperty::WithMultiplyTwoExactFilter as u64,
+        RunProperties::WITH_MULTIPLY_TWO_EXACT_FILTER,
     );
 
     // Equivalent filterset to the above.
@@ -556,7 +564,7 @@ fn test_run() {
     check_run_output_with_junit(
         &output.stderr,
         &p.junit_path("default"),
-        RunProperty::WithMultiplyTwoExactFilter as u64,
+        RunProperties::WITH_MULTIPLY_TWO_EXACT_FILTER,
     );
 
     // Check the output with --exact and --skip.
@@ -581,7 +589,7 @@ fn test_run() {
     check_run_output_with_junit(
         &output.stderr,
         &p.junit_path("default"),
-        RunProperty::WithSkipCdylibFilter as u64 | RunProperty::WithMultiplyTwoExactFilter as u64,
+        RunProperties::WITH_SKIP_CDYLIB_FILTER | RunProperties::WITH_MULTIPLY_TWO_EXACT_FILTER,
     );
 
     // Equivalent filterset to the above.
@@ -601,7 +609,7 @@ fn test_run() {
     check_run_output_with_junit(
         &output.stderr,
         &p.junit_path("default"),
-        RunProperty::WithSkipCdylibFilter as u64 | RunProperty::WithMultiplyTwoExactFilter as u64,
+        RunProperties::WITH_SKIP_CDYLIB_FILTER | RunProperties::WITH_MULTIPLY_TWO_EXACT_FILTER,
     );
 
     // Another equivalent.
@@ -624,7 +632,7 @@ fn test_run() {
     check_run_output_with_junit(
         &output.stderr,
         &p.junit_path("default"),
-        RunProperty::WithSkipCdylibFilter as u64 | RunProperty::WithMultiplyTwoExactFilter as u64,
+        RunProperties::WITH_SKIP_CDYLIB_FILTER | RunProperties::WITH_MULTIPLY_TWO_EXACT_FILTER,
     );
 
     // Yet another equivalent.
@@ -648,7 +656,7 @@ fn test_run() {
     check_run_output_with_junit(
         &output.stderr,
         &p.junit_path("default"),
-        RunProperty::WithSkipCdylibFilter as u64 | RunProperty::WithMultiplyTwoExactFilter as u64,
+        RunProperties::WITH_SKIP_CDYLIB_FILTER | RunProperties::WITH_MULTIPLY_TWO_EXACT_FILTER,
     );
 }
 
@@ -675,7 +683,11 @@ fn test_run_after_build() {
         Some(NextestExitCode::TEST_RUN_FAILED),
         "correct exit code for command\n{output}"
     );
-    check_run_output_with_junit(&output.stderr, &p.junit_path("default"), 0);
+    check_run_output_with_junit(
+        &output.stderr,
+        &p.junit_path("default"),
+        RunProperties::empty(),
+    );
 }
 
 /// Test that per-benchmark override for bench.slow-timeout is respected.
@@ -713,9 +725,9 @@ fn test_bench_override_slow_timeout() {
     check_run_output_with_junit(
         &output.stderr,
         &p.junit_path("with-bench-override"),
-        RunProperty::BenchOverrideTimeout as u64
-            | RunProperty::Benchmarks as u64
-            | RunProperty::SkipSummaryCheck as u64,
+        RunProperties::BENCH_OVERRIDE_TIMEOUT
+            | RunProperties::BENCHMARKS
+            | RunProperties::SKIP_SUMMARY_CHECK,
     );
 }
 
@@ -752,9 +764,9 @@ fn test_bench_termination() {
     check_run_output_with_junit(
         &output.stderr,
         &p.junit_path("with-bench-termination"),
-        RunProperty::BenchTermination as u64
-            | RunProperty::Benchmarks as u64
-            | RunProperty::SkipSummaryCheck as u64,
+        RunProperties::BENCH_TERMINATION
+            | RunProperties::BENCHMARKS
+            | RunProperties::SKIP_SUMMARY_CHECK,
     );
 }
 
@@ -798,9 +810,9 @@ fn test_bench_ignores_test_slow_timeout() {
     check_run_output_with_junit(
         &output.stderr,
         &p.junit_path("with-test-termination-only"),
-        RunProperty::BenchIgnoresTestTimeout as u64
-            | RunProperty::Benchmarks as u64
-            | RunProperty::SkipSummaryCheck as u64,
+        RunProperties::BENCH_IGNORES_TEST_TIMEOUT
+            | RunProperties::BENCHMARKS
+            | RunProperties::SKIP_SUMMARY_CHECK,
     );
 }
 
@@ -863,7 +875,7 @@ fn test_relocated_run() {
     check_run_output_with_junit(
         &output.stderr,
         &p2.junit_path("default"),
-        RunProperty::Relocated as u64,
+        RunProperties::RELOCATED,
     );
 }
 
@@ -1013,7 +1025,7 @@ fn test_archive_with_build_filter() {
         }
         run_archive_with_args(
             &archive_file,
-            RunProperty::Relocated as u64,
+            RunProperties::RELOCATED,
             NextestExitCode::TEST_RUN_FAILED,
         );
     });
@@ -1038,7 +1050,7 @@ fn test_archive_with_build_filter() {
         }
         run_archive_with_args(
             &archive_file,
-            RunProperty::SkipSummaryCheck as u64 | RunProperty::ExpectNoBinaries as u64,
+            RunProperties::SKIP_SUMMARY_CHECK | RunProperties::EXPECT_NO_BINARIES,
             NextestExitCode::NO_TESTS_RUN,
         );
     });
@@ -1063,7 +1075,7 @@ fn test_archive_with_build_filter() {
         );
         run_archive_with_args(
             &archive_file,
-            RunProperty::CdyLibExamplePackageFilter as u64 | RunProperty::SkipSummaryCheck as u64,
+            RunProperties::CDYLIB_EXAMPLE_PACKAGE_FILTER | RunProperties::SKIP_SUMMARY_CHECK,
             NextestExitCode::OK,
         );
     });
@@ -1227,14 +1239,14 @@ fn create_archive_with_args(
 fn run_archive(archive_file: &Utf8Path) -> (TempProject, Utf8PathBuf) {
     run_archive_with_args(
         archive_file,
-        RunProperty::Relocated as u64,
+        RunProperties::RELOCATED,
         NextestExitCode::TEST_RUN_FAILED,
     )
 }
 
 fn run_archive_with_args(
     archive_file: &Utf8Path,
-    run_property: u64,
+    run_property: RunProperties,
     expected_exit_code: i32,
 ) -> (TempProject, Utf8PathBuf) {
     let p2 = TempProject::new().unwrap();
@@ -1285,7 +1297,7 @@ fn test_bench() {
         Some(0),
         "correct exit code for command\n{output}",
     );
-    check_run_output(&output.stderr, RunProperty::Benchmarks as u64);
+    check_run_output(&output.stderr, RunProperties::BENCHMARKS);
 }
 
 #[test]
@@ -1586,7 +1598,7 @@ fn test_run_with_default_filter() {
     check_run_output_with_junit(
         &output.stderr,
         &p.junit_path("with-default-filter"),
-        RunProperty::WithDefaultFilter as u64,
+        RunProperties::WITH_DEFAULT_FILTER,
     );
 }
 

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -54,7 +54,7 @@ serde_core = { version = "1.0.228", features = ["alloc"] }
 syn = { version = "2.0.106", features = ["extra-traits", "full", "visit", "visit-mut"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
-bitflags = { version = "2.9.4", default-features = false, features = ["std"] }
+bitflags = { version = "2.10.0", default-features = false, features = ["std"] }
 dof = { version = "0.4.0", default-features = false, features = ["des"] }
 futures-channel = { version = "0.3.31", features = ["sink"] }
 futures-core = { version = "0.3.31" }
@@ -72,7 +72,7 @@ usdt-impl = { version = "0.6.0", default-features = false, features = ["des"] }
 zerocopy = { version = "0.8.27", default-features = false, features = ["derive", "simd"] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
-bitflags = { version = "2.9.4", default-features = false, features = ["std"] }
+bitflags = { version = "2.10.0", default-features = false, features = ["std"] }
 dof = { version = "0.4.0", default-features = false, features = ["des"] }
 libc = { version = "0.2.178", features = ["extra_traits"] }
 log = { version = "0.4.29", default-features = false, features = ["std"] }
@@ -81,7 +81,7 @@ usdt-impl = { version = "0.6.0", default-features = false, features = ["des"] }
 zerocopy = { version = "0.8.27", default-features = false, features = ["derive", "simd"] }
 
 [target.aarch64-unknown-linux-gnu.dependencies]
-bitflags = { version = "2.9.4", default-features = false, features = ["std"] }
+bitflags = { version = "2.10.0", default-features = false, features = ["std"] }
 futures-channel = { version = "0.3.31", features = ["sink"] }
 futures-core = { version = "0.3.31" }
 futures-sink = { version = "0.3.31" }
@@ -93,11 +93,11 @@ smallvec = { version = "1.15.1", default-features = false, features = ["const_ne
 tokio = { version = "1.48.0", default-features = false, features = ["net"] }
 
 [target.aarch64-unknown-linux-gnu.build-dependencies]
-bitflags = { version = "2.9.4", default-features = false, features = ["std"] }
+bitflags = { version = "2.10.0", default-features = false, features = ["std"] }
 libc = { version = "0.2.178", features = ["extra_traits"] }
 
 [target.x86_64-unknown-linux-musl.dependencies]
-bitflags = { version = "2.9.4", default-features = false, features = ["std"] }
+bitflags = { version = "2.10.0", default-features = false, features = ["std"] }
 dof = { version = "0.4.0", default-features = false, features = ["des"] }
 futures-channel = { version = "0.3.31", features = ["sink"] }
 futures-core = { version = "0.3.31" }
@@ -115,7 +115,7 @@ usdt-impl = { version = "0.6.0", default-features = false, features = ["des"] }
 zerocopy = { version = "0.8.27", default-features = false, features = ["derive", "simd"] }
 
 [target.x86_64-unknown-linux-musl.build-dependencies]
-bitflags = { version = "2.9.4", default-features = false, features = ["std"] }
+bitflags = { version = "2.10.0", default-features = false, features = ["std"] }
 dof = { version = "0.4.0", default-features = false, features = ["des"] }
 libc = { version = "0.2.178", features = ["extra_traits"] }
 log = { version = "0.4.29", default-features = false, features = ["std"] }
@@ -124,7 +124,7 @@ usdt-impl = { version = "0.6.0", default-features = false, features = ["des"] }
 zerocopy = { version = "0.8.27", default-features = false, features = ["derive", "simd"] }
 
 [target.aarch64-unknown-linux-musl.dependencies]
-bitflags = { version = "2.9.4", default-features = false, features = ["std"] }
+bitflags = { version = "2.10.0", default-features = false, features = ["std"] }
 futures-channel = { version = "0.3.31", features = ["sink"] }
 futures-core = { version = "0.3.31" }
 futures-sink = { version = "0.3.31" }
@@ -136,11 +136,11 @@ smallvec = { version = "1.15.1", default-features = false, features = ["const_ne
 tokio = { version = "1.48.0", default-features = false, features = ["net"] }
 
 [target.aarch64-unknown-linux-musl.build-dependencies]
-bitflags = { version = "2.9.4", default-features = false, features = ["std"] }
+bitflags = { version = "2.10.0", default-features = false, features = ["std"] }
 libc = { version = "0.2.178", features = ["extra_traits"] }
 
 [target.x86_64-unknown-illumos.dependencies]
-bitflags = { version = "2.9.4", default-features = false, features = ["std"] }
+bitflags = { version = "2.10.0", default-features = false, features = ["std"] }
 dof = { version = "0.4.0", default-features = false, features = ["des"] }
 futures-channel = { version = "0.3.31", features = ["sink"] }
 futures-core = { version = "0.3.31" }
@@ -158,7 +158,7 @@ usdt-impl = { version = "0.6.0", default-features = false, features = ["des"] }
 zerocopy = { version = "0.8.27", default-features = false, features = ["derive", "simd"] }
 
 [target.x86_64-unknown-illumos.build-dependencies]
-bitflags = { version = "2.9.4", default-features = false, features = ["std"] }
+bitflags = { version = "2.10.0", default-features = false, features = ["std"] }
 dof = { version = "0.4.0", default-features = false, features = ["des"] }
 libc = { version = "0.2.178", features = ["extra_traits"] }
 log = { version = "0.4.29", default-features = false, features = ["std"] }
@@ -167,7 +167,7 @@ usdt-impl = { version = "0.6.0", default-features = false, features = ["des"] }
 zerocopy = { version = "0.8.27", default-features = false, features = ["derive", "simd"] }
 
 [target.x86_64-unknown-freebsd.dependencies]
-bitflags = { version = "2.9.4", default-features = false, features = ["std"] }
+bitflags = { version = "2.10.0", default-features = false, features = ["std"] }
 dof = { version = "0.4.0", default-features = false, features = ["des"] }
 futures-channel = { version = "0.3.31", features = ["sink"] }
 futures-core = { version = "0.3.31" }
@@ -185,7 +185,7 @@ usdt-impl = { version = "0.6.0", default-features = false, features = ["des"] }
 zerocopy = { version = "0.8.27", default-features = false, features = ["derive", "simd"] }
 
 [target.x86_64-unknown-freebsd.build-dependencies]
-bitflags = { version = "2.9.4", default-features = false, features = ["std"] }
+bitflags = { version = "2.10.0", default-features = false, features = ["std"] }
 dof = { version = "0.4.0", default-features = false, features = ["des"] }
 libc = { version = "0.2.178", features = ["extra_traits"] }
 log = { version = "0.4.29", default-features = false, features = ["std"] }
@@ -194,7 +194,7 @@ usdt-impl = { version = "0.6.0", default-features = false, features = ["des"] }
 zerocopy = { version = "0.8.27", default-features = false, features = ["derive", "simd"] }
 
 [target.aarch64-unknown-freebsd.dependencies]
-bitflags = { version = "2.9.4", default-features = false, features = ["std"] }
+bitflags = { version = "2.10.0", default-features = false, features = ["std"] }
 dof = { version = "0.4.0", default-features = false, features = ["des"] }
 futures-channel = { version = "0.3.31", features = ["sink"] }
 futures-core = { version = "0.3.31" }
@@ -212,7 +212,7 @@ usdt-impl = { version = "0.6.0", default-features = false, features = ["des"] }
 zerocopy = { version = "0.8.27", default-features = false, features = ["derive", "simd"] }
 
 [target.aarch64-unknown-freebsd.build-dependencies]
-bitflags = { version = "2.9.4", default-features = false, features = ["std"] }
+bitflags = { version = "2.10.0", default-features = false, features = ["std"] }
 dof = { version = "0.4.0", default-features = false, features = ["des"] }
 libc = { version = "0.2.178", features = ["extra_traits"] }
 log = { version = "0.4.29", default-features = false, features = ["std"] }
@@ -221,7 +221,7 @@ usdt-impl = { version = "0.6.0", default-features = false, features = ["des"] }
 zerocopy = { version = "0.8.27", default-features = false, features = ["derive", "simd"] }
 
 [target.aarch64-apple-darwin.dependencies]
-bitflags = { version = "2.9.4", default-features = false, features = ["std"] }
+bitflags = { version = "2.10.0", default-features = false, features = ["std"] }
 futures-channel = { version = "0.3.31", features = ["sink"] }
 futures-core = { version = "0.3.31" }
 futures-sink = { version = "0.3.31" }
@@ -238,7 +238,7 @@ usdt-impl = { version = "0.6.0", default-features = false, features = ["des"] }
 zerocopy = { version = "0.8.27", default-features = false, features = ["derive", "simd"] }
 
 [target.aarch64-apple-darwin.build-dependencies]
-bitflags = { version = "2.9.4", default-features = false, features = ["std"] }
+bitflags = { version = "2.10.0", default-features = false, features = ["std"] }
 libc = { version = "0.2.178", features = ["extra_traits"] }
 log = { version = "0.4.29", default-features = false, features = ["std"] }
 serde_json = { version = "1.0.148", features = ["unbounded_depth"] }


### PR DESCRIPTION
Provides type safety -- we aren't just using a bunch of u64s any more.