### PR TITLE
[integration-tests] remove check_run_output

### DIFF
--- a/integration-tests/tests/integration/fixtures.rs
+++ b/integration-tests/tests/integration/fixtures.rs
@@ -703,11 +703,6 @@ fn verify_summary(
 }
 
 #[track_caller]
-pub fn check_run_output(stderr: &[u8], properties: RunProperties) {
-    check_run_output_impl(stderr, None, properties);
-}
-
-#[track_caller]
 pub fn check_run_output_with_junit(
     stderr: &[u8],
     junit_path: &Utf8Path,

--- a/integration-tests/tests/integration/main.rs
+++ b/integration-tests/tests/integration/main.rs
@@ -1345,7 +1345,11 @@ fn test_bench() {
         Some(0),
         "correct exit code for command\n{output}",
     );
-    check_run_output(&output.stderr, RunProperties::BENCHMARKS);
+    check_run_output_with_junit(
+        &output.stderr,
+        &p.junit_path("default"),
+        RunProperties::BENCHMARKS,
+    );
 }
 
 #[test]


### PR DESCRIPTION
Always use check_run_output_with_junit to ensure that JUnit output is verified.