### PR TITLE
[nextest-runner] add ToolName type for validated tool names

### DIFF
--- a/cargo-nextest/src/errors.rs
+++ b/cargo-nextest/src/errors.rs
@@ -8,7 +8,7 @@ use itertools::Itertools;
 use nextest_filtering::errors::FiltersetParseErrors;
 use nextest_metadata::NextestExitCode;
 use nextest_runner::{
-    config::core::ConfigExperimental,
+    config::core::{ConfigExperimental, ToolName},
     errors::*,
     helpers::{format_interceptor_too_many_tests, plural},
     list::OwnedTestInstanceId,
@@ -296,7 +296,7 @@ pub enum ExpectedError {
     RequiredVersionNotMet {
         required: Version,
         current: Version,
-        tool: Option<String>,
+        tool: Option<ToolName>,
     },
     #[error("experimental feature not enabled")]
     ExperimentalFeatureNotEnabled {

--- a/nextest-runner/src/config/elements/inherits.rs
+++ b/nextest-runner/src/config/elements/inherits.rs
@@ -21,7 +21,7 @@ impl Inherits {
 mod tests {
     use crate::{
         config::{
-            core::{NextestConfig, ToolConfigFile},
+            core::{NextestConfig, ToolConfigFile, ToolName},
             elements::{MaxFail, RetryPolicy, TerminateMode},
             utils::test_helpers::*,
         },
@@ -35,6 +35,10 @@ mod tests {
     use nextest_filtering::ParseContext;
     use std::{collections::HashSet, fs};
     use test_case::test_case;
+
+    fn tool_name(s: &str) -> ToolName {
+        ToolName::new(s.into()).unwrap()
+    }
 
     /// Settings checked for inheritance below.
     #[derive(Default)]
@@ -309,11 +313,11 @@ mod tests {
         // tool1 is first = higher priority, tool2 is second = lower priority
         let tool_configs = [
             ToolConfigFile {
-                tool: "tool1".to_string(),
+                tool: tool_name("tool1"),
                 config_file: tool1_config,
             },
             ToolConfigFile {
-                tool: "tool2".to_string(),
+                tool: tool_name("tool2"),
                 config_file: tool2_config,
             },
         ];
@@ -379,11 +383,11 @@ mod tests {
 
         let tool_configs = [
             ToolConfigFile {
-                tool: "tool1".to_string(),
+                tool: tool_name("tool1"),
                 config_file: tool1_config,
             },
             ToolConfigFile {
-                tool: "tool2".to_string(),
+                tool: tool_name("tool2"),
                 config_file: tool2_config,
             },
         ];
@@ -399,7 +403,7 @@ mod tests {
 
         // Error should be attributed to tool2 since that's where the invalid
         // inheritance is defined.
-        assert_eq!(error.tool(), Some("tool2"));
+        assert_eq!(error.tool(), Some(&tool_name("tool2")));
 
         match error.kind() {
             ConfigParseErrorKind::InheritanceErrors(errors) => {

--- a/nextest-runner/src/config/scripts/imp.rs
+++ b/nextest-runner/src/config/scripts/imp.rs
@@ -1020,7 +1020,7 @@ mod tests {
     use super::*;
     use crate::{
         config::{
-            core::{ConfigExperimental, NextestConfig, ToolConfigFile},
+            core::{ConfigExperimental, NextestConfig, ToolConfigFile, ToolName},
             utils::test_helpers::*,
         },
         errors::{
@@ -1033,6 +1033,10 @@ mod tests {
     use indoc::indoc;
     use maplit::btreeset;
     use test_case::test_case;
+
+    fn tool_name(s: &str) -> ToolName {
+        ToolName::new(s.into()).unwrap()
+    }
 
     #[test]
     fn test_scripts_basic() {
@@ -1086,7 +1090,7 @@ mod tests {
         let pcx = ParseContext::new(&graph);
 
         let tool_config_files = [ToolConfigFile {
-            tool: "my-tool".to_owned(),
+            tool: tool_name("my-tool"),
             config_file: tool_path.to_path_buf(),
         }];
 
@@ -1526,7 +1530,7 @@ mod tests {
         let tool_path = workspace_dir.child(".config/my-tool.toml");
         tool_path.write_str(tool_config_contents).unwrap();
         let tool_config_files = [ToolConfigFile {
-            tool: "my-tool".to_owned(),
+            tool: tool_name("my-tool"),
             config_file: tool_path.to_path_buf(),
         }];
 


### PR DESCRIPTION
Introduce a ToolName type that validates tool names at construction time, replacing raw String usage throughout nextest-runner. Tool names are validated to ensure they:

- Are non-empty
- Follow Unicode XID rules (XID_Start followed by XID_Continue or hyphen)
- Are NFC-normalized for consistent comparison
- Do not start with the reserved `@tool` prefix

Also put identifier validation logic into a shared is_valid_identifier_unicode helper in `config::utils`.