### PR TITLE
[nextest-runner] remove indent_write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,7 +355,6 @@ dependencies = [
  "guppy",
  "humantime",
  "idna_adapter",
- "indent_write",
  "insta",
  "itertools",
  "miette",
@@ -1630,12 +1629,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indent_write"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cfe9645a18782869361d9c8732246be7b410ad4e919d3609ebabdac00ba12c3"
-
-[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2093,7 +2086,6 @@ dependencies = [
  "http",
  "humantime-serde",
  "iddqd",
- "indent_write",
  "indexmap",
  "indicatif 0.18.3",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,8 +71,6 @@ humantime-serde = "1.1.1"
 iddqd = "0.3.17"
 # Disable punycode parsing since we only access well-known domains.
 idna_adapter = "=1.0.0"
-indenter = "0.3.4"
-indent_write = "2.2.0"
 indexmap = "2.12.1"
 indicatif = "0.18.3"
 indoc = "2.0.7"

--- a/cargo-nextest/Cargo.toml
+++ b/cargo-nextest/Cargo.toml
@@ -22,7 +22,6 @@ enable-ansi-support.workspace = true
 guppy.workspace = true
 humantime.workspace = true
 idna_adapter.workspace = true
-indent_write.workspace = true
 itertools.workspace = true
 miette = { workspace = true, features = ["fancy"] }
 # Instead of using workspace dependencies which have floating versions, we pin exact versions here

--- a/cargo-nextest/src/errors.rs
+++ b/cargo-nextest/src/errors.rs
@@ -3,7 +3,6 @@
 
 use crate::{ExtractOutputFormat, output::StderrStyles};
 use camino::Utf8PathBuf;
-use indent_write::indentable::Indented;
 use itertools::Itertools;
 use nextest_filtering::errors::FiltersetParseErrors;
 use nextest_metadata::NextestExitCode;
@@ -11,6 +10,7 @@ use nextest_runner::{
     config::core::{ConfigExperimental, ToolName},
     errors::*,
     helpers::{format_interceptor_too_many_tests, plural},
+    indenter::DisplayIndented,
     list::OwnedTestInstanceId,
     redact::Redactor,
     run_mode::NextestRunMode,
@@ -1116,7 +1116,7 @@ impl ExpectedError {
             error!(
                 target: "cargo_nextest::no_heading",
                 "\nCaused by:\n{}",
-                Indented { item: err, indent: "  " },
+                DisplayIndented { item: err, indent: "  " },
             );
             next_error = err.source();
         }

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -37,7 +37,6 @@ guppy.workspace = true
 home.workspace = true
 humantime-serde.workspace = true
 iddqd.workspace = true
-indent_write.workspace = true
 indexmap = { workspace = true, features = ["serde"] }
 indicatif.workspace = true
 is_ci.workspace = true

--- a/nextest-runner/src/indenter.rs
+++ b/nextest-runner/src/indenter.rs
@@ -3,100 +3,36 @@
 
 //! Support for indenting multi-line displays.
 //!
-//! This module is adapted from [indenter](https://github.com/eyre-rs/indenter) and is used under the
-//! terms of the MIT or Apache-2.0 licenses.
+//! This module is adapted from [indenter](https://github.com/eyre-rs/indenter) and is used under
+//! the terms of the MIT or Apache-2.0 licenses.
 //!
-//! # Notes
-//!
-//! We previously used to use `indenter` to indent multi-line `fmt::Display`
-//! instances. However, at some point we needed to also indent
-//! `std::io::Write`s, not just `fmt::Write`. `indenter` 0.3.3 doesn't support
-//! `std::io::Write`, so we switched to `indent_write`.
-//!
-//! This file still has the `indenter` API. So we have both APIs floating around
-//! for a bit... oh well. Still in two minds about which one's better here.
+//! The main type is [`Indented`], which wraps a writer and indents each line. It works with both
+//! [`WriteStr`] and [`fmt::Write`].
 
 use crate::write_str::WriteStr;
-use std::io;
+use std::{
+    fmt::{self, Write as _},
+    io,
+};
 
-/// The set of supported formats for indentation
-#[expect(missing_debug_implementations)]
-pub enum Format<'a> {
-    /// Insert uniform indentation before every line
-    ///
-    /// This format takes a static string as input and inserts it after every newline
-    Uniform {
-        /// The string to insert as indentation
-        indentation: &'static str,
-    },
-    /// Inserts a number before the first line
-    ///
-    /// This format hard codes the indentation level to match the indentation from
-    /// `core::backtrace::Backtrace`
-    Numbered {
-        /// The index to insert before the first line of output
-        ind: usize,
-    },
-    /// A custom indenter which is executed after every newline
-    ///
-    /// Custom indenters are passed the current line number and the buffer to be written to as args
-    Custom {
-        /// The custom indenter
-        inserter: &'a mut Inserter,
-    },
-}
-
-/// Helper struct for efficiently indenting multi line display implementations
-///
-/// # Explanation
+/// Helper struct for efficiently indenting multi-line display implementations.
 ///
 /// This type will never allocate a string to handle inserting indentation. It instead leverages
 /// the `write_str` function that serves as the foundation of the `core::fmt::Write` trait. This
-/// lets it intercept each piece of output as its being written to the output buffer. It then
+/// lets it intercept each piece of output as it's being written to the output buffer. It then
 /// splits on newlines giving slices into the original string. Finally we alternate writing these
 /// lines and the specified indentation to the output buffer.
 #[expect(missing_debug_implementations)]
 pub struct Indented<'a, D: ?Sized> {
     inner: &'a mut D,
     needs_indent: bool,
-    format: Format<'a>,
-}
-
-/// A callback for `Format::Custom` used to insert indenation after a new line
-///
-/// The first argument is the line number within the output, starting from 0
-pub type Inserter = dyn FnMut(usize, &mut dyn WriteStr) -> io::Result<()>;
-
-impl Format<'_> {
-    fn insert_indentation(&mut self, line: usize, f: &mut dyn WriteStr) -> io::Result<()> {
-        match self {
-            Format::Uniform { indentation } => write!(f, "{indentation}"),
-            Format::Numbered { ind } => {
-                if line == 0 {
-                    write!(f, "{ind: >4}: ")
-                } else {
-                    write!(f, "      ")
-                }
-            }
-            Format::Custom { inserter } => inserter(line, f),
-        }
-    }
+    indentation: &'static str,
 }
 
 impl<'a, D: ?Sized> Indented<'a, D> {
-    /// Sets the format to `Format::Numbered` with the provided index
-    pub fn ind(self, ind: usize) -> Self {
-        self.with_format(Format::Numbered { ind })
-    }
-
-    /// Sets the format to `Format::Uniform` with the provided static string
-    pub fn with_str(self, indentation: &'static str) -> Self {
-        self.with_format(Format::Uniform { indentation })
-    }
-
-    /// Construct an indenter with a user defined format
-    pub fn with_format(mut self, format: Format<'a>) -> Self {
-        self.format = format;
+    /// Sets the indentation string.
+    pub fn with_str(mut self, indentation: &'static str) -> Self {
+        self.indentation = indentation;
         self
     }
 
@@ -127,16 +63,16 @@ where
             }
 
             if self.needs_indent {
-                // Don't render the line unless its actually got text on it
+                // Don't render the line unless it actually has text on it.
                 if line.is_empty() {
                     continue;
                 }
 
-                self.format.insert_indentation(ind, &mut self.inner)?;
+                self.inner.write_str(self.indentation)?;
                 self.needs_indent = false;
             }
 
-            self.inner.write_fmt(format_args!("{line}"))?;
+            self.inner.write_str(line)?;
         }
 
         Ok(())
@@ -149,13 +85,61 @@ where
     }
 }
 
-/// Helper function for creating a default indenter
+impl<T> fmt::Write for Indented<'_, T>
+where
+    T: fmt::Write + ?Sized,
+{
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for (ind, line) in s.split('\n').enumerate() {
+            if ind > 0 {
+                self.inner.write_char('\n')?;
+                self.needs_indent = true;
+            }
+
+            if self.needs_indent {
+                // Don't render the line unless it actually has text on it.
+                if line.is_empty() {
+                    continue;
+                }
+
+                self.inner.write_str(self.indentation)?;
+                self.needs_indent = false;
+            }
+
+            self.inner.write_str(line)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Helper function for creating a default indenter.
 pub fn indented<D: ?Sized>(f: &mut D) -> Indented<'_, D> {
     Indented {
         inner: f,
         needs_indent: true,
-        format: Format::Uniform {
-            indentation: "    ",
-        },
+        indentation: "    ",
+    }
+}
+
+/// Wraps a `Display` item to indent each line when displayed.
+///
+/// This is useful for indenting error messages or other multi-line output.
+#[derive(Clone, Debug)]
+pub struct DisplayIndented<T> {
+    /// The item to display with indentation.
+    pub item: T,
+    /// The indentation string to prepend to each line.
+    pub indent: &'static str,
+}
+
+impl<T: fmt::Display> fmt::Display for DisplayIndented<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut indented = Indented {
+            inner: f,
+            needs_indent: true,
+            indentation: self.indent,
+        };
+        write!(indented, "{}", self.item)
     }
 }

--- a/nextest-runner/src/platform.rs
+++ b/nextest-runner/src/platform.rs
@@ -9,10 +9,10 @@ use crate::{
     errors::{
         DisplayErrorChain, HostPlatformDetectError, RustBuildMetaParseError, TargetTripleError,
     },
+    indenter::DisplayIndented,
     reuse_build::{LibdirMapper, PlatformLibdirMapper},
 };
 use camino::{Utf8Path, Utf8PathBuf};
-use indent_write::indentable::Indented;
 use nextest_metadata::{
     BuildPlatformsSummary, HostPlatformSummary, PlatformLibdirSummary, PlatformLibdirUnavailable,
     TargetPlatformSummary,
@@ -317,11 +317,11 @@ fn detect_host_platform() -> Result<Platform, HostPlatformDetectError> {
                              - `rustc -vV` stderr:\n{}",
                             output.status,
                             build_target.triple().as_str(),
-                            Indented {
+                            DisplayIndented {
                                 item: String::from_utf8_lossy(&output.stdout),
                                 indent: "  "
                             },
-                            Indented {
+                            DisplayIndented {
                                 item: String::from_utf8_lossy(&output.stderr),
                                 indent: "  "
                             },


### PR DESCRIPTION
We have our own indented wrapper, so just use that.