### PR TITLE
[nextest-runner] support "host-tuple" as a target triple

### DIFF
--- a/cargo-nextest/src/dispatch/helpers.rs
+++ b/cargo-nextest/src/dispatch/helpers.rs
@@ -15,7 +15,7 @@ use nextest_runner::{
     RustcCli,
     cargo_config::{CargoConfigs, TargetTriple},
     errors::TargetTripleError,
-    platform::{BuildPlatforms, HostPlatform, PlatformLibdir, TargetPlatform},
+    platform::{BuildPlatforms, HostPlatform, Platform, PlatformLibdir, TargetPlatform},
     reporter::TestOutputErrorSlice,
     target_runner::{PlatformRunner, TargetRunner},
 };
@@ -75,7 +75,7 @@ pub(super) fn detect_build_platforms(
     let host = HostPlatform::detect(PlatformLibdir::from_rustc_stdout(
         RustcCli::print_host_libdir().read(),
     ))?;
-    let triple_info = discover_target_triple(cargo_configs, target_cli_option)?;
+    let triple_info = discover_target_triple(cargo_configs, target_cli_option, &host.platform)?;
     let target = triple_info.map(|triple| {
         let libdir =
             PlatformLibdir::from_rustc_stdout(RustcCli::print_target_libdir(&triple).read());
@@ -87,8 +87,9 @@ pub(super) fn detect_build_platforms(
 pub(super) fn discover_target_triple(
     cargo_configs: &CargoConfigs,
     target_cli_option: Option<&str>,
+    host_platform: &Platform,
 ) -> Result<Option<TargetTriple>, TargetTripleError> {
-    TargetTriple::find(cargo_configs, target_cli_option).inspect(|v| {
+    TargetTriple::find(cargo_configs, target_cli_option, host_platform).inspect(|v| {
         if let Some(triple) = v {
             debug!(
                 "using target triple `{}` defined by `{}`; {}",

--- a/nextest-runner/src/config/utils/test_helpers.rs
+++ b/nextest-runner/src/config/utils/test_helpers.rs
@@ -124,12 +124,14 @@ pub(in crate::config) fn custom_build_platforms(workspace_dir: &Utf8Path) -> Bui
     )
     .unwrap();
 
+    let host_platform = Platform::new("x86_64-unknown-linux-gnu", TargetFeatures::Unknown).unwrap();
+
     let mut fixture =
         Utf8PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("manifest dir is available"));
     fixture.pop();
     fixture.push("fixtures/custom-target/my-target.json");
 
-    let triple = TargetTriple::find(&configs, Some(fixture.as_str()))
+    let triple = TargetTriple::find(&configs, Some(fixture.as_str()), &host_platform)
         .expect("custom platform parsed")
         .expect("custom platform found");
     assert!(
@@ -143,7 +145,7 @@ pub(in crate::config) fn custom_build_platforms(workspace_dir: &Utf8Path) -> Bui
     );
 
     let host = HostPlatform {
-        platform: Platform::new("x86_64-unknown-linux-gnu", TargetFeatures::Unknown).unwrap(),
+        platform: host_platform,
         libdir: PlatformLibdir::Available(Utf8PathBuf::from(
             "/home/fake/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib",
         )),

--- a/nextest-runner/tests/integration/target_runner.rs
+++ b/nextest-runner/tests/integration/target_runner.rs
@@ -24,7 +24,7 @@ fn runner_for_target(triple: Option<&str>) -> Result<(BuildPlatforms, TargetRunn
         let host = HostPlatform::detect(PlatformLibdir::from_rustc_stdout(
             RustcCli::print_host_libdir().read(),
         ))?;
-        let target = if let Some(triple) = TargetTriple::find(&configs, triple)? {
+        let target = if let Some(triple) = TargetTriple::find(&configs, triple, &host.platform)? {
             let libdir =
                 PlatformLibdir::from_rustc_stdout(RustcCli::print_target_libdir(&triple).read());
             Some(TargetPlatform::new(triple, libdir))

--- a/nextest-runner/tests/integration/target_triple.rs
+++ b/nextest-runner/tests/integration/target_triple.rs
@@ -194,10 +194,19 @@ fn target_triple(
         target_paths,
     )
     .unwrap();
-    let triple = TargetTriple::find(&configs, target_cli_option)?;
+    let host_platform = dummy_host_platform();
+    let triple = TargetTriple::find(&configs, target_cli_option, &host_platform)?;
     Ok(triple)
 }
 
 fn platform(triple_str: &str) -> Platform {
     Platform::new(triple_str.to_owned(), TargetFeatures::Unknown).unwrap()
+}
+
+fn dummy_host_platform() -> Platform {
+    Platform::new(
+        "x86_64-unknown-linux-gnu".to_owned(),
+        TargetFeatures::Unknown,
+    )
+    .unwrap()
 }


### PR DESCRIPTION
Recent Rust versions added `--target host-tuple` support, allowing users to explicitly do a cross-compile targeting the host platform. This change adds support for "host-tuple" as a special target string that resolves to the detected host platform.

Closes #2858.