### PR TITLE
[nextest-runner] ignore SIGTTIN/SIGTTOU while input handling is active

### DIFF
--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -25,6 +25,10 @@ path = "test-helpers/fake-interceptor.rs"
 name = "passthrough"
 path = "test-helpers/passthrough.rs"
 
+[[bin]]
+name = "grab-foreground"
+path = "test-helpers/grab-foreground.rs"
+
 [[test]]
 name = "custom-harness"
 harness = false

--- a/integration-tests/test-helpers/grab-foreground.rs
+++ b/integration-tests/test-helpers/grab-foreground.rs
@@ -1,0 +1,73 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! A test helper that grabs foreground process group access.
+//!
+//! This simulates what interactive shells do when they start up: they open
+//! `/dev/tty` directly (bypassing any stdin redirection) and call `tcsetpgrp`
+//! to become the foreground process group. This causes the parent process to
+//! become a background process, which will receive SIGTTOU if it tries to
+//! modify terminal state.
+//!
+//! See <https://github.com/nextest-rs/nextest/issues/2878>.
+
+fn main() {
+    #[cfg(unix)]
+    unix::grab_foreground();
+}
+
+#[cfg(unix)]
+mod unix {
+    use std::{fs::File, os::fd::AsRawFd};
+
+    pub(super) fn grab_foreground() {
+        // Open /dev/tty directly, like interactive shells do. This bypasses
+        // any stdin redirection that nextest might have set up.
+        eprintln!("[grab-foreground] opening /dev/tty");
+        let tty = match File::open("/dev/tty") {
+            Ok(f) => f,
+            Err(e) => {
+                // No controlling terminal (e.g., in CI). This is expected.
+                eprintln!("[grab-foreground] failed to open /dev/tty (expected in CI): {e}");
+                return;
+            }
+        };
+        let tty_fd = tty.as_raw_fd();
+        eprintln!("[grab-foreground] opened /dev/tty");
+
+        // Ignore SIGTTOU before calling tcsetpgrp. This is what zsh does:
+        // https://github.com/zsh-users/zsh/blob/3e72a52/Src/init.c#L1439
+        // Without this, tcsetpgrp from a background process would cause us to
+        // receive SIGTTOU and stop. Ignoring SIGTTOU has the special effect of
+        // allowing tcsetpgrp to succeed even from a background process.
+        //
+        // See also: https://github.com/zsh-users/zsh/blob/3e72a52/Src/exec.c#L1134-L1143
+        unsafe {
+            libc::signal(libc::SIGTTOU, libc::SIG_IGN);
+        }
+
+        // Create a new process group with this process as the leader.
+        let pid = unsafe { libc::getpid() };
+        let res = unsafe { libc::setpgid(pid, pid) };
+        if res == -1 {
+            eprintln!(
+                "[grab-foreground] setpgid failed: {}",
+                std::io::Error::last_os_error()
+            );
+            std::process::exit(1);
+        }
+        eprintln!("[grab-foreground] created new process group: {pid}");
+
+        // Grab the foreground process group on the controlling terminal.
+        let res = unsafe { libc::tcsetpgrp(tty_fd, pid) };
+        if res == -1 {
+            eprintln!(
+                "[grab-foreground] tcsetpgrp failed: {}",
+                std::io::Error::last_os_error()
+            );
+            std::process::exit(1);
+        }
+
+        eprintln!("[grab-foreground] successfully grabbed foreground");
+    }
+}

--- a/integration-tests/tests/integration/main.rs
+++ b/integration-tests/tests/integration/main.rs
@@ -37,6 +37,8 @@ use target_spec::{Platform, summaries::TargetFeaturesSummary};
 mod fixtures;
 mod interceptor;
 mod large_alloc;
+#[cfg(unix)]
+mod sigttou;
 mod stuck_signal;
 mod temp_project;
 mod user_config;

--- a/integration-tests/tests/integration/sigttou.rs
+++ b/integration-tests/tests/integration/sigttou.rs
@@ -1,0 +1,43 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Tests for SIGTTOU handling when subprocesses grab foreground access.
+//!
+//! When a test spawns a subprocess that takes over the foreground process
+//! group (e.g., an interactive shell), nextest becomes a background process.
+//! If nextest then tries to restore terminal state via `tcsetattr`, it will
+//! receive SIGTTOU and be suspended.
+//!
+//! The fix is to block SIGTTOU during `tcsetattr` calls.
+//!
+//! See <https://github.com/nextest-rs/nextest/issues/2878>.
+
+use std::process::Command;
+
+/// Spawning a subprocess that grabs the foreground process would trigger
+/// SIGTTOU without the fix.
+///
+/// This test is currently ignored because it requires a version of nextest with
+/// the fix.
+#[ignore]
+#[test]
+fn test_foreground_grab_does_not_suspend() {
+    // This issue could be reproduced with zsh -ic, though not with bash -ic or
+    // sh -ic (Ubuntu 24.04). But we don't want to introduce a dependency on zsh
+    // in our test suite, so we have a small helper binary which simulates the
+    // issue.
+    let bin_path = std::env::var("NEXTEST_BIN_EXE_grab_foreground")
+        .expect("NEXTEST_BIN_EXE_grab_foreground should be set by nextest");
+    let child = Command::new(bin_path)
+        .spawn()
+        .expect("spawned grab-foreground");
+    let output = child
+        .wait_with_output()
+        .expect("waited for grab-foreground");
+
+    assert!(
+        output.status.success(),
+        "grab-foreground should exit successfully: {:?}",
+        output
+    );
+}


### PR DESCRIPTION
When a test spawns an interactive shell (e.g., `zsh -ic`), the shell opens `/dev/tty` directly and calls `tcsetpgrp` to become the foreground process group. This causes nextest to become a background process. If nextest then tries to read from stdin (SIGTTIN) or restore terminal state via `tcsetattr` (SIGTTOU), it gets stopped.

The fix is to ignore SIGTTIN and SIGTTOU for the process lifetime once input handling is enabled (which only happens after we've checked that we're in the foreground in the first place). This is the same approach zsh uses for job control: https://github.com/zsh-users/zsh/blob/3e72a52/Src/init.c#L1439

Less invasive approaches don't work:

1. **Blocking SIGTTOU only around `tcsetattr` calls**: This doesn't handle SIGTTIN, which is sent when crossterm's background thread tries to read from stdin while we're a background process.

2. **Restoring SIG_DFL after `restore()`**: The crossterm input thread may still be running and could trigger SIGTTIN after we restore default signal handling but before the thread exits.

3. **Dropping EventStream before restoring SIG_DFL**: Dropping the stream doesn't synchronously wait for the crossterm thread to exit, so there's still a race.

The signals remain ignored for the process lifetime. This is fine for a test runner since we don't need SIGTTIN/SIGTTOU behavior.

Also add a test helper binary (`grab-foreground`) that simulates what interactive shells do, and an ignored integration test to verify the fix. (We'll un-ignore it once a version of nextest is out with this fix.)

```
cargo nextest run -p integration-tests sigttou --run-ignored all
```

Note that this fixes the signal, though not the larger issue that input handling is broken after a test does something weird like that. At some point we'll probably want to let users specify that some tests should be run under a pty, though that's not today.

Fixes: https://github.com/nextest-rs/nextest/issues/2878