### PR TITLE
[nextest-runner] add default-user-config.toml for user config defaults

### DIFF
--- a/integration-tests/tests/integration/user_config.rs
+++ b/integration-tests/tests/integration/user_config.rs
@@ -344,7 +344,7 @@ max-progress-running = "not-a-number"
 
     let stderr = output.stderr_as_str();
     assert!(
-        stderr.contains("invalid max-progress-running value"),
+        stderr.contains("invalid value: string \"not-a-number\""),
         "error message should mention invalid max-progress-running value\n{output}"
     );
 }

--- a/nextest-runner/default-user-config.toml
+++ b/nextest-runner/default-user-config.toml
@@ -1,0 +1,20 @@
+# This is the default user config used by nextest. It is embedded in the binary
+# at build time. It may be used as a template for ~/.config/nextest/config.toml.
+#
+# For documentation on these settings, see:
+# https://nexte.st/docs/user-config/reference
+
+[ui]
+# How to show progress during test runs.
+# Valid values: "auto", "none", "bar", "counter", "only"
+show-progress = "auto"
+
+# Maximum running tests to display in the progress bar.
+# Valid values: an integer, or "infinite" for unlimited.
+max-progress-running = 8
+
+# Whether to enable the input handler for keyboard shortcuts during test runs.
+input-handler = true
+
+# Whether to indent captured test output for visual clarity.
+output-indent = true

--- a/nextest-runner/src/user_config/imp.rs
+++ b/nextest-runner/src/user_config/imp.rs
@@ -3,7 +3,10 @@
 
 //! User config implementation.
 
-use super::{discovery::user_config_paths, elements::UiConfig};
+use super::{
+    discovery::user_config_paths,
+    elements::{DefaultUiConfig, UiConfig},
+};
 use crate::errors::UserConfigError;
 use camino::Utf8Path;
 use serde::Deserialize;
@@ -79,5 +82,38 @@ impl UserConfig {
 
         debug!("user config: loaded successfully from {path}");
         Ok(Some(config))
+    }
+}
+
+/// Default user configuration parsed from the embedded TOML.
+///
+/// All fields are required - this ensures the default config is complete.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DefaultUserConfig {
+    /// UI configuration.
+    pub ui: DefaultUiConfig,
+}
+
+impl DefaultUserConfig {
+    /// The embedded default user config TOML.
+    pub const DEFAULT_CONFIG: &'static str = include_str!("../../default-user-config.toml");
+
+    /// Parses the default config.
+    ///
+    /// Panics if the embedded TOML is invalid.
+    pub fn from_embedded() -> Self {
+        toml::from_str(Self::DEFAULT_CONFIG).expect("embedded default user config should be valid")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_user_config_is_valid() {
+        // This will panic if the TOML is missing any required fields.
+        let _ = DefaultUserConfig::from_embedded();
     }
 }

--- a/site/src/docs/user-config/reference.md
+++ b/site/src/docs/user-config/reference.md
@@ -109,10 +109,6 @@ UI settings are configured under `[ui]`.
 
 The default user configuration is:
 
-```toml
-[ui]
-show-progress = "auto"
-max-progress-running = 8
-input-handler = true
-output-indent = true
+```bash exec="true" result="toml"
+cat ../nextest-runner/default-user-config.toml
 ```


### PR DESCRIPTION
Previously, user config defaults were scattered across a few places. With this commit, `default-user-config.toml` is now embedded in the binary and parsed into `DefaultUserConfig`/`DefaultUiConfig` types with non-optional fields. If the TOML is missing any values, parsing fails at test time. The website dynamically includes this file similar to `default-config.toml`.

Also replace `serde(untagged)` use with explicit visitors, and require that the case of `infinite` matches (this hasn't been released yet so is not a breaking change.)