### PR TITLE
[cargo-nextest] add pager support for help output

### DIFF
--- a/cargo-nextest/Cargo.toml
+++ b/cargo-nextest/Cargo.toml
@@ -16,7 +16,7 @@ camino.workspace = true
 cfg-if.workspace = true
 clap = { workspace = true, features = ["derive", "env", "unicode", "wrap_help"] }
 color-eyre.workspace = true
-dialoguer.workspace = true
+dialoguer = { workspace = true, optional = true }
 duct.workspace = true
 enable-ansi-support.workspace = true
 guppy.workspace = true
@@ -54,7 +54,7 @@ insta.workspace = true
 default = ["default-no-update", "self-update"]
 experimental-tokio-console = ["nextest-runner/experimental-tokio-console"]
 # Perform self-updates (enabled by default)
-self-update = ["nextest-runner/self-update"]
+self-update = ["dep:dialoguer", "nextest-runner/self-update"]
 # Default set of features excluding self-update. This is the recommended set of features for
 # distributor and custom CI builds.
 default-no-update = []

--- a/cargo-nextest/src/dispatch/clap_error.rs
+++ b/cargo-nextest/src/dispatch/clap_error.rs
@@ -1,0 +1,274 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Clap error handling with pager support for help output.
+//!
+//! This module provides early argument extraction and clap error handling,
+//! enabling paged help output.
+//!
+//! The early argument extraction uses clap's own parsing with `ignore_errors`
+//! to properly handle the `--` separator.
+
+use crate::output::Color;
+use clap::{ArgAction, Args, Command};
+use nextest_runner::{
+    pager::PagedOutput,
+    platform::Platform,
+    user_config::{EarlyUserConfig, elements::PaginateSetting},
+};
+use std::io::{IsTerminal, Write};
+use tracing::debug;
+
+/// Early setup information needed before full CLI parsing.
+///
+/// This contains the build-time host platform and early arguments extracted
+/// from the command line. This is used for help output and other early
+/// decisions where we don't want to run `rustc -vV`.
+#[derive(Debug)]
+pub struct EarlySetup {
+    /// The build-time host platform.
+    ///
+    /// This uses `Platform::build_target()` rather than runtime detection via
+    /// `rustc -vV`. For help output and early config, this is sufficient and
+    /// avoids potential failures from missing/broken rustc.
+    build_target_platform: Platform,
+    /// Early arguments extracted before full parsing.
+    pub early_args: EarlyArgs,
+}
+
+impl EarlySetup {
+    /// Performs early setup: gets build target platform and extracts early args.
+    ///
+    /// This should be called once at startup, before CLI parsing. To avoid
+    /// complex error handling, this uses `Platform::build_target()`, which is
+    /// compile-time detection, not runtime `rustc -vV` detection.
+    pub fn new(cli_args: &[String], app: &Command) -> Self {
+        // Use the build target platform for early setup. This is compile-time
+        // detection and essentially infallible for supported platforms.
+        let build_target_platform =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        let early_args = extract_early_args(cli_args, app);
+        Self {
+            build_target_platform,
+            early_args,
+        }
+    }
+}
+
+/// Early arguments extracted before full CLI parsing.
+///
+/// These are needed to handle clap errors (especially help output) before
+/// the full argument parsing completes. Using clap's derive system with
+/// `global = true` ensures proper handling of the `--` separator.
+#[derive(Copy, Clone, Debug, Default, Args)]
+pub struct EarlyArgs {
+    /// Produce color output: auto, always, never
+    #[arg(
+        long,
+        value_enum,
+        default_value_t,
+        hide_possible_values = true,
+        global = true,
+        value_name = "WHEN",
+        env = "CARGO_TERM_COLOR"
+    )]
+    pub color: Color,
+
+    /// Do not pipe output through a pager.
+    #[arg(long, global = true)]
+    pub no_pager: bool,
+}
+
+/// Extracts early arguments from CLI args using clap's parsing.
+///
+/// This approach uses clap's own argument parsing with `ignore_errors(true)`
+/// to properly handle the `--` separator and other edge cases.
+///
+/// The technique is inspired by Jujutsu, which uses a similar approach for
+/// early argument extraction.
+fn extract_early_args(args: &[String], app: &Command) -> EarlyArgs {
+    // Clone the command and configure it for early parsing:
+    //
+    // - disable_version_flag: Don't stop at --version
+    // - disable_help_flag: Don't stop at -h/--help (we add a dummy instead)
+    // - ignore_errors: Continue parsing even with errors
+    //
+    // We add a dummy help flag that counts occurrences instead of triggering
+    // the DisplayHelp error. This allows early parsing to complete and extract
+    // our global options.
+    let early_cmd = app
+        .clone()
+        .disable_version_flag(true)
+        .disable_help_flag(true)
+        // Add a dummy help arg that doesn't stop parsing.
+        .arg(
+            clap::Arg::new("help")
+                .short('h')
+                .long("help")
+                .global(true)
+                .action(ArgAction::Count),
+        )
+        .ignore_errors(true);
+
+    // Try to parse. With ignore_errors, this should always succeed.
+    match early_cmd.try_get_matches_from(args) {
+        Ok(matches) => {
+            // Extract early args manually from matches.
+            // We use try_get_one to handle cases where the arg might not be
+            // present (e.g., if parsing failed partway through).
+            let no_pager = matches
+                .try_get_one::<bool>("no_pager")
+                .ok()
+                .flatten()
+                .copied()
+                .unwrap_or(false);
+            let color = matches
+                .try_get_one::<Color>("color")
+                .ok()
+                .flatten()
+                .copied()
+                .unwrap_or_default();
+            EarlyArgs { color, no_pager }
+        }
+        Err(_) => {
+            // This shouldn't happen with ignore_errors, but fall back to defaults.
+            EarlyArgs::default()
+        }
+    }
+}
+
+/// Handles a clap error, potentially paging help output.
+///
+/// Returns the exit code to use.
+pub fn handle_clap_error(err: clap::Error, early_setup: &EarlySetup) -> i32 {
+    use clap::error::ErrorKind;
+
+    match err.kind() {
+        ErrorKind::DisplayHelp | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => {
+            handle_help_output(
+                err,
+                &early_setup.early_args,
+                &early_setup.build_target_platform,
+            );
+            0
+        }
+        ErrorKind::DisplayVersion => {
+            // Version output is short, no paging needed.
+            let _ = err.print();
+            0
+        }
+        _ => {
+            // Other errors go to stderr.
+            let _ = err.print();
+            err.exit_code()
+        }
+    }
+}
+
+/// Handles help output, potentially through a pager.
+fn handle_help_output(err: clap::Error, early_args: &EarlyArgs, host_platform: &Platform) {
+    let should_colorize = early_args
+        .color
+        .should_colorize(supports_color::Stream::Stdout);
+
+    let help_text = if should_colorize {
+        err.render().ansi().to_string()
+    } else {
+        err.render().to_string()
+    };
+
+    let should_page = !early_args.no_pager && std::io::stdout().is_terminal();
+
+    if !should_page {
+        // No paging: write output directly. Do this as an early check before
+        // loading the user config.
+        let _ = std::io::stdout().write_all(help_text.as_bytes());
+        return;
+    }
+
+    let early_config = EarlyUserConfig::for_platform(host_platform);
+    if early_config.paginate == PaginateSetting::Never {
+        let _ = std::io::stdout().write_all(help_text.as_bytes());
+        return;
+    }
+
+    let mut paged = PagedOutput::request_pager(
+        &early_config.pager,
+        early_config.paginate,
+        &early_config.streampager,
+    );
+
+    if let Err(e) = paged.stdout().write_all(help_text.as_bytes()) {
+        // If writing to pager fails, try stdout directly.
+        debug!("failed to write to pager: {e}, falling back to stdout");
+        let _ = std::io::stdout().write_all(help_text.as_bytes());
+        return;
+    }
+
+    paged.finalize();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dispatch::cli::CargoNextestApp;
+    use clap::CommandFactory;
+
+    fn cmd() -> Command {
+        CargoNextestApp::command()
+    }
+
+    fn args(s: &str) -> Vec<String> {
+        s.split_whitespace().map(Into::into).collect()
+    }
+
+    #[test]
+    fn test_extract_early_args() {
+        // Remove this env var (which is set in CI) so that without arguments,
+        // color is auto.
+        unsafe {
+            std::env::remove_var("CARGO_TERM_COLOR");
+        }
+
+        // Empty args.
+        let early = extract_early_args(&[], &cmd());
+        assert!(!early.no_pager);
+        assert!(matches!(early.color, Color::Auto));
+
+        // --no-pager before subcommand.
+        let early = extract_early_args(&args("cargo nextest --no-pager run"), &cmd());
+        assert!(early.no_pager);
+
+        // --color=always (equals syntax).
+        let early = extract_early_args(&args("cargo nextest --color=always"), &cmd());
+        assert!(matches!(early.color, Color::Always));
+
+        // --color=never (equals syntax).
+        let early = extract_early_args(&args("cargo nextest --color=never"), &cmd());
+        assert!(matches!(early.color, Color::Never));
+
+        // --color always (space syntax).
+        let early = extract_early_args(&args("cargo nextest --color always"), &cmd());
+        assert!(matches!(early.color, Color::Always));
+
+        // Combined --no-pager and --color.
+        let early = extract_early_args(&args("cargo nextest --no-pager --color=never run"), &cmd());
+        assert!(early.no_pager);
+        assert!(matches!(early.color, Color::Never));
+
+        // --no-pager after -- should be ignored.
+        let early = extract_early_args(&args("cargo nextest run -- --no-pager"), &cmd());
+        assert!(!early.no_pager, "--no-pager after -- should be ignored");
+
+        // --no-pager before -- should work.
+        let early = extract_early_args(&args("cargo nextest --no-pager run -- test_name"), &cmd());
+        assert!(early.no_pager, "--no-pager before -- should work");
+
+        // --color after -- should be ignored.
+        let early = extract_early_args(&args("cargo nextest run -- --color=never"), &cmd());
+        assert!(
+            matches!(early.color, Color::Auto),
+            "--color after -- should be ignored"
+        );
+    }
+}

--- a/cargo-nextest/src/dispatch/cli.rs
+++ b/cargo-nextest/src/dispatch/cli.rs
@@ -3,6 +3,7 @@
 
 //! CLI argument parsing structures and enums.
 
+use super::clap_error::EarlyArgs;
 use crate::{
     ExpectedError, Result,
     cargo_cli::{CargoCli, CargoOptions},
@@ -1434,6 +1435,10 @@ impl From<ShowProgressOpt> for UiShowProgress {
     max_term_width = 100,
 )]
 pub struct CargoNextestApp {
+    /// Early args (color, no_pager) flattened at root for early extraction.
+    #[clap(flatten)]
+    early_args: EarlyArgs,
+
     #[clap(subcommand)]
     subcommand: NextestSubcommand,
 }
@@ -1442,8 +1447,8 @@ impl CargoNextestApp {
     /// Initializes the output context.
     pub fn init_output(&self) -> OutputContext {
         match &self.subcommand {
-            NextestSubcommand::Nextest(args) => args.common.output.init(),
-            NextestSubcommand::Ntr(args) => args.common.output.init(),
+            NextestSubcommand::Nextest(args) => args.common.output.init(self.early_args),
+            NextestSubcommand::Ntr(args) => args.common.output.init(self.early_args),
             #[cfg(unix)]
             // Double-spawned processes should never use coloring.
             NextestSubcommand::DoubleSpawn(_) => OutputContext::color_never_init(),
@@ -1587,8 +1592,8 @@ impl AppOpts {
                 output,
                 output_writer,
             ),
-            Command::Self_ { command } => command.exec(self.common.output),
-            Command::Debug { command } => command.exec(self.common.output),
+            Command::Self_ { command } => command.exec(output),
+            Command::Debug { command } => command.exec(output),
         }
     }
 }

--- a/cargo-nextest/src/dispatch/commands.rs
+++ b/cargo-nextest/src/dispatch/commands.rs
@@ -11,7 +11,7 @@ use super::{
 use crate::{
     ExpectedError, Result,
     cargo_cli::{CargoCli, CargoOptions},
-    output::{OutputContext, OutputOpts, OutputWriter},
+    output::{OutputContext, OutputWriter},
     reuse_build::ReuseBuildOpts,
 };
 use camino::{Utf8Path, Utf8PathBuf};
@@ -208,9 +208,7 @@ pub(super) enum SetupSource {
 
 impl SelfCommand {
     #[cfg_attr(not(feature = "self-update"), expect(unused_variables))]
-    pub(super) fn exec(self, output: OutputOpts) -> Result<i32> {
-        let output = output.init();
-
+    pub(super) fn exec(self, output: OutputContext) -> Result<i32> {
         match self {
             Self::Setup { source: _source } => {
                 // Currently a no-op.
@@ -290,8 +288,8 @@ pub(super) enum DebugCommand {
 }
 
 impl DebugCommand {
-    pub(super) fn exec(self, output: OutputOpts) -> Result<i32> {
-        let _ = output.init();
+    pub(super) fn exec(self, output: OutputContext) -> Result<i32> {
+        let _ = output;
 
         match self {
             DebugCommand::Extract {

--- a/cargo-nextest/src/dispatch/imp.rs
+++ b/cargo-nextest/src/dispatch/imp.rs
@@ -1,0 +1,41 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Main entry point implementation.
+
+use super::{
+    clap_error::{EarlySetup, handle_clap_error},
+    cli::CargoNextestApp,
+};
+use clap::{CommandFactory, Parser};
+
+/// Main entry point for cargo-nextest.
+///
+/// This function handles CLI parsing, early setup (for paged help), and
+/// dispatches to the appropriate command. Both the main binary and the
+/// integration test duplicate use this.
+pub fn main_impl() -> ! {
+    let cli_args: Vec<_> = std::env::args_os()
+        .map(|arg| arg.to_string_lossy().into_owned())
+        .collect();
+
+    let app = CargoNextestApp::command();
+    let early_setup = EarlySetup::new(&cli_args, &app);
+
+    match CargoNextestApp::try_parse() {
+        Ok(opts) => {
+            let output = opts.init_output();
+            match opts.exec(cli_args, output, &mut crate::OutputWriter::default()) {
+                Ok(code) => std::process::exit(code),
+                Err(error) => {
+                    error.display_to_stderr(&output.stderr_styles());
+                    std::process::exit(error.process_exit_code())
+                }
+            }
+        }
+        Err(err) => {
+            let code = handle_clap_error(err, &early_setup);
+            std::process::exit(code);
+        }
+    }
+}

--- a/cargo-nextest/src/dispatch/mod.rs
+++ b/cargo-nextest/src/dispatch/mod.rs
@@ -3,11 +3,13 @@
 
 //! Command dispatch and execution.
 
+mod clap_error;
 mod cli;
 mod commands;
 mod execution;
 mod helpers;
+mod imp;
 
-// Re-export main types for backward compatibility
-pub use cli::{CargoNextestApp, TestRunnerOpts};
-pub use commands::ExtractOutputFormat;
+pub(crate) use clap_error::EarlyArgs;
+pub(crate) use commands::ExtractOutputFormat;
+pub use imp::main_impl;

--- a/cargo-nextest/src/lib.rs
+++ b/cargo-nextest/src/lib.rs
@@ -43,9 +43,7 @@ mod reuse_build;
 mod update;
 mod version;
 
-#[doc(hidden)]
-pub use dispatch::*;
-#[doc(hidden)]
-pub use errors::*;
-#[doc(hidden)]
-pub use output::OutputWriter;
+pub(crate) use dispatch::ExtractOutputFormat;
+pub use dispatch::main_impl;
+pub(crate) use errors::*;
+pub(crate) use output::OutputWriter;

--- a/cargo-nextest/src/main.rs
+++ b/cargo-nextest/src/main.rs
@@ -1,26 +1,11 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use cargo_nextest::{CargoNextestApp, OutputWriter};
-use clap::Parser;
 use color_eyre::Result;
 
 fn main() -> Result<()> {
     color_eyre::install()?;
     let _ = enable_ansi_support::enable_ansi_support();
 
-    let cli_args: Vec<_> = std::env::args_os()
-        .map(|arg| arg.to_string_lossy().into_owned())
-        .collect();
-
-    let opts = CargoNextestApp::parse();
-    let output = opts.init_output();
-
-    match opts.exec(cli_args, output, &mut OutputWriter::default()) {
-        Ok(code) => std::process::exit(code),
-        Err(error) => {
-            error.display_to_stderr(&output.stderr_styles());
-            std::process::exit(error.process_exit_code())
-        }
-    }
+    cargo_nextest::main_impl()
 }

--- a/cargo-nextest/src/output.rs
+++ b/cargo-nextest/src/output.rs
@@ -2,6 +2,7 @@
 // Copyright (c) The cargo-guppy Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use crate::dispatch::EarlyArgs;
 use clap::{Args, ValueEnum};
 use miette::{GraphicalTheme, MietteHandlerOpts, ThemeStyles};
 use nextest_runner::{reporter::ReporterStderr, write_str::WriteStr};
@@ -61,26 +62,18 @@ pub(crate) struct OutputOpts {
     #[arg(long, short, global = true, env = "NEXTEST_VERBOSE")]
     pub(crate) verbose: bool,
     // TODO: quiet?
-    /// Produce color output: auto, always, never
-    #[arg(
-        long,
-        value_enum,
-        default_value_t,
-        hide_possible_values = true,
-        global = true,
-        value_name = "WHEN",
-        env = "CARGO_TERM_COLOR"
-    )]
-    pub(crate) color: Color,
 }
 
 impl OutputOpts {
-    pub(crate) fn init(self) -> OutputContext {
-        let OutputOpts { verbose, color } = self;
+    pub(crate) fn init(self, early_args: EarlyArgs) -> OutputContext {
+        let OutputOpts { verbose } = self;
 
-        color.init();
+        early_args.color.init();
 
-        OutputContext { verbose, color }
+        OutputContext {
+            verbose,
+            color: early_args.color,
+        }
     }
 }
 
@@ -332,8 +325,9 @@ pub enum OutputWriter {
     /// No capture
     #[default]
     Normal,
-    /// Output captured
+    /// Output captured (TODO: clean this up, it's no longer used)
     #[cfg(test)]
+    #[expect(dead_code)]
     Test {
         /// stdout capture
         stdout: String,

--- a/integration-tests/test-helpers/cargo-nextest-dup.rs
+++ b/integration-tests/test-helpers/cargo-nextest-dup.rs
@@ -1,28 +1,14 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! This is a duplicate of cargo-nextest's main.rs to avoid issues on Windows. See
-//! tests/integration/main.rs for more.
+//! This is a duplicate of cargo-nextest's main.rs to avoid issues on Windows.
+//! See tests/integration/main.rs for more.
 
-use cargo_nextest::{CargoNextestApp, OutputWriter};
-use clap::Parser;
 use color_eyre::Result;
 
 fn main() -> Result<()> {
     color_eyre::install()?;
     let _ = enable_ansi_support::enable_ansi_support();
 
-    let cli_args: Vec<_> = std::env::args_os()
-        .map(|arg| arg.to_string_lossy().into_owned())
-        .collect();
-
-    let opts = CargoNextestApp::parse();
-    let output = opts.init_output();
-    match opts.exec(cli_args, output, &mut OutputWriter::default()) {
-        Ok(code) => std::process::exit(code),
-        Err(error) => {
-            error.display_to_stderr(&output.stderr_styles());
-            std::process::exit(error.process_exit_code())
-        }
-    }
+    cargo_nextest::main_impl()
 }

--- a/nextest-runner/src/user_config/early.rs
+++ b/nextest-runner/src/user_config/early.rs
@@ -1,0 +1,333 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Early user configuration loading for pager settings.
+//!
+//! This module provides minimal configuration loading for use before full CLI
+//! parsing is complete.
+//!
+//! Following the pattern of [`crate::config::core::VersionOnlyConfig`], this
+//! loads only the fields needed for early decisions, with graceful fallback
+//! to defaults on any errors.
+
+use super::{
+    discovery::user_config_paths,
+    elements::{
+        CompiledUiOverride, DeserializedUiOverrideData, PagerSetting, PaginateSetting,
+        StreampagerConfig, StreampagerInterface, StreampagerWrapping,
+    },
+    helpers::resolve_ui_setting,
+    imp::DefaultUserConfig,
+};
+use camino::Utf8Path;
+use serde::Deserialize;
+use std::{fmt, io};
+use target_spec::{Platform, TargetSpec};
+use tracing::{debug, warn};
+
+/// Early user configuration for pager settings.
+///
+/// This is a minimal subset of user configuration loaded before full CLI
+/// parsing completes. It contains only the settings needed to decide whether
+/// and how to page help output.
+///
+/// Use [`Self::for_platform`] to load from the default location. If an error
+/// occurs, defaults are used and a warning is logged.
+#[derive(Clone, Debug)]
+pub struct EarlyUserConfig {
+    /// Which pager to use.
+    pub pager: PagerSetting,
+    /// When to paginate.
+    pub paginate: PaginateSetting,
+    /// Streampager configuration (for builtin pager).
+    pub streampager: StreampagerConfig,
+}
+
+impl EarlyUserConfig {
+    /// Loads early user configuration for the given host platform.
+    ///
+    /// This attempts to load user config from the default location and resolve
+    /// pager settings. On any error, returns defaults and logs a warning.
+    ///
+    /// This is intentionally fault-tolerant: help paging is a nice-to-have
+    /// feature, so we prefer degraded behavior over failing to show help.
+    pub fn for_platform(host_platform: &Platform) -> Self {
+        match Self::try_load(host_platform) {
+            Ok(config) => config,
+            Err(error) => {
+                warn!(
+                    "failed to load user config for pager settings, using defaults: {}",
+                    error
+                );
+                Self::defaults(host_platform)
+            }
+        }
+    }
+
+    /// Returns the default pager configuration for the host platform.
+    fn defaults(host_platform: &Platform) -> Self {
+        let default_config = DefaultUserConfig::from_embedded();
+        Self::resolve_from_defaults(&default_config, host_platform)
+    }
+
+    /// Attempts to load early user configuration.
+    fn try_load(host_platform: &Platform) -> Result<Self, EarlyConfigError> {
+        let default_config = DefaultUserConfig::from_embedded();
+
+        // Try to find and load user config.
+        let paths = user_config_paths().map_err(EarlyConfigError::Discovery)?;
+
+        if paths.is_empty() {
+            debug!("early user config: no config directory found, using defaults");
+            return Ok(Self::resolve_from_defaults(&default_config, host_platform));
+        }
+
+        // Try each candidate path.
+        for path in &paths {
+            match EarlyDeserializedConfig::from_path(path) {
+                Ok(Some(user_config)) => {
+                    debug!("early user config: loaded from {path}");
+                    return Ok(Self::resolve(
+                        &default_config,
+                        Some(&user_config),
+                        host_platform,
+                    ));
+                }
+                Ok(None) => {
+                    debug!("early user config: file not found at {path}");
+                    continue;
+                }
+                Err(error) => {
+                    // Log a warning, but continue to try other paths or use defaults.
+                    warn!("early user config: error loading {path}: {error}");
+                    continue;
+                }
+            }
+        }
+
+        debug!("early user config: no config file found, using defaults");
+        Ok(Self::resolve_from_defaults(&default_config, host_platform))
+    }
+
+    /// Resolves configuration from defaults.
+    fn resolve_from_defaults(default_config: &DefaultUserConfig, host_platform: &Platform) -> Self {
+        Self::resolve(default_config, None, host_platform)
+    }
+
+    /// Resolves configuration from defaults and optional user config.
+    fn resolve(
+        default_config: &DefaultUserConfig,
+        user_config: Option<&EarlyDeserializedConfig>,
+        host_platform: &Platform,
+    ) -> Self {
+        // Compile user overrides.
+        let user_overrides: Vec<CompiledUiOverride> = user_config
+            .map(|c| {
+                c.overrides
+                    .iter()
+                    .filter_map(|o| {
+                        match TargetSpec::new(o.platform.clone()) {
+                            Ok(spec) => Some(CompiledUiOverride::new(spec, o.ui.clone())),
+                            Err(error) => {
+                                // Log a warning, but otherwise skip invalid overrides.
+                                warn!(
+                                    "user config: invalid platform spec '{}': {error}",
+                                    o.platform
+                                );
+                                None
+                            }
+                        }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Resolve each setting using standard priority order.
+        let pager = resolve_ui_setting(
+            &default_config.ui.pager,
+            &default_config.ui_overrides,
+            user_config.and_then(|c| c.ui.pager.as_ref()),
+            &user_overrides,
+            host_platform,
+            |data| data.pager(),
+        );
+
+        let paginate = resolve_ui_setting(
+            &default_config.ui.paginate,
+            &default_config.ui_overrides,
+            user_config.and_then(|c| c.ui.paginate.as_ref()),
+            &user_overrides,
+            host_platform,
+            |data| data.paginate(),
+        );
+
+        let streampager = StreampagerConfig {
+            interface: resolve_ui_setting(
+                &default_config.ui.streampager.interface,
+                &default_config.ui_overrides,
+                user_config.and_then(|c| c.ui.streampager_interface()),
+                &user_overrides,
+                host_platform,
+                |data| data.streampager_interface(),
+            ),
+            wrapping: resolve_ui_setting(
+                &default_config.ui.streampager.wrapping,
+                &default_config.ui_overrides,
+                user_config.and_then(|c| c.ui.streampager_wrapping()),
+                &user_overrides,
+                host_platform,
+                |data| data.streampager_wrapping(),
+            ),
+            show_ruler: resolve_ui_setting(
+                &default_config.ui.streampager.show_ruler,
+                &default_config.ui_overrides,
+                user_config.and_then(|c| c.ui.streampager_show_ruler()),
+                &user_overrides,
+                host_platform,
+                |data| data.streampager_show_ruler(),
+            ),
+        };
+
+        Self {
+            pager,
+            paginate,
+            streampager,
+        }
+    }
+}
+
+/// Error type for early config loading.
+///
+/// This is internal and not exposed; errors are logged and defaults used.
+#[derive(Debug)]
+enum EarlyConfigError {
+    Discovery(crate::errors::UserConfigError),
+    Read(std::io::Error),
+    Parse(toml::de::Error),
+}
+
+impl fmt::Display for EarlyConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Discovery(e) => write!(f, "config discovery: {e}"),
+            Self::Read(e) => write!(f, "read: {e}"),
+            Self::Parse(e) => write!(f, "parse: {e}"),
+        }
+    }
+}
+
+/// Deserialized early config - only pager-related fields.
+///
+/// Uses `#[serde(default)]` on all fields to ignore unknown keys and accept
+/// partial configs.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct EarlyDeserializedConfig {
+    #[serde(default)]
+    ui: EarlyDeserializedUiConfig,
+    #[serde(default)]
+    overrides: Vec<EarlyDeserializedOverride>,
+}
+
+impl EarlyDeserializedConfig {
+    /// Loads early config from a path.
+    ///
+    /// Returns `Ok(None)` if file doesn't exist, `Err` on read/parse errors.
+    fn from_path(path: &Utf8Path) -> Result<Option<Self>, EarlyConfigError> {
+        let contents = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(EarlyConfigError::Read(e)),
+        };
+
+        let config: Self = toml::from_str(&contents).map_err(EarlyConfigError::Parse)?;
+        Ok(Some(config))
+    }
+}
+
+/// Deserialized UI config - only pager-related fields.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct EarlyDeserializedUiConfig {
+    #[serde(default)]
+    pager: Option<PagerSetting>,
+    #[serde(default)]
+    paginate: Option<PaginateSetting>,
+    // Streampager fields flattened for simpler access.
+    #[serde(default, rename = "streampager")]
+    streampager_section: EarlyDeserializedStreampagerConfig,
+}
+
+impl EarlyDeserializedUiConfig {
+    fn streampager_interface(&self) -> Option<&StreampagerInterface> {
+        self.streampager_section.interface.as_ref()
+    }
+
+    fn streampager_wrapping(&self) -> Option<&StreampagerWrapping> {
+        self.streampager_section.wrapping.as_ref()
+    }
+
+    fn streampager_show_ruler(&self) -> Option<&bool> {
+        self.streampager_section.show_ruler.as_ref()
+    }
+}
+
+/// Deserialized streampager config.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct EarlyDeserializedStreampagerConfig {
+    #[serde(default)]
+    interface: Option<StreampagerInterface>,
+    #[serde(default)]
+    wrapping: Option<StreampagerWrapping>,
+    #[serde(default)]
+    show_ruler: Option<bool>,
+}
+
+/// Deserialized override entry.
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct EarlyDeserializedOverride {
+    platform: String,
+    #[serde(default)]
+    ui: DeserializedUiOverrideData,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform::detect_host_platform_for_tests;
+
+    #[test]
+    fn test_early_user_config_defaults() {
+        let host = detect_host_platform_for_tests();
+        let config = EarlyUserConfig::defaults(&host);
+
+        // This should have a configured pager.
+        match &config.pager {
+            PagerSetting::Builtin => {}
+            PagerSetting::External(cmd) => {
+                assert!(!cmd.command_name().is_empty());
+            }
+        }
+
+        // Paginate should default to auto.
+        assert_eq!(config.paginate, PaginateSetting::Auto);
+    }
+
+    #[test]
+    fn test_early_user_config_from_host_platform() {
+        let host = detect_host_platform_for_tests();
+
+        // This should not panic, even if no config file exists.
+        let config = EarlyUserConfig::for_platform(&host);
+
+        // Should return a valid config.
+        match &config.pager {
+            PagerSetting::Builtin => {}
+            PagerSetting::External(cmd) => {
+                assert!(!cmd.command_name().is_empty());
+            }
+        }
+    }
+}

--- a/nextest-runner/src/user_config/helpers.rs
+++ b/nextest-runner/src/user_config/helpers.rs
@@ -1,0 +1,43 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Helper functions for user configuration resolution.
+
+use super::elements::{CompiledUiOverride, UiOverrideData};
+use target_spec::Platform;
+
+/// Resolves a single setting using the standard priority order.
+pub(crate) fn resolve_ui_setting<T: Clone>(
+    default_value: &T,
+    default_overrides: &[CompiledUiOverride],
+    user_value: Option<&T>,
+    user_overrides: &[CompiledUiOverride],
+    host_platform: &Platform,
+    get_override: impl Fn(&UiOverrideData) -> Option<&T>,
+) -> T {
+    // 1. User overrides (first match).
+    for override_ in user_overrides {
+        if override_.matches(host_platform)
+            && let Some(v) = get_override(override_.data())
+        {
+            return v.clone();
+        }
+    }
+
+    // 2. Default overrides (first match).
+    for override_ in default_overrides {
+        if override_.matches(host_platform)
+            && let Some(v) = get_override(override_.data())
+        {
+            return v.clone();
+        }
+    }
+
+    // 3. User base config.
+    if let Some(v) = user_value {
+        return v.clone();
+    }
+
+    // 4. Default base config.
+    default_value.clone()
+}

--- a/nextest-runner/src/user_config/mod.rs
+++ b/nextest-runner/src/user_config/mod.rs
@@ -31,8 +31,11 @@
 //! 5. Built-in defaults
 
 mod discovery;
+mod early;
 pub mod elements;
+mod helpers;
 mod imp;
 
 pub use discovery::*;
+pub use early::*;
 pub use imp::*;


### PR DESCRIPTION
Add infrastructure to page --help and -h output through a pager, similar to Jujutsu. This improves the user experience when viewing long help text in a terminal.

This required a two-phase parsing process, where we first parse the parts of user config necessary to show pager output. As a decision, we use the build target platform (which is usually the same as the host platform, though not always) to avoid having to deal with `rustc -vV` failures.