### PR TITLE
[cargo-nextest] support --beta and --rc update channels

### DIFF
--- a/cargo-nextest/src/dispatch/cli.rs
+++ b/cargo-nextest/src/dispatch/cli.rs
@@ -1749,6 +1749,17 @@ mod tests {
             "cargo nextest run --build-jobs -1",
             "cargo nextest run --build-jobs 1",
             // ---
+            // Self update options
+            // ---
+            "cargo nextest self update",
+            "cargo nextest self update --beta",
+            "cargo nextest self update --rc",
+            "cargo nextest self update --version 0.9.100",
+            "cargo nextest self update --version latest",
+            "cargo nextest self update --check",
+            "cargo nextest self update --beta --check",
+            "cargo nextest self update --rc --force",
+            // ---
             // Bench command
             // ---
             "cargo nextest bench",
@@ -1911,6 +1922,18 @@ mod tests {
             ("cargo nextest bench --stress-count 0", ValueValidation),
             // Invalid stress duration: 0
             ("cargo nextest bench --stress-duration 0m", ValueValidation),
+            // ---
+            // Self update option conflicts
+            // ---
+            ("cargo nextest self update --beta --rc", ArgumentConflict),
+            (
+                "cargo nextest self update --beta --version 0.9.100",
+                ArgumentConflict,
+            ),
+            (
+                "cargo nextest self update --rc --version 0.9.100",
+                ArgumentConflict,
+            ),
         ];
 
         // Unset all NEXTEST_ env vars because they can conflict with the try_parse_from below.

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -1917,13 +1917,13 @@ pub enum InheritsError {
 #[cfg(feature = "self-update")]
 mod self_update_errors {
     use super::*;
+    use crate::update::PrereleaseKind;
     use mukti_metadata::ReleaseStatus;
     use semver::{Version, VersionReq};
 
     /// An error that occurs while performing a self-update.
     ///
     /// Returned by methods in the [`update`](crate::update) module.
-    #[cfg(feature = "self-update")]
     #[derive(Debug, Error)]
     #[non_exhaustive]
     pub enum UpdateError {
@@ -1961,6 +1961,17 @@ mod self_update_errors {
         NoMatchForVersionReq {
             /// The version requirement that had no matches.
             req: VersionReq,
+        },
+
+        /// No stable (non-prerelease) version was found.
+        #[error("no stable version found")]
+        NoStableVersion,
+
+        /// No version matching the requested prerelease kind was found.
+        #[error("no version found matching {} channel", kind.description())]
+        NoVersionForPrereleaseKind {
+            /// The kind of prerelease that was requested.
+            kind: PrereleaseKind,
         },
 
         /// The specified mukti project was not found.
@@ -2092,7 +2103,6 @@ mod self_update_errors {
         display_str
     }
 
-    #[cfg(feature = "self-update")]
     /// An error occurred while parsing an [`UpdateVersion`](crate::update::UpdateVersion).
     #[derive(Debug, Error)]
     pub enum UpdateVersionParseError {

--- a/site/src/docs/installation/updating.md
+++ b/site/src/docs/installation/updating.md
@@ -23,6 +23,29 @@ To request a specific version, add `--version <version>` to the command. For exa
 cargo nextest self update --version 0.9.72
 ```
 
+### Beta and RC channels
+
+<!-- md:version 0.9.119 -->
+
+The nextest project occasionally publishes betas and release candidates (RCs) to test new features. To update to the latest prerelease, run:
+
+```sh
+# Update to the latest beta release:
+cargo nextest self update --beta
+
+# Update to the latest RC release:
+cargo nextest self update --rc
+```
+
+If no newer betas or RCs are available, these commands update to the latest stable release.
+
+You can also specify an exact prerelease version. This approach works with older versions of nextest as well:
+
+```sh
+# Update to a specific version:
+cargo nextest self update --version 0.9.119-b.2
+```
+
 ## From source
 
 Nextest can also be updated from source, by running:
@@ -38,3 +61,37 @@ For versions of nextest packaged by a distributor, follow the instructions for t
 ### Note for distributors
 
 The `cargo-nextest` crate has a `default-no-update` feature which consists of all default features except for self-update. The recommended, forward-compatible way to build cargo-nextest is with `--locked --no-default-features --features default-no-update`.
+
+## Options and arguments
+
+=== "Summarized output"
+
+    The output of `cargo nextest self update -h`:
+
+    === "Colorized"
+
+        ```bash exec="true" result="ansi"
+        CLICOLOR_FORCE=1 cargo nextest self update -h | ../scripts/strip-hyperlinks.sh
+        ```
+
+    === "Plaintext"
+
+        ```bash exec="true" result="text"
+        cargo nextest self update -h | ../scripts/strip-hyperlinks.sh
+        ```
+
+=== "Full output"
+
+    The output of `cargo nextest self update --help`:
+
+    === "Colorized"
+
+        ```bash exec="true" result="ansi"
+        CLICOLOR_FORCE=1 cargo nextest self update --help | ../scripts/strip-hyperlinks.sh
+        ```
+
+    === "Plaintext"
+
+        ```bash exec="true" result="text"
+        cargo nextest self update --help | ../scripts/strip-hyperlinks.sh
+        ```


### PR DESCRIPTION
Add support for beta and RC releases. Also add information about updating to prereleases to the nextest site.