### PR TITLE
[integration-tests] unignore test_foreground_grab_does_not_suspend

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,4 +1,4 @@
-nextest-version = "0.9.113"
+nextest-version = "0.9.118"
 experimental = ["setup-scripts"]
 
 [profile.default]

--- a/integration-tests/tests/integration/sigttou.rs
+++ b/integration-tests/tests/integration/sigttou.rs
@@ -14,12 +14,9 @@
 
 use std::process::Command;
 
-/// Spawning a subprocess that grabs the foreground process would trigger
-/// SIGTTOU without the fix.
-///
-/// This test is currently ignored because it requires a version of nextest with
+/// If this test is run under nextest in an interactive terminal, spawning a
+/// subprocess that grabs the foreground process would trigger SIGTTOU without
 /// the fix.
-#[ignore]
 #[test]
 fn test_foreground_grab_does_not_suspend() {
     // This issue could be reproduced with zsh -ic, though not with bash -ic or


### PR DESCRIPTION
Now that cargo-nextest 0.9.118 is out, we can enable this test. It won't trigger in CI but it will trigger in local runs, so it should be pretty noticeable.