### PR TITLE
[nextest-runner] don't pass CargoConfigs into ReporterBuilder

### DIFF
--- a/cargo-nextest/src/dispatch/execution.rs
+++ b/cargo-nextest/src/dispatch/execution.rs
@@ -36,6 +36,7 @@ use nextest_runner::{
     platform::BuildPlatforms,
     redact::Redactor,
     reporter::{
+        ShowTerminalProgress,
         events::{FinalRunStats, RunStats, RunStatsFailureKind},
         structured,
     },
@@ -57,6 +58,7 @@ use semver::Version;
 use std::{
     collections::BTreeSet,
     env::VarError,
+    io::IsTerminal,
     sync::{Arc, OnceLock},
 };
 use tracing::{Level, info, warn};
@@ -823,10 +825,14 @@ impl App {
         )?;
 
         // Make the reporter.
+        let show_term_progress = ShowTerminalProgress::from_cargo_configs(
+            &self.base.cargo_configs,
+            std::io::stderr().is_terminal(),
+        );
         let mut reporter = reporter_builder.build(
             &test_list,
             &profile,
-            &self.base.cargo_configs,
+            show_term_progress,
             output,
             structured_reporter,
         );
@@ -983,10 +989,14 @@ impl App {
         )?;
 
         // Make the reporter.
+        let show_term_progress = ShowTerminalProgress::from_cargo_configs(
+            &self.base.cargo_configs,
+            std::io::stderr().is_terminal(),
+        );
         let mut reporter = reporter_builder.build(
             &test_list,
             &profile,
-            &self.base.cargo_configs,
+            show_term_progress,
             output,
             structured_reporter,
         );

--- a/nextest-runner/src/reporter/displayer/mod.rs
+++ b/nextest-runner/src/reporter/displayer/mod.rs
@@ -11,6 +11,6 @@ mod unit_output;
 
 pub(crate) use formatters::DisplayUnitKind;
 pub(crate) use imp::*;
-pub use progress::{MaxProgressRunning, ShowProgress};
+pub use progress::{MaxProgressRunning, ShowProgress, ShowTerminalProgress};
 pub use status_level::*;
 pub use unit_output::*;

--- a/nextest-runner/src/reporter/imp.rs
+++ b/nextest-runner/src/reporter/imp.rs
@@ -7,10 +7,9 @@
 
 use super::{
     FinalStatusLevel, MaxProgressRunning, StatusLevel, TestOutputDisplay,
-    displayer::{DisplayReporter, DisplayReporterBuilder, StatusLevels},
+    displayer::{DisplayReporter, DisplayReporterBuilder, ShowTerminalProgress, StatusLevels},
 };
 use crate::{
-    cargo_config::CargoConfigs,
     config::core::EvaluatableProfile,
     errors::WriteEventError,
     list::TestList,
@@ -126,7 +125,7 @@ impl ReporterBuilder {
         &self,
         test_list: &TestList,
         profile: &EvaluatableProfile<'a>,
-        cargo_configs: &CargoConfigs,
+        show_term_progress: ShowTerminalProgress,
         output: ReporterStderr<'a>,
         structured_reporter: StructuredReporter<'a>,
     ) -> Reporter<'a> {
@@ -153,8 +152,9 @@ impl ReporterBuilder {
             show_progress: self.show_progress,
             no_output_indent: self.no_output_indent,
             max_progress_running: self.max_progress_running,
+            show_term_progress,
         }
-        .build(cargo_configs, output);
+        .build(output);
 
         Reporter {
             display_reporter,

--- a/nextest-runner/src/reporter/mod.rs
+++ b/nextest-runner/src/reporter/mod.rs
@@ -14,7 +14,8 @@ mod imp;
 pub mod structured;
 
 pub use displayer::{
-    FinalStatusLevel, MaxProgressRunning, ShowProgress, StatusLevel, TestOutputDisplay,
+    FinalStatusLevel, MaxProgressRunning, ShowProgress, ShowTerminalProgress, StatusLevel,
+    TestOutputDisplay,
 };
 pub use error_description::*;
 pub use helpers::highlight_end;


### PR DESCRIPTION
The only use is for terminal progress, which can be factored out into its own enum.