### PR TITLE
[nextest-runner] rename ReporterStderr to ReporterOutput, use dyn WriteStr

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,6 +177,7 @@ Examples:
 - Release preparation: `[meta] prepare releases`.
 - Keep descriptions concise but descriptive.
 - Use simple past and present tense: "Previously, when the user did X, Y used to happen. With this commit, now Z happens. Also add tests for U, V, and W."
+- Commit messages should be Markdown. Don't use backticks in commit message titles, but do use them in bodies.
 
 ### Commit quality
 

--- a/cargo-nextest/src/output.rs
+++ b/cargo-nextest/src/output.rs
@@ -5,7 +5,7 @@
 use crate::dispatch::EarlyArgs;
 use clap::{Args, ValueEnum};
 use miette::{GraphicalTheme, MietteHandlerOpts, ThemeStyles};
-use nextest_runner::{reporter::ReporterStderr, write_str::WriteStr};
+use nextest_runner::{reporter::ReporterOutput, write_str::WriteStr};
 use owo_colors::{OwoColorize, Style, style};
 use std::{
     fmt,
@@ -337,9 +337,9 @@ impl OutputWriter {
         }
     }
 
-    pub(crate) fn reporter_output(&mut self) -> ReporterStderr<'_> {
+    pub(crate) fn reporter_output(&mut self) -> ReporterOutput<'_> {
         match self {
-            Self::Normal => ReporterStderr::Terminal,
+            Self::Normal => ReporterOutput::Terminal,
         }
     }
 

--- a/nextest-runner/src/reporter/imp.rs
+++ b/nextest-runner/src/reporter/imp.rs
@@ -17,19 +17,20 @@ use crate::{
         aggregator::EventAggregator, displayer::ShowProgress, events::*,
         structured::StructuredReporter,
     },
+    write_str::WriteStr,
 };
 
-/// Standard error destination for the reporter.
+/// Output destination for the reporter.
 ///
 /// This is usually a terminal, but can be an in-memory buffer for tests.
-pub enum ReporterStderr<'a> {
+pub enum ReporterOutput<'a> {
     /// Produce output on the (possibly piped) terminal.
     ///
     /// If the terminal isn't piped, produce output to a progress bar.
     Terminal,
 
     /// Write output to a buffer.
-    Buffer(&'a mut String),
+    Writer(&'a mut (dyn WriteStr + Send)),
 }
 
 /// Test reporter builder.
@@ -126,7 +127,7 @@ impl ReporterBuilder {
         test_list: &TestList,
         profile: &EvaluatableProfile<'a>,
         show_term_progress: ShowTerminalProgress,
-        output: ReporterStderr<'a>,
+        output: ReporterOutput<'a>,
         structured_reporter: StructuredReporter<'a>,
     ) -> Reporter<'a> {
         let aggregator = EventAggregator::new(test_list.mode(), profile);


### PR DESCRIPTION
Rename `ReporterStderr` to `ReporterOutput` to better reflect its purpose as a general output destination. In particular, upcoming replay work will cause reporter output to go to standard out.

Change the `Buffer` variant from `&'a mut String` to `&'a mut (dyn WriteStr + Send)`, allowing any `WriteStr` implementation to be used as an output destination. The `Send` bound is required because `Reporter` is passed across thread boundaries in the test executor.

Internal types are also renamed: `ReporterStderrImpl` -> `ReporterOutputImpl`, and the `stderr` field in `DisplayReporter` -> `output`.