### PR TITLE
[nextest-runner] add description types for execution results

### DIFF
--- a/nextest-runner/src/config/elements/leak_timeout.rs
+++ b/nextest-runner/src/config/elements/leak_timeout.rs
@@ -3,7 +3,7 @@
 
 //! Leak timeout configuration.
 
-use serde::{Deserialize, de::IntoDeserializer};
+use serde::{Deserialize, Serialize, de::IntoDeserializer};
 use std::{fmt, time::Duration};
 
 /// Controls leak timeout behavior.
@@ -30,7 +30,7 @@ impl Default for LeakTimeout {
 }
 
 /// The result of controlling leak timeout behavior.
-#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum LeakTimeoutResult {
     /// The test is marked as failed.

--- a/nextest-runner/src/config/elements/slow_timeout.rs
+++ b/nextest-runner/src/config/elements/slow_timeout.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::time::far_future_duration;
-use serde::{Deserialize, de::IntoDeserializer};
+use serde::{Deserialize, Serialize, de::IntoDeserializer};
 use std::{fmt, num::NonZeroUsize, time::Duration};
 
 /// Type for the slow-timeout config key.
@@ -88,7 +88,7 @@ where
 /// they generally check for invariants and other properties of the code under test during their
 /// execution. A timeout in this context doesn't mean that there are no failing inputs, it just
 /// means that they weren't found up until that moment, which is still valuable information.
-#[derive(Clone, Copy, Debug, Deserialize, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum SlowTimeoutResult {
     #[default]

--- a/nextest-runner/src/reporter/error_description.rs
+++ b/nextest-runner/src/reporter/error_description.rs
@@ -1,10 +1,9 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use super::events::{AbortStatus, ExecutionResult, FailureStatus, UnitKind};
+use super::events::{AbortDescription, ExecutionResult, FailureStatus, UnitKind};
 use crate::{
     errors::{ChildError, ChildStartError, ErrorList},
-    helpers::display_abort_status,
     test_output::{ChildExecutionOutput, ChildOutput},
 };
 use bstr::ByteSlice;
@@ -67,7 +66,7 @@ impl<'a> UnitErrorDescription<'a> {
                     } = result
                     {
                         abort = Some(UnitAbortDescription {
-                            status: *status,
+                            description: AbortDescription::from(*status),
                             leaked: *leaked,
                         });
                     }
@@ -144,15 +143,15 @@ impl<'a> UnitErrorDescription<'a> {
     }
 }
 
-#[derive(Clone, Copy, Debug, Error)]
+#[derive(Clone, Debug, Error)]
 struct UnitAbortDescription {
-    status: AbortStatus,
+    description: AbortDescription,
     leaked: bool,
 }
 
 impl fmt::Display for UnitAbortDescription {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "process {}", display_abort_status(self.status))?;
+        write!(f, "process {}", self.description)?;
         if self.leaked {
             write!(f, ", and also leaked handles")?;
         }

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__abort_unix_signal_no_name.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__abort_unix_signal_no_name.snap
@@ -1,0 +1,10 @@
+---
+source: nextest-runner/src/reporter/events.rs
+expression: json
+snapshot_kind: text
+---
+{
+  "kind": "unix-signal",
+  "signal": 42,
+  "name": null
+}

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__abort_unix_signal_with_name.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__abort_unix_signal_with_name.snap
@@ -1,0 +1,10 @@
+---
+source: nextest-runner/src/reporter/events.rs
+expression: json
+snapshot_kind: text
+---
+{
+  "kind": "unix-signal",
+  "signal": 15,
+  "name": "TERM"
+}

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__abort_windows_job_object.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__abort_windows_job_object.snap
@@ -1,0 +1,8 @@
+---
+source: nextest-runner/src/reporter/events.rs
+expression: json
+snapshot_kind: text
+---
+{
+  "kind": "windows-job-object"
+}

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__abort_windows_nt_status.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__abort_windows_nt_status.snap
@@ -1,0 +1,10 @@
+---
+source: nextest-runner/src/reporter/events.rs
+expression: json
+snapshot_kind: text
+---
+{
+  "kind": "windows-nt-status",
+  "code": -1073741510,
+  "message": "The application terminated as a result of a CTRL+C."
+}

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__abort_windows_nt_status_no_message.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__abort_windows_nt_status_no_message.snap
@@ -1,0 +1,10 @@
+---
+source: nextest-runner/src/reporter/events.rs
+expression: json
+snapshot_kind: text
+---
+{
+  "kind": "windows-nt-status",
+  "code": -1073741819,
+  "message": null
+}

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__exec_fail.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__exec_fail.snap
@@ -1,0 +1,8 @@
+---
+source: nextest-runner/src/reporter/events.rs
+expression: json
+snapshot_kind: text
+---
+{
+  "status": "exec-fail"
+}

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__fail_exit_code.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__fail_exit_code.snap
@@ -1,0 +1,13 @@
+---
+source: nextest-runner/src/reporter/events.rs
+expression: json
+snapshot_kind: text
+---
+{
+  "status": "fail",
+  "failure": {
+    "kind": "exit-code",
+    "code": 101
+  },
+  "leaked": false
+}

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__fail_exit_code_leaked.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__fail_exit_code_leaked.snap
@@ -1,0 +1,13 @@
+---
+source: nextest-runner/src/reporter/events.rs
+expression: json
+snapshot_kind: text
+---
+{
+  "status": "fail",
+  "failure": {
+    "kind": "exit-code",
+    "code": 1
+  },
+  "leaked": true
+}

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__fail_unix_signal.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__fail_unix_signal.snap
@@ -1,0 +1,17 @@
+---
+source: nextest-runner/src/reporter/events.rs
+expression: json
+snapshot_kind: text
+---
+{
+  "status": "fail",
+  "failure": {
+    "kind": "abort",
+    "abort": {
+      "kind": "unix-signal",
+      "signal": 11,
+      "name": "SEGV"
+    }
+  },
+  "leaked": false
+}

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__fail_unix_signal_unknown_leaked.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__fail_unix_signal_unknown_leaked.snap
@@ -1,0 +1,17 @@
+---
+source: nextest-runner/src/reporter/events.rs
+expression: json
+snapshot_kind: text
+---
+{
+  "status": "fail",
+  "failure": {
+    "kind": "abort",
+    "abort": {
+      "kind": "unix-signal",
+      "signal": 42,
+      "name": null
+    }
+  },
+  "leaked": true
+}

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__fail_windows_job_object.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__fail_windows_job_object.snap
@@ -1,0 +1,15 @@
+---
+source: nextest-runner/src/reporter/events.rs
+expression: json
+snapshot_kind: text
+---
+{
+  "status": "fail",
+  "failure": {
+    "kind": "abort",
+    "abort": {
+      "kind": "windows-job-object"
+    }
+  },
+  "leaked": false
+}

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__fail_windows_nt_status.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__fail_windows_nt_status.snap
@@ -1,0 +1,17 @@
+---
+source: nextest-runner/src/reporter/events.rs
+expression: json
+snapshot_kind: text
+---
+{
+  "status": "fail",
+  "failure": {
+    "kind": "abort",
+    "abort": {
+      "kind": "windows-nt-status",
+      "code": -1073741510,
+      "message": "The application terminated as a result of a CTRL+C."
+    }
+  },
+  "leaked": false
+}

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__fail_windows_nt_status_no_message.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__fail_windows_nt_status_no_message.snap
@@ -1,0 +1,17 @@
+---
+source: nextest-runner/src/reporter/events.rs
+expression: json
+snapshot_kind: text
+---
+{
+  "status": "fail",
+  "failure": {
+    "kind": "abort",
+    "abort": {
+      "kind": "windows-nt-status",
+      "code": -1073741819,
+      "message": null
+    }
+  },
+  "leaked": false
+}

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__leak_fail.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__leak_fail.snap
@@ -1,0 +1,9 @@
+---
+source: nextest-runner/src/reporter/events.rs
+expression: json
+snapshot_kind: text
+---
+{
+  "status": "leak",
+  "result": "fail"
+}

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__leak_pass.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__leak_pass.snap
@@ -1,0 +1,9 @@
+---
+source: nextest-runner/src/reporter/events.rs
+expression: json
+snapshot_kind: text
+---
+{
+  "status": "leak",
+  "result": "pass"
+}

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__pass.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__pass.snap
@@ -1,0 +1,8 @@
+---
+source: nextest-runner/src/reporter/events.rs
+expression: json
+snapshot_kind: text
+---
+{
+  "status": "pass"
+}

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__timeout_fail.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__timeout_fail.snap
@@ -1,0 +1,9 @@
+---
+source: nextest-runner/src/reporter/events.rs
+expression: json
+snapshot_kind: text
+---
+{
+  "status": "timeout",
+  "result": "fail"
+}

--- a/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__timeout_pass.snap
+++ b/nextest-runner/src/reporter/snapshots/nextest_runner__reporter__events__tests__timeout_pass.snap
@@ -1,0 +1,9 @@
+---
+source: nextest-runner/src/reporter/events.rs
+expression: json
+snapshot_kind: text
+---
+{
+  "status": "timeout",
+  "result": "pass"
+}

--- a/nextest-runner/src/runner/dispatcher.rs
+++ b/nextest-runner/src/runner/dispatcher.rs
@@ -16,9 +16,9 @@ use crate::{
     input::{InputEvent, InputHandler},
     list::{TestInstance, TestInstanceId, TestList},
     reporter::events::{
-        CancelReason, ExecuteStatus, ExecutionStatuses, FinalRunStats, InfoResponse, ReporterEvent,
-        RunFinishedStats, RunStats, StressIndex, StressProgress, StressRunStats, TestEvent,
-        TestEventKind,
+        CancelReason, ExecuteStatus, ExecutionResultDescription, ExecutionStatuses,
+        FailureDescription, FinalRunStats, InfoResponse, ReporterEvent, RunFinishedStats, RunStats,
+        StressIndex, StressProgress, StressRunStats, TestEvent, TestEventKind,
     },
     runner::{ExecutorEvent, RunUnitQuery, SignalRequest, StressCondition, StressCount},
     signal::{
@@ -600,11 +600,11 @@ where
 
                 // Fire the setup-script-done probe, extracting the exit code
                 // from the result if available.
-                let exit_code = match status.result {
-                    crate::reporter::events::ExecutionResult::Fail {
-                        failure_status: crate::reporter::events::FailureStatus::ExitCode(code),
+                let exit_code = match &status.result {
+                    ExecutionResultDescription::Fail {
+                        failure: FailureDescription::ExitCode { code },
                         ..
-                    } => Some(code),
+                    } => Some(*code),
                     _ => None,
                 };
 

--- a/nextest-runner/src/runner/executor.rs
+++ b/nextest-runner/src/runner/executor.rs
@@ -300,8 +300,9 @@ impl<'a> ExecutorContext<'a> {
                     .next()
                     .expect("backoff delay must be non-empty");
 
-                let run_status = run_status.into_external();
+                // Capture the internal result before converting to external.
                 let previous_result = run_status.result;
+                let run_status = run_status.into_external();
                 let previous_slow = run_status.is_slow;
 
                 let _ = resp_tx.send(ExecutorEvent::AttemptFailedWillRetry {

--- a/nextest-runner/src/runner/internal_events.rs
+++ b/nextest-runner/src/runner/internal_events.rs
@@ -162,7 +162,7 @@ impl InternalExecuteStatus<'_> {
         ExecuteStatus {
             retry_data: self.test.retry_data(),
             output: self.output,
-            result: self.result,
+            result: self.result.into(),
             start_time: self.stopwatch_end.start_time.fixed_offset(),
             time_taken: self.stopwatch_end.active,
             is_slow: self.slow_after.is_some(),
@@ -184,7 +184,7 @@ impl InternalSetupScriptExecuteStatus<'_> {
     pub(super) fn into_external(self) -> SetupScriptExecuteStatus {
         SetupScriptExecuteStatus {
             output: self.output,
-            result: self.result,
+            result: self.result.into(),
             start_time: self.stopwatch_end.start_time.fixed_offset(),
             time_taken: self.stopwatch_end.active,
             is_slow: self.slow_after.is_some(),


### PR DESCRIPTION
`AbortStatus`, `FailureStatus`, and `ExecutionResult` are platform-dependent, making them impossible to serialize on one platform and deserialize on another.

Add platform-independent description types that contain all information needed for display without requiring platform-specific lookups at render time:

- `AbortDescription`: represents abort status from any platform
  - `UnixSignal { signal: i32, name: Option<SmolStr> }`
  - `WindowsNtStatus { code: i32, message: Option<SmolStr> }`
  - `WindowsJobObject`

- `FailureDescription`: represents failure status
  - `ExitCode { code: i32 }`
  - `Abort { abort: AbortDescription }`

- `ExecutionResultDescription`: represents execution results
  - `Pass`, `Leak`, `Fail`, `ExecFail`, `Timeout`

These types derive `Serialize`/`Deserialize` with tagged JSON representation. The internal types remain unchanged for platform-specific pattern matching with compile-time safety. Conversion happens at the serialization/display boundary.

Note: `FailureDescription::Abort` uses a struct variant (not newtype) because both `FailureDescription` and `AbortDescription` use `#[serde(tag = "kind")]`. A newtype variant would flatten the inner type, causing duplicate `"kind"` fields.

Also add insta snapshot tests for serialization with roundtrip verification and cross-platform deserialization tests, and extract `windows_nt_status_message()` helper for reuse.