### PR TITLE
[nextest-runner] add ChildExecutionOutputDescription for external-facing output

### DIFF
--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -394,8 +394,35 @@ impl<T: std::error::Error> ErrorList<T> {
         }
     }
 
-    pub(crate) fn iter(&self) -> impl Iterator<Item = &T> {
+    /// Returns the description of what the errors are.
+    pub fn description(&self) -> &'static str {
+        self.description
+    }
+
+    /// Iterates over the errors in this list.
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
         self.inner.iter()
+    }
+
+    /// Transforms the errors in this list using the given function.
+    pub fn map<U, F>(self, f: F) -> ErrorList<U>
+    where
+        U: std::error::Error,
+        F: FnMut(T) -> U,
+    {
+        ErrorList {
+            description: self.description,
+            inner: self.inner.into_iter().map(f).collect(),
+        }
+    }
+}
+
+impl<T: std::error::Error> IntoIterator for ErrorList<T> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.into_iter()
     }
 }
 

--- a/nextest-runner/src/reporter/displayer/imp.rs
+++ b/nextest-runner/src/reporter/displayer/imp.rs
@@ -2463,7 +2463,9 @@ mod tests {
     use super::*;
     use crate::{
         errors::{ChildError, ChildFdError, ChildStartError, ErrorList},
-        reporter::events::{ExecutionResult, FailureStatus, UnitTerminateReason},
+        reporter::events::{
+            ChildExecutionOutputDescription, ExecutionResult, FailureStatus, UnitTerminateReason,
+        },
         test_output::{ChildExecutionOutput, ChildOutput, ChildSplitOutput},
     };
     use bytes::Bytes;
@@ -2546,6 +2548,8 @@ mod tests {
             time_taken: Duration::from_secs(1),
             is_slow: false,
             delay_before_start: Duration::ZERO,
+            error_summary: None,
+            output_error_slice: None,
         };
         let fail_describe = ExecutionDescription::Failure {
             first_status: &fail_status,
@@ -2565,6 +2569,8 @@ mod tests {
             time_taken: Duration::from_secs(2),
             is_slow: false,
             delay_before_start: Duration::ZERO,
+            error_summary: None,
+            output_error_slice: None,
         };
 
         // Make an `ExecutionStatuses` with a failure and a success, indicating flakiness.
@@ -2980,7 +2986,8 @@ mod tests {
                                 },
                                 output: ChildExecutionOutput::StartError(ChildStartError::Spawn(
                                     Arc::new(std::io::Error::other("exec error")),
-                                )),
+                                ))
+                                .into(),
                             }),
                         },
                     })
@@ -3012,7 +3019,8 @@ mod tests {
                                 },
                                 output: ChildExecutionOutput::StartError(ChildStartError::Spawn(
                                     Arc::new(std::io::Error::other("exec error")),
-                                )),
+                                ))
+                                .into(),
                             }),
                         },
                     })
@@ -3213,7 +3221,7 @@ mod tests {
         result: Option<ExecutionResult>,
         stdout: &str,
         stderr: &str,
-    ) -> ChildExecutionOutput {
+    ) -> ChildExecutionOutputDescription {
         ChildExecutionOutput::Output {
             result,
             output: ChildOutput::Split(ChildSplitOutput {
@@ -3222,6 +3230,7 @@ mod tests {
             }),
             errors: None,
         }
+        .into()
     }
 
     fn make_split_output_with_errors(
@@ -3229,7 +3238,7 @@ mod tests {
         stdout: &str,
         stderr: &str,
         errors: Vec<ChildError>,
-    ) -> ChildExecutionOutput {
+    ) -> ChildExecutionOutputDescription {
         ChildExecutionOutput::Output {
             result,
             output: ChildOutput::Split(ChildSplitOutput {
@@ -3238,13 +3247,14 @@ mod tests {
             }),
             errors: ErrorList::new("testing split output", errors),
         }
+        .into()
     }
 
     fn make_combined_output_with_errors(
         result: Option<ExecutionResult>,
         output: &str,
         errors: Vec<ChildError>,
-    ) -> ChildExecutionOutput {
+    ) -> ChildExecutionOutputDescription {
         ChildExecutionOutput::Output {
             result,
             output: ChildOutput::Combined {
@@ -3252,6 +3262,7 @@ mod tests {
             },
             errors: ErrorList::new("testing split output", errors),
         }
+        .into()
     }
 
     #[test]

--- a/nextest-runner/src/reporter/displayer/unit_output.rs
+++ b/nextest-runner/src/reporter/displayer/unit_output.rs
@@ -11,7 +11,7 @@ use crate::{
         events::*,
         helpers::{Styles, highlight_end},
     },
-    test_output::{ChildExecutionOutput, ChildOutput, ChildSingleOutput},
+    test_output::{ChildOutput, ChildSingleOutput},
     write_str::WriteStr,
 };
 use owo_colors::Style;
@@ -125,11 +125,11 @@ impl UnitOutputReporter {
         &self,
         styles: &Styles,
         spec: &ChildOutputSpec,
-        exec_output: &ChildExecutionOutput,
+        exec_output: &ChildExecutionOutputDescription,
         mut writer: &mut dyn WriteStr,
     ) -> io::Result<()> {
         match exec_output {
-            ChildExecutionOutput::Output {
+            ChildExecutionOutputDescription::Output {
                 output,
                 // result and errors are captured by desc.
                 result: _,
@@ -158,7 +158,7 @@ impl UnitOutputReporter {
                 self.write_child_output(styles, spec, output, highlight_slice, writer)?;
             }
 
-            ChildExecutionOutput::StartError(error) => {
+            ChildExecutionOutputDescription::StartError(error) => {
                 writeln!(writer, "{}", spec.exec_fail_header)?;
 
                 // Indent the displayed error chain.

--- a/nextest-runner/src/runner/dispatcher.rs
+++ b/nextest-runner/src/runner/dispatcher.rs
@@ -16,9 +16,10 @@ use crate::{
     input::{InputEvent, InputHandler},
     list::{TestInstance, TestInstanceId, TestList},
     reporter::events::{
-        CancelReason, ExecuteStatus, ExecutionResultDescription, ExecutionStatuses,
-        FailureDescription, FinalRunStats, InfoResponse, ReporterEvent, RunFinishedStats, RunStats,
-        StressIndex, StressProgress, StressRunStats, TestEvent, TestEventKind,
+        CancelReason, ChildExecutionOutputDescription, ExecuteStatus, ExecutionResultDescription,
+        ExecutionStatuses, FailureDescription, FinalRunStats, InfoResponse, ReporterEvent,
+        RunFinishedStats, RunStats, StressIndex, StressProgress, StressRunStats, TestEvent,
+        TestEventKind,
     },
     runner::{ExecutorEvent, RunUnitQuery, SignalRequest, StressCondition, StressCount},
     signal::{
@@ -608,12 +609,12 @@ where
                     _ => None,
                 };
 
-                // Extract stdout and stderr lengths from the output
+                // Extract stdout and stderr lengths from the output.
                 let (stdout_len, stderr_len) = match &status.output {
-                    crate::test_output::ChildExecutionOutput::Output { output, .. } => {
+                    ChildExecutionOutputDescription::Output { output, .. } => {
                         output.stdout_stderr_len()
                     }
-                    crate::test_output::ChildExecutionOutput::StartError(_) => (None, None),
+                    ChildExecutionOutputDescription::StartError(_) => (None, None),
                 };
 
                 crate::fire_usdt!(UsdtSetupScriptDone {

--- a/nextest-runner/src/runner/executor.rs
+++ b/nextest-runner/src/runner/executor.rs
@@ -1238,7 +1238,7 @@ impl<'a> TestPacket<'a> {
             test_instance: self.test_instance.id(),
             state,
             retry_data: self.retry_data,
-            output,
+            output: output.into(),
         })
     }
 }
@@ -1293,7 +1293,7 @@ impl<'a> SetupScriptPacket<'a> {
             program: self.program.clone(),
             args: &self.config.command.args,
             state,
-            output,
+            output: output.into(),
         })
     }
 }

--- a/nextest-runner/src/test_output.rs
+++ b/nextest-runner/src/test_output.rs
@@ -112,25 +112,6 @@ pub enum ChildExecutionOutput {
     StartError(ChildStartError),
 }
 
-impl ChildExecutionOutput {
-    /// Returns true if there are any errors in this output.
-    pub(crate) fn has_errors(&self) -> bool {
-        match self {
-            ChildExecutionOutput::Output { errors, result, .. } => {
-                if errors.is_some() {
-                    return true;
-                }
-                if let Some(result) = result {
-                    return !result.is_success();
-                }
-
-                false
-            }
-            ChildExecutionOutput::StartError(_) => true,
-        }
-    }
-}
-
 /// The output of a child process: stdout and/or stderr.
 ///
 /// Part of [`ChildExecutionOutput`], and can be used independently as well.


### PR DESCRIPTION
Introduce `ChildExecutionOutputDescription` as the external-facing counterpart to `ChildExecutionOutput`. This separates internal platform-specific types from serializable external types at the executor -> events boundary.