### PR TITLE
add a type param to ChildExecutionOutputDescription

### DIFF
--- a/nextest-runner/src/reporter/displayer/imp.rs
+++ b/nextest-runner/src/reporter/displayer/imp.rs
@@ -2466,7 +2466,7 @@ mod tests {
         reporter::events::{
             ChildExecutionOutputDescription, ExecutionResult, FailureStatus, UnitTerminateReason,
         },
-        test_output::{ChildExecutionOutput, ChildOutput, ChildSplitOutput},
+        test_output::{ChildExecutionOutput, ChildOutput, ChildSingleOutput, ChildSplitOutput},
     };
     use bytes::Bytes;
     use chrono::Local;
@@ -3221,7 +3221,7 @@ mod tests {
         result: Option<ExecutionResult>,
         stdout: &str,
         stderr: &str,
-    ) -> ChildExecutionOutputDescription {
+    ) -> ChildExecutionOutputDescription<ChildSingleOutput> {
         ChildExecutionOutput::Output {
             result,
             output: ChildOutput::Split(ChildSplitOutput {
@@ -3238,7 +3238,7 @@ mod tests {
         stdout: &str,
         stderr: &str,
         errors: Vec<ChildError>,
-    ) -> ChildExecutionOutputDescription {
+    ) -> ChildExecutionOutputDescription<ChildSingleOutput> {
         ChildExecutionOutput::Output {
             result,
             output: ChildOutput::Split(ChildSplitOutput {
@@ -3254,7 +3254,7 @@ mod tests {
         result: Option<ExecutionResult>,
         output: &str,
         errors: Vec<ChildError>,
-    ) -> ChildExecutionOutputDescription {
+    ) -> ChildExecutionOutputDescription<ChildSingleOutput> {
         ChildExecutionOutput::Output {
             result,
             output: ChildOutput::Combined {

--- a/nextest-runner/src/reporter/displayer/unit_output.rs
+++ b/nextest-runner/src/reporter/displayer/unit_output.rs
@@ -11,7 +11,7 @@ use crate::{
         events::*,
         helpers::{Styles, highlight_end},
     },
-    test_output::{ChildOutput, ChildSingleOutput},
+    test_output::ChildSingleOutput,
     write_str::WriteStr,
 };
 use owo_colors::Style;
@@ -125,7 +125,7 @@ impl UnitOutputReporter {
         &self,
         styles: &Styles,
         spec: &ChildOutputSpec,
-        exec_output: &ChildExecutionOutputDescription,
+        exec_output: &ChildExecutionOutputDescription<ChildSingleOutput>,
         mut writer: &mut dyn WriteStr,
     ) -> io::Result<()> {
         match exec_output {
@@ -177,13 +177,13 @@ impl UnitOutputReporter {
         &self,
         styles: &Styles,
         spec: &ChildOutputSpec,
-        output: &ChildOutput,
+        output: &ChildOutputDescription<ChildSingleOutput>,
         highlight_slice: Option<TestOutputErrorSlice<'_>>,
         mut writer: &mut dyn WriteStr,
     ) -> io::Result<()> {
         match output {
-            ChildOutput::Split(split) => {
-                if let Some(stdout) = &split.stdout
+            ChildOutputDescription::Split { stdout, stderr } => {
+                if let Some(stdout) = stdout
                     && (self.display_empty_outputs || !stdout.is_empty())
                 {
                     writeln!(writer, "{}", spec.stdout_header)?;
@@ -203,7 +203,7 @@ impl UnitOutputReporter {
                     writer = indent_writer.into_inner();
                 }
 
-                if let Some(stderr) = &split.stderr
+                if let Some(stderr) = stderr
                     && (self.display_empty_outputs || !stderr.is_empty())
                 {
                     writeln!(writer, "{}", spec.stderr_header)?;
@@ -218,7 +218,7 @@ impl UnitOutputReporter {
                     indent_writer.write_str_flush()?;
                 }
             }
-            ChildOutput::Combined { output } => {
+            ChildOutputDescription::Combined { output } => {
                 if self.display_empty_outputs || !output.is_empty() {
                     writeln!(writer, "{}", spec.combined_header)?;
 

--- a/nextest-runner/src/runner/internal_events.rs
+++ b/nextest-runner/src/runner/internal_events.rs
@@ -21,7 +21,7 @@ use crate::{
         },
     },
     signal::ShutdownEvent,
-    test_output::ChildExecutionOutput,
+    test_output::{ChildExecutionOutput, ChildSingleOutput},
     time::StopwatchSnapshot,
 };
 use nextest_metadata::MismatchReason;
@@ -161,7 +161,7 @@ pub(super) struct InternalExecuteStatus<'a> {
 
 impl InternalExecuteStatus<'_> {
     pub(super) fn into_external(self) -> ExecuteStatus {
-        let output: ChildExecutionOutputDescription = self.output.into();
+        let output: ChildExecutionOutputDescription<ChildSingleOutput> = self.output.into();
 
         // Compute the error summary and output error slice using
         // UnitErrorDescription.
@@ -200,7 +200,7 @@ pub(super) struct InternalSetupScriptExecuteStatus<'a> {
 
 impl InternalSetupScriptExecuteStatus<'_> {
     pub(super) fn into_external(self) -> SetupScriptExecuteStatus {
-        let output: ChildExecutionOutputDescription = self.output.into();
+        let output: ChildExecutionOutputDescription<ChildSingleOutput> = self.output.into();
 
         // Compute the error summary using UnitErrorDescription.
         // Setup scripts don't have output_error_slice since that's only for


### PR DESCRIPTION
As part of record-replay work, we're going to have an alternative ChildExecutionOutputDescription that stores the output in a zip file. We can reuse the type hierarchy quite nicely.