### PR TITLE
iTerm supports OSC 9;4

### DIFF
--- a/nextest-runner/src/reporter/displayer/progress.rs
+++ b/nextest-runner/src/reporter/displayer/progress.rs
@@ -662,7 +662,7 @@ fn supports_osc_9_4(is_terminal: bool) -> bool {
         return true;
     }
     if let Ok(term) = std::env::var("TERM_PROGRAM")
-        && (term == "WezTerm" || term == "ghostty")
+        && (term == "WezTerm" || term == "ghostty" || term == "iTerm.app")
     {
         debug!("autodetect terminal progress reporting: enabling since TERM_PROGRAM is {term}");
         return true;


### PR DESCRIPTION
Similar to https://github.com/nextest-rs/nextest/pull/2724

> it would be really nice if there was an universally established protocol to query supported emulator features, too late for that

Yup. :/