### PR TITLE
[cargo-nextest] add --user-config-file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,7 @@ Every Rust source file must start with:
 
 **CRITICAL**: Always use `cargo nextest run` to run unit and integration tests. Never use `cargo test` for these! Nextest dogfoods itself and its test suite depends on nextest's execution model.
 
-To invoke the in-repo (locally built) copy of nextest, use `cargo local-nt` instead of `cargo nextest`. This is useful for testing changes to nextest itself.
+Use `cargo local-nt` only when you need to verify changes to nextest's own behavior (e.g., testing a new CLI flag or output format). For running the test suite itself, including `integration-tests`, use `cargo nextest run`—the integration tests spawn their own inner nextest processes from the build artifacts.
 
 For doctests, use `cargo test --doc` (doctests are not supported by nextest).
 

--- a/cargo-nextest/src/dispatch/commands.rs
+++ b/cargo-nextest/src/dispatch/commands.rs
@@ -4,6 +4,7 @@
 //! Subcommand implementations for show-config, self, and debug commands.
 
 use super::{
+    EarlyArgs,
     cli::{ConfigOpts, PagerOpts, TestBuildFilter},
     execution::{App, BaseApp},
     helpers::{detect_build_platforms, display_output_slice, extract_slice_from_output},
@@ -53,6 +54,7 @@ pub(super) enum ShowConfigCommand {
 impl ShowConfigCommand {
     pub(super) fn exec(
         self,
+        early_args: EarlyArgs,
         manifest_path: Option<Utf8PathBuf>,
         config_opts: ConfigOpts,
         output: OutputContext,
@@ -138,6 +140,7 @@ impl ShowConfigCommand {
             } => {
                 let base = BaseApp::new(
                     output,
+                    early_args,
                     *reuse_build,
                     *cargo_options,
                     config_opts,

--- a/cargo-nextest/src/dispatch/execution.rs
+++ b/cargo-nextest/src/dispatch/execution.rs
@@ -65,6 +65,7 @@ use tracing::{Level, info, warn};
 
 pub(super) struct BaseApp {
     output: OutputContext,
+    early_args: super::EarlyArgs,
     // TODO: support multiple --target options
     build_platforms: BuildPlatforms,
     cargo_metadata_json: Arc<String>,
@@ -85,6 +86,7 @@ pub(super) struct BaseApp {
 impl BaseApp {
     pub(super) fn new(
         output: OutputContext,
+        early_args: super::EarlyArgs,
         reuse_build: crate::reuse_build::ReuseBuildOpts,
         cargo_opts: crate::cargo_cli::CargoOptions,
         config_opts: super::cli::ConfigOpts,
@@ -154,6 +156,7 @@ impl BaseApp {
 
         Ok(Self {
             output,
+            early_args,
             build_platforms,
             cargo_metadata_json,
             package_graph,
@@ -528,7 +531,10 @@ impl App {
         let binary_list = self.base.build_binary_list("test")?;
 
         // Resolve user config to get pager settings.
-        let resolved_user_config = resolve_user_config(&self.base.build_platforms.host.platform)?;
+        let resolved_user_config = resolve_user_config(
+            &self.base.build_platforms.host.platform,
+            self.base.early_args.user_config_location(),
+        )?;
         let (pager_setting, paginate) = pager_opts.resolve(&resolved_user_config.ui);
 
         // Determine if we should page output.
@@ -641,7 +647,10 @@ impl App {
         let test_list = self.build_test_list(&ctx, binary_list, test_filter_builder, &profile)?;
 
         // Resolve user config to get pager settings.
-        let resolved_user_config = resolve_user_config(&self.base.build_platforms.host.platform)?;
+        let resolved_user_config = resolve_user_config(
+            &self.base.build_platforms.host.platform,
+            self.base.early_args.user_config_location(),
+        )?;
         let (pager_setting, paginate) = pager_opts.resolve(&resolved_user_config.ui);
 
         // Create paged output.
@@ -727,7 +736,10 @@ impl App {
             .should_colorize(supports_color::Stream::Stderr);
 
         // Load and resolve user config with platform-specific overrides.
-        let resolved_user_config = resolve_user_config(&self.base.build_platforms.host.platform)?;
+        let resolved_user_config = resolve_user_config(
+            &self.base.build_platforms.host.platform,
+            self.base.early_args.user_config_location(),
+        )?;
 
         // Make the runner and reporter builders. Do them now so warnings are
         // emitted before we start doing the build.
@@ -897,7 +909,10 @@ impl App {
             .should_colorize(supports_color::Stream::Stderr);
 
         // Load and resolve user config with platform-specific overrides.
-        let resolved_user_config = resolve_user_config(&self.base.build_platforms.host.platform)?;
+        let resolved_user_config = resolve_user_config(
+            &self.base.build_platforms.host.platform,
+            self.base.early_args.user_config_location(),
+        )?;
 
         // Make the runner and reporter builders. Do them now so warnings are
         // emitted before we start doing the build.

--- a/cargo-nextest/src/dispatch/helpers.rs
+++ b/cargo-nextest/src/dispatch/helpers.rs
@@ -18,7 +18,7 @@ use nextest_runner::{
     platform::{BuildPlatforms, HostPlatform, Platform, PlatformLibdir, TargetPlatform},
     reporter::TestOutputErrorSlice,
     target_runner::{PlatformRunner, TargetRunner},
-    user_config::UserConfig,
+    user_config::{UserConfig, UserConfigLocation},
 };
 use owo_colors::OwoColorize;
 use std::io::Write;
@@ -86,8 +86,11 @@ pub(super) fn detect_build_platforms(
 }
 
 /// Loads and resolves user configuration with platform-specific overrides.
-pub(super) fn resolve_user_config(host_platform: &Platform) -> Result<UserConfig, ExpectedError> {
-    UserConfig::for_host_platform(host_platform)
+pub(super) fn resolve_user_config(
+    host_platform: &Platform,
+    location: UserConfigLocation<'_>,
+) -> Result<UserConfig, ExpectedError> {
+    UserConfig::for_host_platform(host_platform, location)
         .map_err(|e| ExpectedError::UserConfigError { err: Box::new(e) })
 }
 

--- a/cargo-nextest/src/output.rs
+++ b/cargo-nextest/src/output.rs
@@ -65,7 +65,7 @@ pub(crate) struct OutputOpts {
 }
 
 impl OutputOpts {
-    pub(crate) fn init(self, early_args: EarlyArgs) -> OutputContext {
+    pub(crate) fn init(self, early_args: &EarlyArgs) -> OutputContext {
         let OutputOpts { verbose } = self;
 
         early_args.color.init();

--- a/integration-tests/src/env.rs
+++ b/integration-tests/src/env.rs
@@ -44,5 +44,11 @@ pub fn set_env_vars() {
         // Set NEXTEST_SHOW_PROGRESS to counter to ensure user config doesn't
         // affect test output.
         std::env::set_var("NEXTEST_SHOW_PROGRESS", "counter");
+
+        // Skip user config loading entirely for test isolation. This prevents
+        // the user's personal config from affecting test results. (Note that
+        // some config tests pass in --user-config-file, which overrides this
+        // environment variable.)
+        std::env::set_var("NEXTEST_USER_CONFIG_FILE", "none");
     }
 }

--- a/integration-tests/tests/integration/snapshots/integration__user_config__user_config_explicit_path_not_found.snap
+++ b/integration-tests/tests/integration/snapshots/integration__user_config__user_config_explicit_path_not_found.snap
@@ -1,0 +1,6 @@
+---
+source: integration-tests/tests/integration/user_config.rs
+assertion_line: 289
+expression: error_line
+---
+error: user config file not found at /nonexistent/path/to/config.toml

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -739,6 +739,14 @@ pub enum ToolConfigFileParseError {
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum UserConfigError {
+    /// The user config file specified via `--user-config-file` or
+    /// `NEXTEST_USER_CONFIG_FILE` does not exist.
+    #[error("user config file not found at {path}")]
+    FileNotFound {
+        /// The path that was specified.
+        path: Utf8PathBuf,
+    },
+
     /// Failed to read the user config file.
     #[error("failed to read user config at {path}")]
     Read {


### PR DESCRIPTION
Add a new `--user-config-file` CLI flag and `NEXTEST_USER_CONFIG_FILE` environment variable that allow explicit control over user configuration loading. This is useful for test isolation and custom configurations.

The flag accepts either a path to a config file, or the special value "none" to skip user config loading entirely. When an explicit path is provided and the file doesn't exist, nextest returns an error rather than silently falling back to defaults.

Also clarify AGENTS.md guidance on when to use `cargo local-nt` vs `cargo nextest run`.