### PR TITLE
fix panic with on-timeout = pass

### DIFF
--- a/nextest-runner/src/reporter/displayer/snapshots/nextest_runner__reporter__displayer__imp__tests__final_status_timeout_pass.snap
+++ b/nextest-runner/src/reporter/displayer/snapshots/nextest_runner__reporter__displayer__imp__tests__final_status_timeout_pass.snap
@@ -1,0 +1,6 @@
+---
+source: nextest-runner/src/reporter/displayer/imp.rs
+expression: out
+---
+      TMPASS [ 240.000s] ( 1/10) my-binary-id timeout_test
+ SLOW+TMPASS [ 300.000s] ( 2/10) my-binary-id timeout_test


### PR DESCRIPTION
fixes #2939

`write_final_status_line` and `output_spec_for_finished` were missing `Timeout { Pass }` handling

adds:
- `TMPASS` / `SLOW+TMPASS` status display
- test with snapshot