### PR TITLE
[nextest-runner] add use_unicode to ReporterOutput::Writer

### DIFF
--- a/cargo-nextest/src/dispatch/execution.rs
+++ b/cargo-nextest/src/dispatch/execution.rs
@@ -1367,6 +1367,7 @@ pub(super) fn exec_replay(
         PagedOutput::request_pager(&pager_setting, paginate, &user_config.ui.streampager);
 
     let should_colorize = output.color.should_colorize(supports_color::Stream::Stdout);
+    let use_unicode = supports_unicode::on(supports_unicode::Stream::Stdout);
 
     let mut reporter_builder = ReplayReporterBuilder::new();
     reporter_builder.set_colorize(should_colorize);
@@ -1378,7 +1379,10 @@ pub(super) fn exec_replay(
     let mut reporter = reporter_builder.build(
         record_opts.run_mode,
         test_list.test_count(),
-        ReporterOutput::Writer(&mut paged_output),
+        ReporterOutput::Writer {
+            writer: &mut paged_output,
+            use_unicode,
+        },
     );
 
     // Write the replay header through the reporter.

--- a/nextest-runner/src/reporter/displayer/imp.rs
+++ b/nextest-runner/src/reporter/displayer/imp.rs
@@ -86,15 +86,16 @@ impl DisplayReporterBuilder {
         };
 
         let mut theme_characters = ThemeCharacters::default();
-        match output {
+        match &output {
             ReporterOutput::Terminal => {
                 if supports_unicode::on(supports_unicode::Stream::Stderr) {
                     theme_characters.use_unicode();
                 }
             }
-            ReporterOutput::Writer(_) => {
-                // Always use Unicode for writers.
-                theme_characters.use_unicode();
+            ReporterOutput::Writer { use_unicode, .. } => {
+                if *use_unicode {
+                    theme_characters.use_unicode();
+                }
             }
         }
 
@@ -120,7 +121,7 @@ impl DisplayReporterBuilder {
                     term_progress,
                 }
             }
-            ReporterOutput::Writer(writer) => ReporterOutputImpl::Writer(writer),
+            ReporterOutput::Writer { writer, .. } => ReporterOutputImpl::Writer(writer),
         };
 
         // success_output is meaningless if the runner isn't capturing any
@@ -2596,7 +2597,10 @@ mod tests {
             show_term_progress: ShowTerminalProgress::No,
         };
 
-        let output = ReporterOutput::Writer(out);
+        let output = ReporterOutput::Writer {
+            writer: out,
+            use_unicode: true,
+        };
         let reporter = builder.build(output);
         f(reporter);
     }

--- a/nextest-runner/src/reporter/imp.rs
+++ b/nextest-runner/src/reporter/imp.rs
@@ -56,7 +56,16 @@ pub enum ReporterOutput<'a> {
 
     /// Write output to a `WriteStr` implementation (e.g., for pager support or
     /// an in-memory buffer for tests).
-    Writer(&'a mut (dyn WriteStr + Send)),
+    Writer {
+        /// The writer to use for output.
+        writer: &'a mut (dyn WriteStr + Send),
+        /// Whether to use unicode characters for output.
+        ///
+        /// The caller should determine this based on the actual output
+        /// destination (e.g., by checking `supports_unicode::on()` for the
+        /// appropriate stream).
+        use_unicode: bool,
+    },
 }
 
 /// Test reporter builder.


### PR DESCRIPTION
Previously, `DisplayReporterBuilder::build()` unconditionally enabled unicode characters for all `ReporterOutput::Writer` cases. But a writer could have been writing to a pager where the ultimate output destination may not support unicode.

Change `ReporterOutput::Writer` from a tuple variant to a struct variant with an explicit `use_unicode` field.