### PR TITLE
[nextest-runner] add a last-written-at field to runs.json

### DIFF
--- a/internal-docs/record-replay.md
+++ b/internal-docs/record-replay.md
@@ -275,6 +275,27 @@ NEXTEST_EXPERIMENTAL_RECORD=1 cargo nextest run
 - For stress test runs (`--stress`), should each sub-run be recorded separately?
 - Proposal: Record as single archive with stress index in event metadata
 
+## LRU eviction with `last-written-at`
+
+The retention policy uses true LRU (least recently used) eviction rather than LRC (least recently created). This ensures that frequently-used runs are kept even if they were created long ago—important for the future `rerun` feature where repeatedly rerunning from the same base run should not cause that original run to be evicted.
+
+Each run has a `last-written-at` timestamp (`DateTime<Utc>`) that tracks when the run was last used in a way that caused a write. The retention policy in `compute_runs_to_delete()` sorts runs by this timestamp and uses it for age calculation.
+
+**Data model** (in `runs.json`):
+```json
+{
+  "run-id": "...",
+  "started-at": "2024-12-19T14:22:33-08:00",
+  "last-written-at": "2024-12-20T10:15:00Z",
+  ...
+}
+```
+
+**What updates `last-written-at`**:
+1. **Creating the run**: Set to the current time when the run is created
+2. **Rerun from this run** (future): When `cargo nextest rerun -r <run-id>` creates a new run that references this one, update `last-written-at` on the source run
+3. **Other operations** (future): Any operation that reads a run and produces a new artifact based on it
+
 ## Files to modify
 
 ### New files

--- a/nextest-runner/src/record/run_id_index.rs
+++ b/nextest-runner/src/record/run_id_index.rs
@@ -243,13 +243,15 @@ mod tests {
 
     /// Creates a test run with the given run ID.
     fn make_run(run_id: ReportUuid) -> RecordedRunInfo {
+        let started_at = chrono::FixedOffset::east_opt(0)
+            .unwrap()
+            .with_ymd_and_hms(2024, 1, 1, 0, 0, 0)
+            .unwrap();
         RecordedRunInfo {
             run_id,
             nextest_version: Version::new(0, 1, 0),
-            started_at: chrono::FixedOffset::east_opt(0)
-                .unwrap()
-                .with_ymd_and_hms(2024, 1, 1, 0, 0, 0)
-                .unwrap(),
+            started_at,
+            last_written_at: started_at.to_utc(),
             duration_secs: None,
             compressed_size: 0,
             uncompressed_size: 0,

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_cancelled.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_cancelled.snap
@@ -1,11 +1,13 @@
 ---
 source: nextest-runner/src/record/format.rs
 expression: json
+snapshot_kind: text
 ---
 {
   "run-id": "550e8400-e29b-41d4-a716-446655440000",
   "nextest-version": "0.9.111",
   "started-at": "2024-12-19T14:22:33-08:00",
+  "last-written-at": "2024-12-19T22:22:33Z",
   "duration-secs": 12.345,
   "compressed-size": 12345,
   "uncompressed-size": 45678,

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_completed.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_completed.snap
@@ -1,11 +1,13 @@
 ---
 source: nextest-runner/src/record/format.rs
 expression: json
+snapshot_kind: text
 ---
 {
   "run-id": "550e8400-e29b-41d4-a716-446655440000",
   "nextest-version": "0.9.111",
   "started-at": "2024-12-19T14:22:33-08:00",
+  "last-written-at": "2024-12-19T22:22:33Z",
   "duration-secs": 12.345,
   "compressed-size": 12345,
   "uncompressed-size": 45678,

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_incomplete.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_incomplete.snap
@@ -1,11 +1,13 @@
 ---
 source: nextest-runner/src/record/format.rs
 expression: json
+snapshot_kind: text
 ---
 {
   "run-id": "550e8400-e29b-41d4-a716-446655440000",
   "nextest-version": "0.9.111",
   "started-at": "2024-12-19T14:22:33-08:00",
+  "last-written-at": "2024-12-19T22:22:33Z",
   "duration-secs": 12.345,
   "compressed-size": 12345,
   "uncompressed-size": 45678,

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_cancelled.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_cancelled.snap
@@ -7,6 +7,7 @@ snapshot_kind: text
   "run-id": "550e8400-e29b-41d4-a716-446655440000",
   "nextest-version": "0.9.111",
   "started-at": "2024-12-19T14:22:33-08:00",
+  "last-written-at": "2024-12-19T22:22:33Z",
   "duration-secs": 12.345,
   "compressed-size": 12345,
   "uncompressed-size": 45678,

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_completed.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_completed.snap
@@ -7,6 +7,7 @@ snapshot_kind: text
   "run-id": "550e8400-e29b-41d4-a716-446655440000",
   "nextest-version": "0.9.111",
   "started-at": "2024-12-19T14:22:33-08:00",
+  "last-written-at": "2024-12-19T22:22:33Z",
   "duration-secs": 12.345,
   "compressed-size": 12345,
   "uncompressed-size": 45678,

--- a/nextest-runner/src/record/store.rs
+++ b/nextest-runner/src/record/store.rs
@@ -346,6 +346,7 @@ impl<'store> ExclusiveLockedRunStore<'store> {
             run_id,
             nextest_version,
             started_at,
+            last_written_at: Utc::now(),
             duration_secs: None,
             compressed_size: 0,
             uncompressed_size: 0,
@@ -373,6 +374,11 @@ pub struct RecordedRunInfo {
     pub nextest_version: Version,
     /// When the run started.
     pub started_at: DateTime<FixedOffset>,
+    /// When this run was last written to.
+    ///
+    /// Used for LRU eviction. Updated when the run is created, and in the
+    /// future when operations like `rerun` reference this run.
+    pub last_written_at: DateTime<Utc>,
     /// Duration of the run in seconds.
     ///
     /// This is `None` for incomplete runs.


### PR DESCRIPTION
We're going to update this field on the parent run during reruns to avoid those runs getting pruned in the middle of work.