### PR TITLE
[nextest-runner] use DateTime<FixedOffset> for last-written-at

### DIFF
--- a/internal-docs/record-replay.md
+++ b/internal-docs/record-replay.md
@@ -279,7 +279,7 @@ NEXTEST_EXPERIMENTAL_RECORD=1 cargo nextest run
 
 The retention policy uses true LRU (least recently used) eviction rather than LRC (least recently created). This ensures that frequently-used runs are kept even if they were created long ago—important for the future `rerun` feature where repeatedly rerunning from the same base run should not cause that original run to be evicted.
 
-Each run has a `last-written-at` timestamp (`DateTime<Utc>`) that tracks when the run was last used in a way that caused a write. The retention policy in `compute_runs_to_delete()` sorts runs by this timestamp and uses it for age calculation.
+Each run has a `last-written-at` timestamp (`DateTime<FixedOffset>`) that tracks when the run was last used in a way that caused a write. The retention policy in `compute_runs_to_delete()` sorts runs by this timestamp and uses it for age calculation.
 
 **Data model** (in `runs.json`):
 ```json
@@ -293,8 +293,9 @@ Each run has a `last-written-at` timestamp (`DateTime<Utc>`) that tracks when th
 
 **What updates `last-written-at`**:
 1. **Creating the run**: Set to the current time when the run is created
-2. **Rerun from this run** (future): When `cargo nextest rerun -r <run-id>` creates a new run that references this one, update `last-written-at` on the source run
-3. **Other operations** (future): Any operation that reads a run and produces a new artifact based on it
+2. **Completing the run**: Updated when the run finishes (successful or otherwise)
+3. **Rerun from this run** (future): When `cargo nextest rerun -r <run-id>` creates a new run that references this one, update `last-written-at` on the source run
+4. **Other operations** (future): Any operation that reads a run and produces a new artifact based on it
 
 ## Files to modify
 

--- a/nextest-runner/src/record/format.rs
+++ b/nextest-runner/src/record/format.rs
@@ -126,9 +126,10 @@ pub(super) struct RecordedRun {
     pub(super) started_at: DateTime<FixedOffset>,
     /// When this run was last written to.
     ///
-    /// Used for LRU eviction. Updated when the run is created, and in the
-    /// future when operations like `rerun` reference this run.
-    pub(super) last_written_at: DateTime<Utc>,
+    /// Used for LRU eviction. Updated when the run is created, when the run
+    /// completes, and in the future when operations like `rerun` reference
+    /// this run.
+    pub(super) last_written_at: DateTime<FixedOffset>,
     /// Duration of the run in seconds.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) duration_secs: Option<f64>,
@@ -589,8 +590,7 @@ mod tests {
             started_at: DateTime::parse_from_rfc3339("2024-12-19T14:22:33-08:00")
                 .expect("valid timestamp"),
             last_written_at: DateTime::parse_from_rfc3339("2024-12-19T22:22:33Z")
-                .expect("valid timestamp")
-                .to_utc(),
+                .expect("valid timestamp"),
             duration_secs: Some(12.345),
             sizes: RecordedSizesFormat {
                 log: ComponentSizesFormat {

--- a/nextest-runner/src/record/retention.rs
+++ b/nextest-runner/src/record/retention.rs
@@ -536,7 +536,7 @@ mod tests {
             run_id,
             nextest_version: Version::new(0, 1, 0),
             started_at,
-            last_written_at: started_at.to_utc(),
+            last_written_at: started_at,
             duration_secs: Some(1.0),
             sizes: RecordedSizes {
                 log: ComponentSizes::default(),
@@ -1001,7 +1001,7 @@ mod tests {
             run_id: uuid.parse().expect("valid UUID"),
             nextest_version: Version::parse(version).expect("valid version"),
             started_at,
-            last_written_at: started_at.to_utc(),
+            last_written_at: started_at,
             duration_secs: Some(1.0),
             sizes: RecordedSizes {
                 log: ComponentSizes::default(),

--- a/nextest-runner/src/record/run_id_index.rs
+++ b/nextest-runner/src/record/run_id_index.rs
@@ -251,7 +251,7 @@ mod tests {
             run_id,
             nextest_version: Version::new(0, 1, 0),
             started_at,
-            last_written_at: started_at.to_utc(),
+            last_written_at: started_at,
             duration_secs: None,
             sizes: RecordedSizes::default(),
             status: RecordedRunStatus::Incomplete,


### PR DESCRIPTION
Also bump it at run completion.