### PR TITLE
[nextest-runner] further cleanup

### DIFF
--- a/cargo-nextest/src/dispatch/cli.rs
+++ b/cargo-nextest/src/dispatch/cli.rs
@@ -30,7 +30,7 @@ use nextest_runner::{
     },
     partition::PartitionerBuilder,
     platform::BuildPlatforms,
-    record::{NoTestsBehavior, ReplayReporterBuilder},
+    record::{NoTestsBehavior, ReplayReporterBuilder, RunIdSelector},
     reporter::{
         FinalStatusLevel, MaxProgressRunning, ReporterBuilder, StatusLevel, TestOutputDisplay,
     },
@@ -310,11 +310,12 @@ pub(super) struct ListOpts {
 /// Options for the replay command.
 #[derive(Debug, Args)]
 pub(super) struct ReplayOpts {
-    /// Run ID to replay (default: most recent completed run).
+    /// Run ID to replay.
     ///
-    /// Accepts full UUIDs or unambiguous prefixes.
-    #[arg(long, short = 'r', value_name = "RUN_ID")]
-    pub(super) run_id: Option<String>,
+    /// Accepts "latest" (the default) for the most recent completed run,
+    /// or a full UUID or unambiguous prefix.
+    #[arg(long, short = 'r', value_name = "RUN_ID", default_value_t)]
+    pub(super) run_id: RunIdSelector,
 
     /// Exit with the same code as the original run.
     ///

--- a/integration-tests/tests/integration/record_replay.rs
+++ b/integration-tests/tests/integration/record_replay.rs
@@ -292,6 +292,19 @@ fn test_record_replay_cycle() {
         RunProperties::ALLOW_SKIPPED_NAMES_IN_OUTPUT,
     );
 
+    // Replay with explicit "latest" (should produce same output as default).
+    let replay_latest = cli_with_recording(&p, &cache_dir, &user_config_path, None)
+        .args(["replay", "-r", "latest", "--status-level", "all"])
+        .output();
+    assert!(
+        replay_latest.exit_status.success(),
+        "replay with -r latest should succeed: {replay_latest}"
+    );
+    check_run_output(
+        &replay_latest.stdout,
+        RunProperties::ALLOW_SKIPPED_NAMES_IN_OUTPUT,
+    );
+
     // Verify archive structure.
     let runs_dir = find_runs_dir(&cache_dir).expect("runs directory should exist");
     let run_dirs: Vec<_> = std::fs::read_dir(&runs_dir)

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__error_replay_invalid_run_id.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__error_replay_invalid_run_id.snap
@@ -1,5 +1,8 @@
 ---
 source: integration-tests/tests/integration/record_replay.rs
-expression: redact_dynamic_fields(&replay_invalid.stderr_as_str())
+expression: "redact_dynamic_fields(&replay_invalid.stderr_as_str(), temp_root)"
+snapshot_kind: text
 ---
-error: prefix `not-a-uuid!!!` contains invalid characters (expected hexadecimal)
+error: invalid value 'not-a-uuid!!!' for '--run-id <RUN_ID>': invalid run ID selector `not-a-uuid!!!`: expected `latest` or hex digits
+
+For more information, try '--help'.

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_multiple_runs.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_multiple_runs.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 3 recorded runs:
 
-  50000003  [TIMESTAMP]  [DURATION]  [SIZE]  2 passed
+  50000003  [TIMESTAMP]  [DURATION]  [SIZE]  2 passed  *latest
   50000002  [TIMESTAMP]  [DURATION]  [SIZE]  1 passed
   50000001  [TIMESTAMP]  [DURATION]  [SIZE]  1 passed
   ──────

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_single_run.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_single_run.snap
@@ -5,6 +5,6 @@ snapshot_kind: text
 ---
 1 recorded run:
 
-  10000001  [TIMESTAMP]  [DURATION]  [SIZE]  21 passed / 9 failed
+  10000001  [TIMESTAMP]  [DURATION]  [SIZE]  21 passed / 9 failed  *latest
   ──────
   [SIZE]

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_stress_run.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_stress_run.snap
@@ -5,6 +5,6 @@ snapshot_kind: text
 ---
 1 recorded run:
 
-  60000001  [TIMESTAMP]  [DURATION]  [SIZE]  5 passed iterations
+  60000001  [TIMESTAMP]  [DURATION]  [SIZE]  5 passed iterations  *latest
   ──────
   [SIZE]

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_verbose_multiple_runs.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_verbose_multiple_runs.snap
@@ -7,7 +7,7 @@ store: [TEMP_DIR]
 
 3 recorded runs:
 
-  50000003  [TIMESTAMP]  [DURATION]  [SIZE]  2 passed
+  50000003  [TIMESTAMP]  [DURATION]  [SIZE]  2 passed  *latest
   50000002  [TIMESTAMP]  [DURATION]  [SIZE]  1 passed
   50000001  [TIMESTAMP]  [DURATION]  [SIZE]  1 passed
   ──────

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_verbose_single_run.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_verbose_single_run.snap
@@ -7,6 +7,6 @@ store: [TEMP_DIR]
 
 1 recorded run:
 
-  10000001  [TIMESTAMP]  [DURATION]  [SIZE]  21 passed / 9 failed
+  10000001  [TIMESTAMP]  [DURATION]  [SIZE]  21 passed / 9 failed  *latest
   ──────
   [SIZE]

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -2358,6 +2358,17 @@ pub enum RecordPruneError {
     },
 }
 
+/// Error returned when parsing an invalid run ID selector.
+///
+/// A valid selector is either "latest" or a string containing only hex digits
+/// and dashes (for UUID format).
+#[derive(Clone, Debug, PartialEq, Eq, Error)]
+#[error("invalid run ID selector `{input}`: expected `latest` or hex digits")]
+pub struct InvalidRunIdSelector {
+    /// The invalid input string.
+    pub input: String,
+}
+
 /// An error resolving a run ID prefix.
 #[derive(Debug, Error)]
 pub enum RunIdResolutionError {

--- a/nextest-runner/src/record/mod.rs
+++ b/nextest-runner/src/record/mod.rs
@@ -49,15 +49,15 @@ pub use retention::{
     DisplayPrunePlan, DisplayPruneResult, PruneKind, PrunePlan, PruneResult, RecordRetentionPolicy,
     format_size_display,
 };
-pub use run_id_index::{RunIdIndex, ShortestRunIdPrefix};
+pub use run_id_index::{RunIdIndex, RunIdSelector, ShortestRunIdPrefix};
 pub use session::{
     RecordFinalizeResult, RecordFinalizeWarning, RecordSession, RecordSessionConfig,
     RecordSessionSetup,
 };
 pub use store::{
     CompletedRunStats, ComponentSizes, DisplayRecordedRunInfo, DisplayRunList,
-    ExclusiveLockedRunStore, MostRecentRunResult, RecordedRunInfo, RecordedRunStatus,
-    RecordedSizes, RunListAlignment, RunStore, RunStoreSnapshot, SharedLockedRunStore,
+    ExclusiveLockedRunStore, RecordedRunInfo, RecordedRunStatus, RecordedSizes, ResolveRunIdResult,
+    RunListAlignment, RunStore, RunStoreSnapshot, SharedLockedRunStore, StoreRunsDir,
     StressCompletedRunStats, Styles,
 };
 pub use summary::{

--- a/nextest-runner/src/record/replay.rs
+++ b/nextest-runner/src/record/replay.rs
@@ -613,13 +613,13 @@ pub struct ReplayHeader {
     pub status: RecordedRunStatus,
     /// Number of newer incomplete runs that were skipped.
     ///
-    /// This is `Some` only when the most recent run was not selected because
+    /// This is non-zero when the most recent run was not selected because
     /// it was incomplete, and we fell back to an earlier completed run.
-    pub newer_incomplete_count: Option<usize>,
+    pub newer_incomplete_count: usize,
 }
 
 impl ReplayHeader {
-    /// Creates a new replay header from run info and optional incomplete count.
+    /// Creates a new replay header from run info and incomplete count.
     ///
     /// The `run_id_index` parameter enables unique prefix highlighting similar
     /// to `cargo nextest store list`. If provided, the shortest unique prefix
@@ -628,7 +628,7 @@ impl ReplayHeader {
         run_id: ReportUuid,
         run_info: Option<&RecordedRunInfo>,
         run_id_index: Option<&RunIdIndex>,
-        newer_incomplete_count: Option<usize>,
+        newer_incomplete_count: usize,
     ) -> Self {
         let (started_at, status) = match run_info {
             Some(info) => (info.started_at, info.status.clone()),

--- a/nextest-runner/src/reporter/displayer/imp.rs
+++ b/nextest-runner/src/reporter/displayer/imp.rs
@@ -310,7 +310,8 @@ impl<'a> DisplayReporter<'a> {
             )?;
 
             // Write skipped incomplete runs if any.
-            if let Some(count) = header.newer_incomplete_count {
+            if header.newer_incomplete_count > 0 {
+                let count = header.newer_incomplete_count;
                 write!(writer, "{:>12} ", "Skipping".style(styles.skip))?;
                 writeln!(
                     writer,


### PR DESCRIPTION
Accept `latest` for the latest completed run, and add a `StoreRunsDir` abstraction.