### PR TITLE
[integration-tests] better redaction

### DIFF
--- a/cargo-nextest/src/errors.rs
+++ b/cargo-nextest/src/errors.rs
@@ -1197,12 +1197,14 @@ impl ExpectedError {
                             count.style(styles.bold),
                             plural::runs_str(*count)
                         );
+                        let redactor =
+                            crate::output::should_redact().then(Redactor::for_snapshot_testing);
                         let alignment = RunListAlignment::from_runs(candidates);
                         for candidate in candidates {
                             info!(
                                 target: "cargo_nextest::no_heading",
                                 "{}",
-                                candidate.display(run_id_index, alignment, &styles.record_styles)
+                                candidate.display(run_id_index, alignment, &styles.record_styles, redactor.as_ref())
                             );
                         }
                         if *count > candidates.len() {

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__error_replay_ambiguous_prefix.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__error_replay_ambiguous_prefix.snap
@@ -4,5 +4,5 @@ expression: "redact_dynamic_fields(&replay_ambiguous.stderr_as_str(), temp_root)
 snapshot_kind: text
 ---
 error: prefix `a` is ambiguous, matches 2 runs:
-  aaaa0002  [TIMESTAMP]  [DURATION]  [SIZE]  1 passed
-  aaaa0001  [TIMESTAMP]  [DURATION]  [SIZE]  1 passed
+  aaaa0002  XXXX-XX-XX XX:XX:XX  <duration>  <size> KB  1 passed
+  aaaa0001  XXXX-XX-XX XX:XX:XX  <duration>  <size> KB  1 passed

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__replay_stress_run.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__replay_stress_run.snap
@@ -3,175 +3,175 @@ source: integration-tests/tests/integration/record_replay.rs
 expression: "redact_dynamic_fields(&output, temp_root)"
 snapshot_kind: text
 ---
-  Replaying recorded run 60000001-0000-0000-0000-000000000001
-  Started [TIMESTAMP]  status: stress completed
+   Replaying recorded run 60000001-0000-0000-0000-000000000001
+     Started XXXX-XX-XX XX:XX:XX  status: stress completed
 ────────────
  Nextest run ID 60000001-0000-0000-0000-000000000001 with nextest profile: default
-  Starting 1 test across 7 binaries (29 tests skipped)
+    Starting 1 test across 7 binaries (29 tests skipped)
 ────────────
  Stress test iteration 1/5 (00:00:00 elapsed so far, 5 iterations remaining)
-  SKIP [  ] [1/5] (─────) nextest-tests tests::call_dylib_add_two
-  SKIP [  ] [1/5] (─────) nextest-tests tests::unit_test_success
-  SKIP [  ] [1/5] (─────) nextest-tests::basic test_cargo_env_vars
-  SKIP [  ] [1/5] (─────) nextest-tests::basic test_cwd
-  SKIP [  ] [1/5] (─────) nextest-tests::basic test_execute_bin
-  SKIP [  ] [1/5] (─────) nextest-tests::basic test_failure_assert
-  SKIP [  ] [1/5] (─────) nextest-tests::basic test_failure_error
-  SKIP [  ] [1/5] (─────) nextest-tests::basic test_failure_should_panic
-  SKIP [  ] [1/5] (─────) nextest-tests::basic test_flaky_mod_4
-  SKIP [  ] [1/5] (─────) nextest-tests::basic test_flaky_mod_6
-  SKIP [  ] [1/5] (─────) nextest-tests::basic test_flaky_slow_timeout_mod_3
-  SKIP [  ] [1/5] (─────) nextest-tests::basic test_ignored
-  SKIP [  ] [1/5] (─────) nextest-tests::basic test_ignored_fail
-  SKIP [  ] [1/5] (─────) nextest-tests::basic test_result_failure
-  SKIP [  ] [1/5] (─────) nextest-tests::basic test_slow_timeout
-  SKIP [  ] [1/5] (─────) nextest-tests::basic test_slow_timeout_2
-  SKIP [  ] [1/5] (─────) nextest-tests::basic test_slow_timeout_subprocess
-  SKIP [  ] [1/5] (─────) nextest-tests::basic test_stdin_closed
-  SKIP [  ] [1/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit
-  SKIP [  ] [1/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit_fail
-  SKIP [  ] [1/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit_leak_fail
-  SKIP [  ] [1/5] (─────) nextest-tests::basic test_success_should_panic
-  SKIP [  ] [1/5] (─────) nextest-tests::other other_test_success
-  SKIP [  ] [1/5] (─────) nextest-tests::segfault test_segfault
-  SKIP [  ] [1/5] (─────) nextest-tests::bin/nextest-tests fake_test_name
-  SKIP [  ] [1/5] (─────) nextest-tests::bin/nextest-tests tests::bin_success
-  SKIP [  ] [1/5] (─────) nextest-tests::bin/other tests::other_bin_success
-  SKIP [  ] [1/5] (─────) nextest-tests::example/nextest-tests fake_test_name
-  SKIP [  ] [1/5] (─────) nextest-tests::example/nextest-tests tests::example_success
-  PASS [  [DURATION]] [1/5] (1/1) nextest-tests::basic test_success
- Stress test [  [DURATION]] iteration 1/5: 1 test run: 1 passed, 29 skipped
+        SKIP [         ] [1/5] (─────) nextest-tests tests::call_dylib_add_two
+        SKIP [         ] [1/5] (─────) nextest-tests tests::unit_test_success
+        SKIP [         ] [1/5] (─────) nextest-tests::basic test_cargo_env_vars
+        SKIP [         ] [1/5] (─────) nextest-tests::basic test_cwd
+        SKIP [         ] [1/5] (─────) nextest-tests::basic test_execute_bin
+        SKIP [         ] [1/5] (─────) nextest-tests::basic test_failure_assert
+        SKIP [         ] [1/5] (─────) nextest-tests::basic test_failure_error
+        SKIP [         ] [1/5] (─────) nextest-tests::basic test_failure_should_panic
+        SKIP [         ] [1/5] (─────) nextest-tests::basic test_flaky_mod_4
+        SKIP [         ] [1/5] (─────) nextest-tests::basic test_flaky_mod_6
+        SKIP [         ] [1/5] (─────) nextest-tests::basic test_flaky_slow_timeout_mod_3
+        SKIP [         ] [1/5] (─────) nextest-tests::basic test_ignored
+        SKIP [         ] [1/5] (─────) nextest-tests::basic test_ignored_fail
+        SKIP [         ] [1/5] (─────) nextest-tests::basic test_result_failure
+        SKIP [         ] [1/5] (─────) nextest-tests::basic test_slow_timeout
+        SKIP [         ] [1/5] (─────) nextest-tests::basic test_slow_timeout_2
+        SKIP [         ] [1/5] (─────) nextest-tests::basic test_slow_timeout_subprocess
+        SKIP [         ] [1/5] (─────) nextest-tests::basic test_stdin_closed
+        SKIP [         ] [1/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit
+        SKIP [         ] [1/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit_fail
+        SKIP [         ] [1/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit_leak_fail
+        SKIP [         ] [1/5] (─────) nextest-tests::basic test_success_should_panic
+        SKIP [         ] [1/5] (─────) nextest-tests::other other_test_success
+        SKIP [         ] [1/5] (─────) nextest-tests::segfault test_segfault
+        SKIP [         ] [1/5] (─────) nextest-tests::bin/nextest-tests fake_test_name
+        SKIP [         ] [1/5] (─────) nextest-tests::bin/nextest-tests tests::bin_success
+        SKIP [         ] [1/5] (─────) nextest-tests::bin/other tests::other_bin_success
+        SKIP [         ] [1/5] (─────) nextest-tests::example/nextest-tests fake_test_name
+        SKIP [         ] [1/5] (─────) nextest-tests::example/nextest-tests tests::example_success
+        PASS [ duration] [1/5] (1/1) nextest-tests::basic test_success
+ Stress test [ duration] iteration 1/5: 1 test run: 1 passed, 29 skipped
 ────────────
  Stress test iteration 2/5 (00:00:00 elapsed so far, 4 iterations remaining)
-  SKIP [  ] [2/5] (─────) nextest-tests tests::call_dylib_add_two
-  SKIP [  ] [2/5] (─────) nextest-tests tests::unit_test_success
-  SKIP [  ] [2/5] (─────) nextest-tests::basic test_cargo_env_vars
-  SKIP [  ] [2/5] (─────) nextest-tests::basic test_cwd
-  SKIP [  ] [2/5] (─────) nextest-tests::basic test_execute_bin
-  SKIP [  ] [2/5] (─────) nextest-tests::basic test_failure_assert
-  SKIP [  ] [2/5] (─────) nextest-tests::basic test_failure_error
-  SKIP [  ] [2/5] (─────) nextest-tests::basic test_failure_should_panic
-  SKIP [  ] [2/5] (─────) nextest-tests::basic test_flaky_mod_4
-  SKIP [  ] [2/5] (─────) nextest-tests::basic test_flaky_mod_6
-  SKIP [  ] [2/5] (─────) nextest-tests::basic test_flaky_slow_timeout_mod_3
-  SKIP [  ] [2/5] (─────) nextest-tests::basic test_ignored
-  SKIP [  ] [2/5] (─────) nextest-tests::basic test_ignored_fail
-  SKIP [  ] [2/5] (─────) nextest-tests::basic test_result_failure
-  SKIP [  ] [2/5] (─────) nextest-tests::basic test_slow_timeout
-  SKIP [  ] [2/5] (─────) nextest-tests::basic test_slow_timeout_2
-  SKIP [  ] [2/5] (─────) nextest-tests::basic test_slow_timeout_subprocess
-  SKIP [  ] [2/5] (─────) nextest-tests::basic test_stdin_closed
-  SKIP [  ] [2/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit
-  SKIP [  ] [2/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit_fail
-  SKIP [  ] [2/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit_leak_fail
-  SKIP [  ] [2/5] (─────) nextest-tests::basic test_success_should_panic
-  SKIP [  ] [2/5] (─────) nextest-tests::other other_test_success
-  SKIP [  ] [2/5] (─────) nextest-tests::segfault test_segfault
-  SKIP [  ] [2/5] (─────) nextest-tests::bin/nextest-tests fake_test_name
-  SKIP [  ] [2/5] (─────) nextest-tests::bin/nextest-tests tests::bin_success
-  SKIP [  ] [2/5] (─────) nextest-tests::bin/other tests::other_bin_success
-  SKIP [  ] [2/5] (─────) nextest-tests::example/nextest-tests fake_test_name
-  SKIP [  ] [2/5] (─────) nextest-tests::example/nextest-tests tests::example_success
-  PASS [  [DURATION]] [2/5] (1/1) nextest-tests::basic test_success
- Stress test [  [DURATION]] iteration 2/5: 1 test run: 1 passed, 29 skipped
+        SKIP [         ] [2/5] (─────) nextest-tests tests::call_dylib_add_two
+        SKIP [         ] [2/5] (─────) nextest-tests tests::unit_test_success
+        SKIP [         ] [2/5] (─────) nextest-tests::basic test_cargo_env_vars
+        SKIP [         ] [2/5] (─────) nextest-tests::basic test_cwd
+        SKIP [         ] [2/5] (─────) nextest-tests::basic test_execute_bin
+        SKIP [         ] [2/5] (─────) nextest-tests::basic test_failure_assert
+        SKIP [         ] [2/5] (─────) nextest-tests::basic test_failure_error
+        SKIP [         ] [2/5] (─────) nextest-tests::basic test_failure_should_panic
+        SKIP [         ] [2/5] (─────) nextest-tests::basic test_flaky_mod_4
+        SKIP [         ] [2/5] (─────) nextest-tests::basic test_flaky_mod_6
+        SKIP [         ] [2/5] (─────) nextest-tests::basic test_flaky_slow_timeout_mod_3
+        SKIP [         ] [2/5] (─────) nextest-tests::basic test_ignored
+        SKIP [         ] [2/5] (─────) nextest-tests::basic test_ignored_fail
+        SKIP [         ] [2/5] (─────) nextest-tests::basic test_result_failure
+        SKIP [         ] [2/5] (─────) nextest-tests::basic test_slow_timeout
+        SKIP [         ] [2/5] (─────) nextest-tests::basic test_slow_timeout_2
+        SKIP [         ] [2/5] (─────) nextest-tests::basic test_slow_timeout_subprocess
+        SKIP [         ] [2/5] (─────) nextest-tests::basic test_stdin_closed
+        SKIP [         ] [2/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit
+        SKIP [         ] [2/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit_fail
+        SKIP [         ] [2/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit_leak_fail
+        SKIP [         ] [2/5] (─────) nextest-tests::basic test_success_should_panic
+        SKIP [         ] [2/5] (─────) nextest-tests::other other_test_success
+        SKIP [         ] [2/5] (─────) nextest-tests::segfault test_segfault
+        SKIP [         ] [2/5] (─────) nextest-tests::bin/nextest-tests fake_test_name
+        SKIP [         ] [2/5] (─────) nextest-tests::bin/nextest-tests tests::bin_success
+        SKIP [         ] [2/5] (─────) nextest-tests::bin/other tests::other_bin_success
+        SKIP [         ] [2/5] (─────) nextest-tests::example/nextest-tests fake_test_name
+        SKIP [         ] [2/5] (─────) nextest-tests::example/nextest-tests tests::example_success
+        PASS [ duration] [2/5] (1/1) nextest-tests::basic test_success
+ Stress test [ duration] iteration 2/5: 1 test run: 1 passed, 29 skipped
 ────────────
  Stress test iteration 3/5 (00:00:00 elapsed so far, 3 iterations remaining)
-  SKIP [  ] [3/5] (─────) nextest-tests tests::call_dylib_add_two
-  SKIP [  ] [3/5] (─────) nextest-tests tests::unit_test_success
-  SKIP [  ] [3/5] (─────) nextest-tests::basic test_cargo_env_vars
-  SKIP [  ] [3/5] (─────) nextest-tests::basic test_cwd
-  SKIP [  ] [3/5] (─────) nextest-tests::basic test_execute_bin
-  SKIP [  ] [3/5] (─────) nextest-tests::basic test_failure_assert
-  SKIP [  ] [3/5] (─────) nextest-tests::basic test_failure_error
-  SKIP [  ] [3/5] (─────) nextest-tests::basic test_failure_should_panic
-  SKIP [  ] [3/5] (─────) nextest-tests::basic test_flaky_mod_4
-  SKIP [  ] [3/5] (─────) nextest-tests::basic test_flaky_mod_6
-  SKIP [  ] [3/5] (─────) nextest-tests::basic test_flaky_slow_timeout_mod_3
-  SKIP [  ] [3/5] (─────) nextest-tests::basic test_ignored
-  SKIP [  ] [3/5] (─────) nextest-tests::basic test_ignored_fail
-  SKIP [  ] [3/5] (─────) nextest-tests::basic test_result_failure
-  SKIP [  ] [3/5] (─────) nextest-tests::basic test_slow_timeout
-  SKIP [  ] [3/5] (─────) nextest-tests::basic test_slow_timeout_2
-  SKIP [  ] [3/5] (─────) nextest-tests::basic test_slow_timeout_subprocess
-  SKIP [  ] [3/5] (─────) nextest-tests::basic test_stdin_closed
-  SKIP [  ] [3/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit
-  SKIP [  ] [3/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit_fail
-  SKIP [  ] [3/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit_leak_fail
-  SKIP [  ] [3/5] (─────) nextest-tests::basic test_success_should_panic
-  SKIP [  ] [3/5] (─────) nextest-tests::other other_test_success
-  SKIP [  ] [3/5] (─────) nextest-tests::segfault test_segfault
-  SKIP [  ] [3/5] (─────) nextest-tests::bin/nextest-tests fake_test_name
-  SKIP [  ] [3/5] (─────) nextest-tests::bin/nextest-tests tests::bin_success
-  SKIP [  ] [3/5] (─────) nextest-tests::bin/other tests::other_bin_success
-  SKIP [  ] [3/5] (─────) nextest-tests::example/nextest-tests fake_test_name
-  SKIP [  ] [3/5] (─────) nextest-tests::example/nextest-tests tests::example_success
-  PASS [  [DURATION]] [3/5] (1/1) nextest-tests::basic test_success
- Stress test [  [DURATION]] iteration 3/5: 1 test run: 1 passed, 29 skipped
+        SKIP [         ] [3/5] (─────) nextest-tests tests::call_dylib_add_two
+        SKIP [         ] [3/5] (─────) nextest-tests tests::unit_test_success
+        SKIP [         ] [3/5] (─────) nextest-tests::basic test_cargo_env_vars
+        SKIP [         ] [3/5] (─────) nextest-tests::basic test_cwd
+        SKIP [         ] [3/5] (─────) nextest-tests::basic test_execute_bin
+        SKIP [         ] [3/5] (─────) nextest-tests::basic test_failure_assert
+        SKIP [         ] [3/5] (─────) nextest-tests::basic test_failure_error
+        SKIP [         ] [3/5] (─────) nextest-tests::basic test_failure_should_panic
+        SKIP [         ] [3/5] (─────) nextest-tests::basic test_flaky_mod_4
+        SKIP [         ] [3/5] (─────) nextest-tests::basic test_flaky_mod_6
+        SKIP [         ] [3/5] (─────) nextest-tests::basic test_flaky_slow_timeout_mod_3
+        SKIP [         ] [3/5] (─────) nextest-tests::basic test_ignored
+        SKIP [         ] [3/5] (─────) nextest-tests::basic test_ignored_fail
+        SKIP [         ] [3/5] (─────) nextest-tests::basic test_result_failure
+        SKIP [         ] [3/5] (─────) nextest-tests::basic test_slow_timeout
+        SKIP [         ] [3/5] (─────) nextest-tests::basic test_slow_timeout_2
+        SKIP [         ] [3/5] (─────) nextest-tests::basic test_slow_timeout_subprocess
+        SKIP [         ] [3/5] (─────) nextest-tests::basic test_stdin_closed
+        SKIP [         ] [3/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit
+        SKIP [         ] [3/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit_fail
+        SKIP [         ] [3/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit_leak_fail
+        SKIP [         ] [3/5] (─────) nextest-tests::basic test_success_should_panic
+        SKIP [         ] [3/5] (─────) nextest-tests::other other_test_success
+        SKIP [         ] [3/5] (─────) nextest-tests::segfault test_segfault
+        SKIP [         ] [3/5] (─────) nextest-tests::bin/nextest-tests fake_test_name
+        SKIP [         ] [3/5] (─────) nextest-tests::bin/nextest-tests tests::bin_success
+        SKIP [         ] [3/5] (─────) nextest-tests::bin/other tests::other_bin_success
+        SKIP [         ] [3/5] (─────) nextest-tests::example/nextest-tests fake_test_name
+        SKIP [         ] [3/5] (─────) nextest-tests::example/nextest-tests tests::example_success
+        PASS [ duration] [3/5] (1/1) nextest-tests::basic test_success
+ Stress test [ duration] iteration 3/5: 1 test run: 1 passed, 29 skipped
 ────────────
  Stress test iteration 4/5 (00:00:00 elapsed so far, 2 iterations remaining)
-  SKIP [  ] [4/5] (─────) nextest-tests tests::call_dylib_add_two
-  SKIP [  ] [4/5] (─────) nextest-tests tests::unit_test_success
-  SKIP [  ] [4/5] (─────) nextest-tests::basic test_cargo_env_vars
-  SKIP [  ] [4/5] (─────) nextest-tests::basic test_cwd
-  SKIP [  ] [4/5] (─────) nextest-tests::basic test_execute_bin
-  SKIP [  ] [4/5] (─────) nextest-tests::basic test_failure_assert
-  SKIP [  ] [4/5] (─────) nextest-tests::basic test_failure_error
-  SKIP [  ] [4/5] (─────) nextest-tests::basic test_failure_should_panic
-  SKIP [  ] [4/5] (─────) nextest-tests::basic test_flaky_mod_4
-  SKIP [  ] [4/5] (─────) nextest-tests::basic test_flaky_mod_6
-  SKIP [  ] [4/5] (─────) nextest-tests::basic test_flaky_slow_timeout_mod_3
-  SKIP [  ] [4/5] (─────) nextest-tests::basic test_ignored
-  SKIP [  ] [4/5] (─────) nextest-tests::basic test_ignored_fail
-  SKIP [  ] [4/5] (─────) nextest-tests::basic test_result_failure
-  SKIP [  ] [4/5] (─────) nextest-tests::basic test_slow_timeout
-  SKIP [  ] [4/5] (─────) nextest-tests::basic test_slow_timeout_2
-  SKIP [  ] [4/5] (─────) nextest-tests::basic test_slow_timeout_subprocess
-  SKIP [  ] [4/5] (─────) nextest-tests::basic test_stdin_closed
-  SKIP [  ] [4/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit
-  SKIP [  ] [4/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit_fail
-  SKIP [  ] [4/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit_leak_fail
-  SKIP [  ] [4/5] (─────) nextest-tests::basic test_success_should_panic
-  SKIP [  ] [4/5] (─────) nextest-tests::other other_test_success
-  SKIP [  ] [4/5] (─────) nextest-tests::segfault test_segfault
-  SKIP [  ] [4/5] (─────) nextest-tests::bin/nextest-tests fake_test_name
-  SKIP [  ] [4/5] (─────) nextest-tests::bin/nextest-tests tests::bin_success
-  SKIP [  ] [4/5] (─────) nextest-tests::bin/other tests::other_bin_success
-  SKIP [  ] [4/5] (─────) nextest-tests::example/nextest-tests fake_test_name
-  SKIP [  ] [4/5] (─────) nextest-tests::example/nextest-tests tests::example_success
-  PASS [  [DURATION]] [4/5] (1/1) nextest-tests::basic test_success
- Stress test [  [DURATION]] iteration 4/5: 1 test run: 1 passed, 29 skipped
+        SKIP [         ] [4/5] (─────) nextest-tests tests::call_dylib_add_two
+        SKIP [         ] [4/5] (─────) nextest-tests tests::unit_test_success
+        SKIP [         ] [4/5] (─────) nextest-tests::basic test_cargo_env_vars
+        SKIP [         ] [4/5] (─────) nextest-tests::basic test_cwd
+        SKIP [         ] [4/5] (─────) nextest-tests::basic test_execute_bin
+        SKIP [         ] [4/5] (─────) nextest-tests::basic test_failure_assert
+        SKIP [         ] [4/5] (─────) nextest-tests::basic test_failure_error
+        SKIP [         ] [4/5] (─────) nextest-tests::basic test_failure_should_panic
+        SKIP [         ] [4/5] (─────) nextest-tests::basic test_flaky_mod_4
+        SKIP [         ] [4/5] (─────) nextest-tests::basic test_flaky_mod_6
+        SKIP [         ] [4/5] (─────) nextest-tests::basic test_flaky_slow_timeout_mod_3
+        SKIP [         ] [4/5] (─────) nextest-tests::basic test_ignored
+        SKIP [         ] [4/5] (─────) nextest-tests::basic test_ignored_fail
+        SKIP [         ] [4/5] (─────) nextest-tests::basic test_result_failure
+        SKIP [         ] [4/5] (─────) nextest-tests::basic test_slow_timeout
+        SKIP [         ] [4/5] (─────) nextest-tests::basic test_slow_timeout_2
+        SKIP [         ] [4/5] (─────) nextest-tests::basic test_slow_timeout_subprocess
+        SKIP [         ] [4/5] (─────) nextest-tests::basic test_stdin_closed
+        SKIP [         ] [4/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit
+        SKIP [         ] [4/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit_fail
+        SKIP [         ] [4/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit_leak_fail
+        SKIP [         ] [4/5] (─────) nextest-tests::basic test_success_should_panic
+        SKIP [         ] [4/5] (─────) nextest-tests::other other_test_success
+        SKIP [         ] [4/5] (─────) nextest-tests::segfault test_segfault
+        SKIP [         ] [4/5] (─────) nextest-tests::bin/nextest-tests fake_test_name
+        SKIP [         ] [4/5] (─────) nextest-tests::bin/nextest-tests tests::bin_success
+        SKIP [         ] [4/5] (─────) nextest-tests::bin/other tests::other_bin_success
+        SKIP [         ] [4/5] (─────) nextest-tests::example/nextest-tests fake_test_name
+        SKIP [         ] [4/5] (─────) nextest-tests::example/nextest-tests tests::example_success
+        PASS [ duration] [4/5] (1/1) nextest-tests::basic test_success
+ Stress test [ duration] iteration 4/5: 1 test run: 1 passed, 29 skipped
 ────────────
  Stress test iteration 5/5 (00:00:00 elapsed so far, 1 iteration remaining)
-  SKIP [  ] [5/5] (─────) nextest-tests tests::call_dylib_add_two
-  SKIP [  ] [5/5] (─────) nextest-tests tests::unit_test_success
-  SKIP [  ] [5/5] (─────) nextest-tests::basic test_cargo_env_vars
-  SKIP [  ] [5/5] (─────) nextest-tests::basic test_cwd
-  SKIP [  ] [5/5] (─────) nextest-tests::basic test_execute_bin
-  SKIP [  ] [5/5] (─────) nextest-tests::basic test_failure_assert
-  SKIP [  ] [5/5] (─────) nextest-tests::basic test_failure_error
-  SKIP [  ] [5/5] (─────) nextest-tests::basic test_failure_should_panic
-  SKIP [  ] [5/5] (─────) nextest-tests::basic test_flaky_mod_4
-  SKIP [  ] [5/5] (─────) nextest-tests::basic test_flaky_mod_6
-  SKIP [  ] [5/5] (─────) nextest-tests::basic test_flaky_slow_timeout_mod_3
-  SKIP [  ] [5/5] (─────) nextest-tests::basic test_ignored
-  SKIP [  ] [5/5] (─────) nextest-tests::basic test_ignored_fail
-  SKIP [  ] [5/5] (─────) nextest-tests::basic test_result_failure
-  SKIP [  ] [5/5] (─────) nextest-tests::basic test_slow_timeout
-  SKIP [  ] [5/5] (─────) nextest-tests::basic test_slow_timeout_2
-  SKIP [  ] [5/5] (─────) nextest-tests::basic test_slow_timeout_subprocess
-  SKIP [  ] [5/5] (─────) nextest-tests::basic test_stdin_closed
-  SKIP [  ] [5/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit
-  SKIP [  ] [5/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit_fail
-  SKIP [  ] [5/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit_leak_fail
-  SKIP [  ] [5/5] (─────) nextest-tests::basic test_success_should_panic
-  SKIP [  ] [5/5] (─────) nextest-tests::other other_test_success
-  SKIP [  ] [5/5] (─────) nextest-tests::segfault test_segfault
-  SKIP [  ] [5/5] (─────) nextest-tests::bin/nextest-tests fake_test_name
-  SKIP [  ] [5/5] (─────) nextest-tests::bin/nextest-tests tests::bin_success
-  SKIP [  ] [5/5] (─────) nextest-tests::bin/other tests::other_bin_success
-  SKIP [  ] [5/5] (─────) nextest-tests::example/nextest-tests fake_test_name
-  SKIP [  ] [5/5] (─────) nextest-tests::example/nextest-tests tests::example_success
-  PASS [  [DURATION]] [5/5] (1/1) nextest-tests::basic test_success
- Stress test [  [DURATION]] iteration 5/5: 1 test run: 1 passed, 29 skipped
+        SKIP [         ] [5/5] (─────) nextest-tests tests::call_dylib_add_two
+        SKIP [         ] [5/5] (─────) nextest-tests tests::unit_test_success
+        SKIP [         ] [5/5] (─────) nextest-tests::basic test_cargo_env_vars
+        SKIP [         ] [5/5] (─────) nextest-tests::basic test_cwd
+        SKIP [         ] [5/5] (─────) nextest-tests::basic test_execute_bin
+        SKIP [         ] [5/5] (─────) nextest-tests::basic test_failure_assert
+        SKIP [         ] [5/5] (─────) nextest-tests::basic test_failure_error
+        SKIP [         ] [5/5] (─────) nextest-tests::basic test_failure_should_panic
+        SKIP [         ] [5/5] (─────) nextest-tests::basic test_flaky_mod_4
+        SKIP [         ] [5/5] (─────) nextest-tests::basic test_flaky_mod_6
+        SKIP [         ] [5/5] (─────) nextest-tests::basic test_flaky_slow_timeout_mod_3
+        SKIP [         ] [5/5] (─────) nextest-tests::basic test_ignored
+        SKIP [         ] [5/5] (─────) nextest-tests::basic test_ignored_fail
+        SKIP [         ] [5/5] (─────) nextest-tests::basic test_result_failure
+        SKIP [         ] [5/5] (─────) nextest-tests::basic test_slow_timeout
+        SKIP [         ] [5/5] (─────) nextest-tests::basic test_slow_timeout_2
+        SKIP [         ] [5/5] (─────) nextest-tests::basic test_slow_timeout_subprocess
+        SKIP [         ] [5/5] (─────) nextest-tests::basic test_stdin_closed
+        SKIP [         ] [5/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit
+        SKIP [         ] [5/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit_fail
+        SKIP [         ] [5/5] (─────) nextest-tests::basic test_subprocess_doesnt_exit_leak_fail
+        SKIP [         ] [5/5] (─────) nextest-tests::basic test_success_should_panic
+        SKIP [         ] [5/5] (─────) nextest-tests::other other_test_success
+        SKIP [         ] [5/5] (─────) nextest-tests::segfault test_segfault
+        SKIP [         ] [5/5] (─────) nextest-tests::bin/nextest-tests fake_test_name
+        SKIP [         ] [5/5] (─────) nextest-tests::bin/nextest-tests tests::bin_success
+        SKIP [         ] [5/5] (─────) nextest-tests::bin/other tests::other_bin_success
+        SKIP [         ] [5/5] (─────) nextest-tests::example/nextest-tests fake_test_name
+        SKIP [         ] [5/5] (─────) nextest-tests::example/nextest-tests tests::example_success
+        PASS [ duration] [5/5] (1/1) nextest-tests::basic test_success
+ Stress test [ duration] iteration 5/5: 1 test run: 1 passed, 29 skipped
 ────────────
-  Summary [  [DURATION]] 5/5 stress run iterations: 5 passed
+     Summary [ duration] 5/5 stress run iterations: 5 passed

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_multiple_runs.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_multiple_runs.snap
@@ -5,8 +5,8 @@ snapshot_kind: text
 ---
 3 recorded runs:
 
-  50000003  [TIMESTAMP]  [DURATION]  [SIZE]  2 passed  *latest
-  50000002  [TIMESTAMP]  [DURATION]  [SIZE]  1 passed
-  50000001  [TIMESTAMP]  [DURATION]  [SIZE]  1 passed
-  ──────
-  [SIZE]
+  50000003  XXXX-XX-XX XX:XX:XX  <duration>  <size> KB  2 passed  *latest
+  50000002  XXXX-XX-XX XX:XX:XX  <duration>  <size> KB  1 passed
+  50000001  XXXX-XX-XX XX:XX:XX  <duration>  <size> KB  1 passed
+                                             ──────
+                                             <size> KB

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_single_run.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_single_run.snap
@@ -5,6 +5,6 @@ snapshot_kind: text
 ---
 1 recorded run:
 
-  10000001  [TIMESTAMP]  [DURATION]  [SIZE]  21 passed / 9 failed  *latest
-  ──────
-  [SIZE]
+  10000001  XXXX-XX-XX XX:XX:XX  <duration>  <size> KB  21 passed / 9 failed  *latest
+                                             ──────
+                                             <size> KB

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_stress_run.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_stress_run.snap
@@ -5,6 +5,6 @@ snapshot_kind: text
 ---
 1 recorded run:
 
-  60000001  [TIMESTAMP]  [DURATION]  [SIZE]  5 passed iterations  *latest
-  ──────
-  [SIZE]
+  60000001  XXXX-XX-XX XX:XX:XX  <duration>  <size> KB  5 passed iterations  *latest
+                                             ──────
+                                             <size> KB

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_verbose_multiple_runs.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_verbose_multiple_runs.snap
@@ -7,8 +7,8 @@ store: [TEMP_DIR]
 
 3 recorded runs:
 
-  50000003  [TIMESTAMP]  [DURATION]  [SIZE]  2 passed  *latest
-  50000002  [TIMESTAMP]  [DURATION]  [SIZE]  1 passed
-  50000001  [TIMESTAMP]  [DURATION]  [SIZE]  1 passed
-  ──────
-  [SIZE]
+  50000003  XXXX-XX-XX XX:XX:XX  <duration>  <size> KB  2 passed  *latest
+  50000002  XXXX-XX-XX XX:XX:XX  <duration>  <size> KB  1 passed
+  50000001  XXXX-XX-XX XX:XX:XX  <duration>  <size> KB  1 passed
+                                             ──────
+                                             <size> KB

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_verbose_single_run.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_verbose_single_run.snap
@@ -7,6 +7,6 @@ store: [TEMP_DIR]
 
 1 recorded run:
 
-  10000001  [TIMESTAMP]  [DURATION]  [SIZE]  21 passed / 9 failed  *latest
-  ──────
-  [SIZE]
+  10000001  XXXX-XX-XX XX:XX:XX  <duration>  <size> KB  21 passed / 9 failed  *latest
+                                             ──────
+                                             <size> KB


### PR DESCRIPTION
Do most redaction via __NEXTEST_REDACT=1 so that we don't have to collapse 2+ spaces down to 1, and we can therefore test alignment properly.