### PR TITLE
[nextest-runner] capture cli args and env vars in recorded runs

### DIFF
--- a/integration-tests/src/env.rs
+++ b/integration-tests/src/env.rs
@@ -1,57 +1,132 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-#[track_caller]
-pub fn set_env_vars() {
+use camino::Utf8PathBuf;
+
+/// Environment info captured before sanitization.
+#[derive(Debug)]
+pub struct TestEnvInfo {
+    /// Path to the cargo-nextest-dup binary.
+    pub cargo_nextest_dup_bin: Utf8PathBuf,
+    /// Path to the fake_interceptor binary.
+    pub fake_interceptor_bin: Utf8PathBuf,
+    /// Path to the rustc_shim binary.
+    pub rustc_shim_bin: Utf8PathBuf,
+    /// Path to the passthrough binary.
+    pub passthrough_bin: Utf8PathBuf,
+    /// Path to the grab_foreground binary (Unix only).
+    #[cfg(unix)]
+    pub grab_foreground_bin: Utf8PathBuf,
+}
+
+/// Sets up environment variables for a setup script.
+///
+/// Setup scripts don't have access to `NEXTEST_BIN_EXE_*` variables, so this
+/// only performs sanitization without capturing binary paths.
+pub fn set_env_vars_for_script() {
     // SAFETY:
     // https://nexte.st/docs/configuration/env-vars/#altering-the-environment-within-tests
     unsafe {
-        // The dynamic library tests require this flag.
-        std::env::set_var("RUSTFLAGS", "-C prefer-dynamic");
-
-        // Set CARGO_TERM_COLOR to never to ensure that ANSI color codes don't
-        // interfere with the output.
-        std::env::set_var("CARGO_TERM_COLOR", "never");
-
-        // This environment variable is required to test the #[bench] fixture.
-        // Note that THIS IS FOR TEST CODE ONLY. NEVER USE THIS IN PRODUCTION.
-        std::env::set_var("RUSTC_BOOTSTRAP", "1");
-
-        // Disable the tests which check for environment variables being set in
-        // `config.toml`, as they won't be in the search path when running
-        // integration tests.
-        std::env::set_var("__NEXTEST_NO_CHECK_CARGO_ENV_VARS", "1");
-
-        // Disable the tests which check for environment variables being set in
-        // `config.toml`, as they won't be in the search path when running
-        // integration tests.
-        std::env::set_var("__NEXTEST_NO_CHECK_CARGO_ENV_VARS", "1");
-
-        // Display empty STDOUT and STDERR lines in the output of failed tests.
-        // This allows tests which make sure outputs are being displayed to
-        // work.
-        std::env::set_var("__NEXTEST_DISPLAY_EMPTY_OUTPUTS", "1");
-
-        // Unset NEXTEST_PROFILE because we don't want to let it interfere with
-        // the tests. But ensure that it's set first.
-        std::env::var("NEXTEST_PROFILE").expect("NEXTEST_PROFILE should be set");
-        std::env::remove_var("NEXTEST_PROFILE");
-
-        // Remove OUT_DIR from the environment, as it interferes with tests
-        // (some of them expect that OUT_DIR isn't set.)
-        std::env::remove_var("OUT_DIR");
-
-        // Set NEXTEST_SHOW_PROGRESS to counter to ensure user config doesn't
-        // affect test output.
-        std::env::set_var("NEXTEST_SHOW_PROGRESS", "counter");
-
-        // Skip user config loading entirely for test isolation. This prevents
-        // the user's personal config from affecting test results. (Note that
-        // some config tests pass in --user-config-file, which overrides this
-        // environment variable.)
-        std::env::set_var("NEXTEST_USER_CONFIG_FILE", "none");
-
-        // Disable recording runs so tests don't accidentally record runs.
-        std::env::remove_var("NEXTEST_EXPERIMENTAL_RECORD");
+        sanitize_env();
     }
+}
+
+/// Sets up environment variables for a test.
+///
+/// This captures binary paths from `NEXTEST_BIN_EXE_*` variables before
+/// sanitizing the environment.
+#[track_caller]
+pub fn set_env_vars_for_test() -> TestEnvInfo {
+    // Capture required binary paths before sanitization.
+    let cargo_nextest_dup_bin: Utf8PathBuf = std::env::var("NEXTEST_BIN_EXE_cargo_nextest_dup")
+        .expect("NEXTEST_BIN_EXE_cargo_nextest_dup should be set")
+        .into();
+    let fake_interceptor_bin: Utf8PathBuf = std::env::var("NEXTEST_BIN_EXE_fake_interceptor")
+        .expect("NEXTEST_BIN_EXE_fake_interceptor should be set")
+        .into();
+    let rustc_shim_bin: Utf8PathBuf = std::env::var("NEXTEST_BIN_EXE_rustc_shim")
+        .expect("NEXTEST_BIN_EXE_rustc_shim should be set")
+        .into();
+    let passthrough_bin: Utf8PathBuf = std::env::var("NEXTEST_BIN_EXE_passthrough")
+        .expect("NEXTEST_BIN_EXE_passthrough should be set")
+        .into();
+    #[cfg(unix)]
+    let grab_foreground_bin: Utf8PathBuf = std::env::var("NEXTEST_BIN_EXE_grab_foreground")
+        .expect("NEXTEST_BIN_EXE_grab_foreground should be set")
+        .into();
+
+    // Ensure NEXTEST_PROFILE is set (we're running under nextest).
+    std::env::var("NEXTEST_PROFILE").expect("NEXTEST_PROFILE should be set");
+
+    // SAFETY:
+    // https://nexte.st/docs/configuration/env-vars/#altering-the-environment-within-tests
+    unsafe {
+        sanitize_env();
+    }
+
+    TestEnvInfo {
+        cargo_nextest_dup_bin,
+        fake_interceptor_bin,
+        rustc_shim_bin,
+        passthrough_bin,
+        #[cfg(unix)]
+        grab_foreground_bin,
+    }
+}
+
+/// Sanitizes the environment by removing `NEXTEST_*` and `CARGO_*` variables
+/// and setting up variables needed for integration tests.
+///
+/// # Safety
+///
+/// This function modifies the process environment, which is not thread-safe.
+/// See <https://nexte.st/docs/configuration/env-vars/#altering-the-environment-within-tests>.
+unsafe fn sanitize_env() {
+    // Sanitize the environment by removing all NEXTEST_* and CARGO_* variables
+    // from the parent environment. This ensures deterministic behavior regardless
+    // of what the parent process has set. We'll then set specific variables below.
+
+    // Collect keys first to avoid mutating while iterating.
+    let keys_to_remove: Vec<_> = std::env::vars()
+        .filter(|(key, _)| key.starts_with("NEXTEST_") || key.starts_with("CARGO_"))
+        .map(|(key, _)| key)
+        .collect();
+    for key in keys_to_remove {
+        std::env::remove_var(&key);
+    }
+
+    // The dynamic library tests require this flag.
+    std::env::set_var("RUSTFLAGS", "-C prefer-dynamic");
+
+    // Set CARGO_TERM_COLOR to never to ensure that ANSI color codes don't
+    // interfere with the output.
+    std::env::set_var("CARGO_TERM_COLOR", "never");
+
+    // This environment variable is required to test the #[bench] fixture.
+    // Note that THIS IS FOR TEST CODE ONLY. NEVER USE THIS IN PRODUCTION.
+    std::env::set_var("RUSTC_BOOTSTRAP", "1");
+
+    // Disable the tests which check for environment variables being set in
+    // `config.toml`, as they won't be in the search path when running
+    // integration tests.
+    std::env::set_var("__NEXTEST_NO_CHECK_CARGO_ENV_VARS", "1");
+
+    // Display empty STDOUT and STDERR lines in the output of failed tests.
+    // This allows tests which make sure outputs are being displayed to
+    // work.
+    std::env::set_var("__NEXTEST_DISPLAY_EMPTY_OUTPUTS", "1");
+
+    // Remove OUT_DIR from the environment, as it interferes with tests
+    // (some of them expect that OUT_DIR isn't set.)
+    std::env::remove_var("OUT_DIR");
+
+    // Set NEXTEST_SHOW_PROGRESS to counter to ensure user config doesn't
+    // affect test output.
+    std::env::set_var("NEXTEST_SHOW_PROGRESS", "counter");
+
+    // Skip user config loading entirely for test isolation. This prevents
+    // the user's personal config from affecting test results. (Note that
+    // some config tests pass in --user-config-file, which overrides this
+    // environment variable.)
+    std::env::set_var("NEXTEST_USER_CONFIG_FILE", "none");
 }

--- a/integration-tests/src/nextest_cli.rs
+++ b/integration-tests/src/nextest_cli.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
+use crate::env::TestEnvInfo;
 use camino::Utf8PathBuf;
 use color_eyre::{
     Result,
@@ -35,11 +36,9 @@ pub struct CargoNextestCli {
 }
 
 impl CargoNextestCli {
-    pub fn for_test() -> Self {
-        let bin = std::env::var("NEXTEST_BIN_EXE_cargo_nextest_dup")
-            .expect("unable to find cargo-nextest-dup");
+    pub fn for_test(env_info: &TestEnvInfo) -> Self {
         Self {
-            bin: bin.into(),
+            bin: env_info.cargo_nextest_dup_bin.clone(),
             args: vec!["nextest".to_owned(), "--no-pager".to_owned()],
             envs: HashMap::new(),
             envs_remove: Vec::new(),

--- a/integration-tests/src/seed.rs
+++ b/integration-tests/src/seed.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use crate::{env::set_env_vars, nextest_cli::CargoNextestCli};
+use crate::{env::set_env_vars_for_script, nextest_cli::CargoNextestCli};
 use camino::{Utf8Path, Utf8PathBuf};
 use color_eyre::eyre::Context;
 use fs_err as fs;
@@ -178,8 +178,8 @@ pub fn make_seed_archive(workspace_dir: &Utf8Path, file_name: &Utf8Path) -> colo
     // rebuilds due to the variables changing.
     //
     // TODO: We shouldn't alter the global state of this process -- instead,
-    // set_env_vars should be part of nextest_cli.rs.
-    set_env_vars();
+    // set_env_vars_for_script should be part of nextest_cli.rs.
+    set_env_vars_for_script();
 
     let output = cli
         .args([

--- a/integration-tests/tests/datatest/custom_target.rs
+++ b/integration-tests/tests/datatest/custom_target.rs
@@ -4,17 +4,18 @@
 use crate::helpers::bind_insta_settings;
 use camino::Utf8Path;
 use camino_tempfile_ext::prelude::*;
-use integration_tests::nextest_cli::CargoNextestCli;
+use integration_tests::{env::set_env_vars_for_test, nextest_cli::CargoNextestCli};
 use nextest_metadata::NextestExitCode;
 
 pub(crate) fn custom_invalid(path: &Utf8Path, contents: String) -> datatest_stable::Result<()> {
+    let env_info = set_env_vars_for_test();
     let (_guard, insta_prefix) = bind_insta_settings(path, "snapshots/custom-invalid");
 
     let dir = Utf8TempDir::with_prefix("nextest-custom-target-")?;
     let json_path = dir.child(path.file_name().unwrap());
     json_path.write_str(&contents)?;
 
-    let output = CargoNextestCli::for_test()
+    let output = CargoNextestCli::for_test(&env_info)
         .args([
             // Use color in snapshots to ensure that it is correctly passed
             // through.

--- a/integration-tests/tests/integration/fixtures.rs
+++ b/integration-tests/tests/integration/fixtures.rs
@@ -8,7 +8,10 @@ use fixture_data::{
     nextest_tests::EXPECTED_TEST_SUITES,
 };
 use iddqd::{IdOrdItem, IdOrdMap, id_upcast};
-use integration_tests::nextest_cli::{CargoNextestCli, cargo_bin};
+use integration_tests::{
+    env::TestEnvInfo,
+    nextest_cli::{CargoNextestCli, cargo_bin},
+};
 use nextest_metadata::{
     BinaryListSummary, BuildPlatform, RustBinaryId, RustTestSuiteStatusSummary, TestCaseName,
     TestListSummary,
@@ -35,8 +38,8 @@ pub fn save_cargo_metadata(p: &TempProject) {
 }
 
 #[track_caller]
-pub fn save_binaries_metadata(p: &TempProject) {
-    let output = CargoNextestCli::for_test()
+pub fn save_binaries_metadata(env_info: &TestEnvInfo, p: &TempProject) {
+    let output = CargoNextestCli::for_test(env_info)
         .args([
             "--manifest-path",
             p.manifest_path().as_str(),

--- a/integration-tests/tests/integration/interceptor.rs
+++ b/integration-tests/tests/integration/interceptor.rs
@@ -4,25 +4,27 @@
 //! Integration tests for debugger and tracer modes.
 
 use super::{fixtures::*, temp_project::TempProject};
-use integration_tests::{env::set_env_vars, nextest_cli::CargoNextestCli};
+use integration_tests::{
+    env::{TestEnvInfo, set_env_vars_for_test},
+    nextest_cli::CargoNextestCli,
+};
 use nextest_metadata::NextestExitCode;
 
-fn fake_interceptor_path() -> String {
-    std::env::var("NEXTEST_BIN_EXE_fake_interceptor")
-        .expect("NEXTEST_BIN_EXE_fake_interceptor should be set by nextest")
+fn fake_interceptor_path(env_info: &TestEnvInfo) -> &str {
+    env_info.fake_interceptor_bin.as_str()
 }
 
 #[test]
 fn test_debugger_integration() {
-    set_env_vars();
+    let env_info = set_env_vars_for_test();
 
-    let p = TempProject::new().unwrap();
-    save_binaries_metadata(&p);
-    let fake_interceptor = fake_interceptor_path();
-    let fake_debugger = shell_words::join([fake_interceptor.as_str(), "--mode=debugger"]);
+    let p = TempProject::new(&env_info).unwrap();
+    save_binaries_metadata(&env_info, &p);
+    let fake_interceptor = fake_interceptor_path(&env_info);
+    let fake_debugger = shell_words::join([fake_interceptor, "--mode=debugger"]);
 
     // Test: Too many tests selected: select exactly 2 tests with "multiply" filter.
-    let output = CargoNextestCli::for_test()
+    let output = CargoNextestCli::for_test(&env_info)
         .args([
             "--manifest-path",
             p.manifest_path().as_str(),
@@ -65,7 +67,7 @@ fn test_debugger_integration() {
     );
 
     // Test: No tests selected.
-    let output = CargoNextestCli::for_test()
+    let output = CargoNextestCli::for_test(&env_info)
         .args([
             "--manifest-path",
             p.manifest_path().as_str(),
@@ -92,7 +94,7 @@ fn test_debugger_integration() {
     );
 
     // Test: Debugger runs successfully with exactly one test.
-    let output = CargoNextestCli::for_test()
+    let output = CargoNextestCli::for_test(&env_info)
         .args([
             "--manifest-path",
             p.manifest_path().as_str(),
@@ -134,8 +136,8 @@ fn test_debugger_integration() {
     }
 
     // Test: --debugger conflicts with --no-run.
-    let fake_debugger = shell_words::join([fake_interceptor.as_str(), "--mode=debugger"]);
-    let output = CargoNextestCli::for_test()
+    let fake_debugger = shell_words::join([fake_interceptor, "--mode=debugger"]);
+    let output = CargoNextestCli::for_test(&env_info)
         .args([
             "--manifest-path",
             p.manifest_path().as_str(),
@@ -163,15 +165,15 @@ fn test_debugger_integration() {
 
 #[test]
 fn test_tracer_integration() {
-    set_env_vars();
+    let env_info = set_env_vars_for_test();
 
-    let p = TempProject::new().unwrap();
-    save_binaries_metadata(&p);
-    let fake_interceptor = fake_interceptor_path();
-    let fake_tracer = shell_words::join([fake_interceptor.as_str(), "--mode=tracer"]);
+    let p = TempProject::new(&env_info).unwrap();
+    save_binaries_metadata(&env_info, &p);
+    let fake_interceptor = fake_interceptor_path(&env_info);
+    let fake_tracer = shell_words::join([fake_interceptor, "--mode=tracer"]);
 
     // Test: Too many tests selected: select exactly 2 tests with "multiply" filter.
-    let output = CargoNextestCli::for_test()
+    let output = CargoNextestCli::for_test(&env_info)
         .args([
             "--manifest-path",
             p.manifest_path().as_str(),
@@ -214,7 +216,7 @@ fn test_tracer_integration() {
     );
 
     // Test: No tests selected.
-    let output = CargoNextestCli::for_test()
+    let output = CargoNextestCli::for_test(&env_info)
         .args([
             "--manifest-path",
             p.manifest_path().as_str(),
@@ -241,7 +243,7 @@ fn test_tracer_integration() {
     );
 
     // Test: Tracer runs successfully with exactly one test.
-    let output = CargoNextestCli::for_test()
+    let output = CargoNextestCli::for_test(&env_info)
         .args([
             "--manifest-path",
             p.manifest_path().as_str(),
@@ -281,8 +283,8 @@ fn test_tracer_integration() {
     }
 
     // Test: --tracer conflicts with --no-run.
-    let fake_tracer = shell_words::join([fake_interceptor.as_str(), "--mode=tracer"]);
-    let output = CargoNextestCli::for_test()
+    let fake_tracer = shell_words::join([fake_interceptor, "--mode=tracer"]);
+    let output = CargoNextestCli::for_test(&env_info)
         .args([
             "--manifest-path",
             p.manifest_path().as_str(),
@@ -308,8 +310,8 @@ fn test_tracer_integration() {
     );
 
     // Test: --tracer conflicts with --debugger.
-    let fake_debugger = shell_words::join([fake_interceptor.as_str(), "--mode=debugger"]);
-    let output = CargoNextestCli::for_test()
+    let fake_debugger = shell_words::join([fake_interceptor, "--mode=debugger"]);
+    let output = CargoNextestCli::for_test(&env_info)
         .args([
             "--manifest-path",
             p.manifest_path().as_str(),
@@ -342,16 +344,16 @@ fn test_tracer_integration() {
 
 #[test]
 fn test_bench_debugger_integration() {
-    set_env_vars();
+    let env_info = set_env_vars_for_test();
 
-    let p = TempProject::new().unwrap();
-    save_binaries_metadata(&p);
-    let fake_interceptor = fake_interceptor_path();
-    let fake_debugger = shell_words::join([fake_interceptor.as_str(), "--mode=debugger"]);
+    let p = TempProject::new(&env_info).unwrap();
+    save_binaries_metadata(&env_info, &p);
+    let fake_interceptor = fake_interceptor_path(&env_info);
+    let fake_debugger = shell_words::join([fake_interceptor, "--mode=debugger"]);
 
     // Test: Too many benchmarks selected (use --run-ignored all to include the
     // ignored benchmark).
-    let output = CargoNextestCli::for_test()
+    let output = CargoNextestCli::for_test(&env_info)
         .args([
             "--manifest-path",
             p.manifest_path().as_str(),
@@ -381,7 +383,7 @@ fn test_bench_debugger_integration() {
     );
 
     // Test: No benchmarks selected.
-    let output = CargoNextestCli::for_test()
+    let output = CargoNextestCli::for_test(&env_info)
         .args([
             "--manifest-path",
             p.manifest_path().as_str(),
@@ -408,7 +410,7 @@ fn test_bench_debugger_integration() {
     );
 
     // Test: Debugger runs successfully with exactly one benchmark.
-    let output = CargoNextestCli::for_test()
+    let output = CargoNextestCli::for_test(&env_info)
         .args([
             "--manifest-path",
             p.manifest_path().as_str(),
@@ -435,7 +437,7 @@ fn test_bench_debugger_integration() {
     );
 
     // Test: --debugger conflicts with --no-run.
-    let output = CargoNextestCli::for_test()
+    let output = CargoNextestCli::for_test(&env_info)
         .args([
             "--manifest-path",
             p.manifest_path().as_str(),
@@ -463,16 +465,16 @@ fn test_bench_debugger_integration() {
 
 #[test]
 fn test_bench_tracer_integration() {
-    set_env_vars();
+    let env_info = set_env_vars_for_test();
 
-    let p = TempProject::new().unwrap();
-    save_binaries_metadata(&p);
-    let fake_interceptor = fake_interceptor_path();
-    let fake_tracer = shell_words::join([fake_interceptor.as_str(), "--mode=tracer"]);
+    let p = TempProject::new(&env_info).unwrap();
+    save_binaries_metadata(&env_info, &p);
+    let fake_interceptor = fake_interceptor_path(&env_info);
+    let fake_tracer = shell_words::join([fake_interceptor, "--mode=tracer"]);
 
     // Test: Too many benchmarks selected (use --run-ignored all to include the
     // ignored benchmark).
-    let output = CargoNextestCli::for_test()
+    let output = CargoNextestCli::for_test(&env_info)
         .args([
             "--manifest-path",
             p.manifest_path().as_str(),
@@ -501,7 +503,7 @@ fn test_bench_tracer_integration() {
     );
 
     // Test: Tracer runs successfully with exactly one benchmark.
-    let output = CargoNextestCli::for_test()
+    let output = CargoNextestCli::for_test(&env_info)
         .args([
             "--manifest-path",
             p.manifest_path().as_str(),

--- a/integration-tests/tests/integration/sigttou.rs
+++ b/integration-tests/tests/integration/sigttou.rs
@@ -12,6 +12,7 @@
 //!
 //! See <https://github.com/nextest-rs/nextest/issues/2878>.
 
+use integration_tests::env::set_env_vars_for_test;
 use std::process::Command;
 
 /// If this test is run under nextest in an interactive terminal, spawning a
@@ -19,13 +20,13 @@ use std::process::Command;
 /// the fix.
 #[test]
 fn test_foreground_grab_does_not_suspend() {
+    let env_info = set_env_vars_for_test();
+
     // This issue could be reproduced with zsh -ic, though not with bash -ic or
     // sh -ic (Ubuntu 24.04). But we don't want to introduce a dependency on zsh
     // in our test suite, so we have a small helper binary which simulates the
     // issue.
-    let bin_path = std::env::var("NEXTEST_BIN_EXE_grab_foreground")
-        .expect("NEXTEST_BIN_EXE_grab_foreground should be set by nextest");
-    let child = Command::new(bin_path)
+    let child = Command::new(&env_info.grab_foreground_bin)
         .spawn()
         .expect("spawned grab-foreground");
     let output = child

--- a/integration-tests/tests/integration/temp_project.rs
+++ b/integration-tests/tests/integration/temp_project.rs
@@ -6,7 +6,7 @@ use camino_tempfile::Utf8TempDir;
 use color_eyre::eyre::{Context, bail};
 use cp_r::CopyOptions;
 use fs_err as fs;
-use integration_tests::{nextest_cli::CargoNextestCli, seed::nextest_tests_dir};
+use integration_tests::{env::TestEnvInfo, nextest_cli::CargoNextestCli, seed::nextest_tests_dir};
 use nextest_metadata::BinaryListSummary;
 use std::path::Path;
 
@@ -47,15 +47,21 @@ pub struct TempProject {
 }
 
 impl TempProject {
-    pub fn new() -> color_eyre::Result<Self> {
-        Self::new_impl(None)
+    pub fn new(env_info: &TestEnvInfo) -> color_eyre::Result<Self> {
+        Self::new_impl(env_info, None)
     }
 
-    pub fn new_custom_target_dir(target_dir: &Utf8Path) -> color_eyre::Result<Self> {
-        Self::new_impl(Some(target_dir.to_path_buf()))
+    pub fn new_custom_target_dir(
+        env_info: &TestEnvInfo,
+        target_dir: &Utf8Path,
+    ) -> color_eyre::Result<Self> {
+        Self::new_impl(env_info, Some(target_dir.to_path_buf()))
     }
 
-    fn new_impl(custom_target_dir: Option<Utf8PathBuf>) -> color_eyre::Result<Self> {
+    fn new_impl(
+        env_info: &TestEnvInfo,
+        custom_target_dir: Option<Utf8PathBuf>,
+    ) -> color_eyre::Result<Self> {
         // Ensure that a custom target dir, if specified, ends with "target".
         if let Some(dir) = &custom_target_dir {
             if !dir.ends_with("target") {
@@ -98,7 +104,7 @@ impl TempProject {
         // dir, but we need to pass it in here. So use the new target dir
         // (knowing that the original one won't be used in this invocation,
         // because it's only used for creating new archives).
-        _ = CargoNextestCli::for_test()
+        _ = CargoNextestCli::for_test(env_info)
             .args([
                 "run",
                 "--no-run",

--- a/nextest-runner/src/record/retention.rs
+++ b/nextest-runner/src/record/retention.rs
@@ -529,7 +529,7 @@ mod tests {
     };
     use chrono::{FixedOffset, TimeZone};
     use semver::Version;
-    use std::num::NonZero;
+    use std::{collections::BTreeMap, num::NonZero};
 
     fn make_run(
         run_id: ReportUuid,
@@ -544,6 +544,8 @@ mod tests {
             started_at,
             last_written_at: started_at,
             duration_secs: Some(1.0),
+            cli_args: Vec::new(),
+            env_vars: BTreeMap::new(),
             sizes: RecordedSizes {
                 log: ComponentSizes::default(),
                 store: ComponentSizes {
@@ -1009,6 +1011,8 @@ mod tests {
             started_at,
             last_written_at: started_at,
             duration_secs: Some(1.0),
+            cli_args: Vec::new(),
+            env_vars: BTreeMap::new(),
             sizes: RecordedSizes {
                 log: ComponentSizes::default(),
                 store: ComponentSizes {

--- a/nextest-runner/src/record/run_id_index.rs
+++ b/nextest-runner/src/record/run_id_index.rs
@@ -288,6 +288,7 @@ mod tests {
     use crate::record::{RecordedRunStatus, RecordedSizes};
     use chrono::TimeZone;
     use semver::Version;
+    use std::collections::BTreeMap;
 
     /// Creates a test run with the given run ID.
     fn make_run(run_id: ReportUuid) -> RecordedRunInfo {
@@ -301,6 +302,8 @@ mod tests {
             started_at,
             last_written_at: started_at,
             duration_secs: None,
+            cli_args: Vec::new(),
+            env_vars: BTreeMap::new(),
             sizes: RecordedSizes::default(),
             status: RecordedRunStatus::Incomplete,
         }

--- a/nextest-runner/src/record/session.rs
+++ b/nextest-runner/src/record/session.rs
@@ -26,7 +26,7 @@ use chrono::{DateTime, FixedOffset};
 use owo_colors::OwoColorize;
 use quick_junit::ReportUuid;
 use semver::Version;
-use std::fmt;
+use std::{collections::BTreeMap, fmt};
 
 /// Configuration for creating a recording session.
 #[derive(Clone, Debug)]
@@ -39,6 +39,10 @@ pub struct RecordSessionConfig<'a> {
     pub nextest_version: Version,
     /// When the run started.
     pub started_at: DateTime<FixedOffset>,
+    /// The command-line arguments used to invoke nextest.
+    pub cli_args: Vec<String>,
+    /// Environment variables that affect nextest behavior (NEXTEST_* and CARGO_*).
+    pub env_vars: BTreeMap<String, String>,
     /// Maximum size per output file before truncation.
     pub max_output_size: ByteSize,
 }
@@ -85,6 +89,8 @@ impl RecordSession {
                 config.run_id,
                 config.nextest_version,
                 config.started_at,
+                config.cli_args,
+                config.env_vars,
                 config.max_output_size,
             )
             .map_err(RecordSetupError::RecorderCreate)?;

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_cancelled.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_cancelled.snap
@@ -9,6 +9,16 @@ snapshot_kind: text
   "started-at": "2024-12-19T14:22:33-08:00",
   "last-written-at": "2024-12-19T22:22:33Z",
   "duration-secs": 12.345,
+  "cli-args": [
+    "cargo",
+    "nextest",
+    "run",
+    "--workspace"
+  ],
+  "env-vars": {
+    "CARGO_TERM_COLOR": "always",
+    "NEXTEST_PROFILE": "ci"
+  },
   "sizes": {
     "log": {
       "compressed": 2345,

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_completed.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_completed.snap
@@ -9,6 +9,16 @@ snapshot_kind: text
   "started-at": "2024-12-19T14:22:33-08:00",
   "last-written-at": "2024-12-19T22:22:33Z",
   "duration-secs": 12.345,
+  "cli-args": [
+    "cargo",
+    "nextest",
+    "run",
+    "--workspace"
+  ],
+  "env-vars": {
+    "CARGO_TERM_COLOR": "always",
+    "NEXTEST_PROFILE": "ci"
+  },
   "sizes": {
     "log": {
       "compressed": 2345,

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_incomplete.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_incomplete.snap
@@ -9,6 +9,16 @@ snapshot_kind: text
   "started-at": "2024-12-19T14:22:33-08:00",
   "last-written-at": "2024-12-19T22:22:33Z",
   "duration-secs": 12.345,
+  "cli-args": [
+    "cargo",
+    "nextest",
+    "run",
+    "--workspace"
+  ],
+  "env-vars": {
+    "CARGO_TERM_COLOR": "always",
+    "NEXTEST_PROFILE": "ci"
+  },
   "sizes": {
     "log": {
       "compressed": 2345,

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_cancelled.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_cancelled.snap
@@ -9,6 +9,16 @@ snapshot_kind: text
   "started-at": "2024-12-19T14:22:33-08:00",
   "last-written-at": "2024-12-19T22:22:33Z",
   "duration-secs": 12.345,
+  "cli-args": [
+    "cargo",
+    "nextest",
+    "run",
+    "--workspace"
+  ],
+  "env-vars": {
+    "CARGO_TERM_COLOR": "always",
+    "NEXTEST_PROFILE": "ci"
+  },
   "sizes": {
     "log": {
       "compressed": 2345,

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_completed.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_completed.snap
@@ -9,6 +9,16 @@ snapshot_kind: text
   "started-at": "2024-12-19T14:22:33-08:00",
   "last-written-at": "2024-12-19T22:22:33Z",
   "duration-secs": 12.345,
+  "cli-args": [
+    "cargo",
+    "nextest",
+    "run",
+    "--workspace"
+  ],
+  "env-vars": {
+    "CARGO_TERM_COLOR": "always",
+    "NEXTEST_PROFILE": "ci"
+  },
   "sizes": {
     "log": {
       "compressed": 2345,

--- a/nextest-runner/src/record/store.rs
+++ b/nextest-runner/src/record/store.rs
@@ -29,7 +29,7 @@ use owo_colors::{OwoColorize, Style};
 use quick_junit::ReportUuid;
 use semver::Version;
 use std::{
-    collections::HashSet,
+    collections::{BTreeMap, HashSet},
     fmt,
     fs::{File, TryLockError},
     io::{self, Write},
@@ -355,6 +355,8 @@ impl<'store> ExclusiveLockedRunStore<'store> {
         run_id: ReportUuid,
         nextest_version: Version,
         started_at: DateTime<FixedOffset>,
+        cli_args: Vec<String>,
+        env_vars: BTreeMap<String, String>,
         max_output_size: bytesize::ByteSize,
     ) -> Result<RunRecorder, RunStoreError> {
         if let RunsJsonWritePermission::Denied {
@@ -379,6 +381,8 @@ impl<'store> ExclusiveLockedRunStore<'store> {
             started_at,
             last_written_at: Local::now().fixed_offset(),
             duration_secs: None,
+            cli_args,
+            env_vars,
             sizes: RecordedSizes::default(),
             status: RecordedRunStatus::Incomplete,
         };
@@ -414,6 +418,10 @@ pub struct RecordedRunInfo {
     ///
     /// This is `None` for incomplete runs.
     pub duration_secs: Option<f64>,
+    /// The command-line arguments used to invoke nextest.
+    pub cli_args: Vec<String>,
+    /// Environment variables that affect nextest behavior (NEXTEST_* and CARGO_*).
+    pub env_vars: BTreeMap<String, String>,
     /// Sizes broken down by component (log and store).
     pub sizes: RecordedSizes,
     /// The status and statistics for this run.

--- a/nextest-runner/src/record/summary.rs
+++ b/nextest-runner/src/record/summary.rs
@@ -29,7 +29,7 @@ use chrono::{DateTime, FixedOffset};
 use nextest_metadata::{MismatchReason, RustBinaryId};
 use quick_junit::ReportUuid;
 use serde::{Deserialize, Serialize};
-use std::{fmt, num::NonZero, time::Duration};
+use std::{collections::BTreeMap, fmt, num::NonZero, time::Duration};
 
 // ---
 // Record options
@@ -39,7 +39,7 @@ use std::{fmt, num::NonZero, time::Duration};
 ///
 /// These options are captured at record time and stored in the archive,
 /// allowing replay to produce the same exit code as the original run.
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub struct RecordOpts {
@@ -50,12 +50,28 @@ pub struct RecordOpts {
     /// The behavior when no tests are run.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub no_tests: Option<NoTestsBehavior>,
+
+    /// The command-line arguments used to invoke nextest.
+    pub cli_args: Vec<String>,
+
+    /// Environment variables that affect nextest behavior (NEXTEST_* and CARGO_*).
+    pub env_vars: BTreeMap<String, String>,
 }
 
 impl RecordOpts {
     /// Creates a new `RecordOpts` with the given settings.
-    pub fn new(run_mode: NextestRunMode, no_tests: Option<NoTestsBehavior>) -> Self {
-        Self { run_mode, no_tests }
+    pub fn new(
+        run_mode: NextestRunMode,
+        no_tests: Option<NoTestsBehavior>,
+        cli_args: Vec<String>,
+        env_vars: BTreeMap<String, String>,
+    ) -> Self {
+        Self {
+            run_mode,
+            no_tests,
+            cli_args,
+            env_vars,
+        }
     }
 }
 


### PR DESCRIPTION
In recorded runs, capture:

* CLI args (the full argv)
* CARGO_ and NEXTEST_ environment variables

We'll be able to display these in the upcoming `info` command.

To allow the integration test environment to be reproducible, we have to sanitize it in set_env_vars. This resulted in a somewhat larger diff because we needed to capture NEXTEST_BIN_EXE_ vars.