### PR TITLE
[nextest-runner] turn user-config experimental into table

### DIFF
--- a/integration-tests/tests/integration/record_replay.rs
+++ b/integration-tests/tests/integration/record_replay.rs
@@ -57,7 +57,8 @@ static BRACKETED_DURATION_REGEX: LazyLock<Regex> =
 /// The `record` experimental feature must be enabled AND `[record] enabled = true`
 /// must be set for recording to occur.
 const RECORD_USER_CONFIG: &str = r#"
-experimental = ["record"]
+[experimental]
+record = true
 
 [record]
 enabled = true
@@ -101,7 +102,7 @@ fn cli_for_project(env_info: &TestEnvInfo, p: &TempProject) -> CargoNextestCli {
 /// This helper:
 /// 1. Sets the manifest path
 /// 2. Sets `--user-config-file` to the provided config path (which must have
-///    `experimental = ["record"]` and `[record] enabled = true`)
+///    `[experimental] record = true` and `[record] enabled = true`)
 /// 3. Sets `NEXTEST_CACHE_DIR` to a directory inside the temp project
 /// 4. Optionally sets `__NEXTEST_FORCE_RUN_ID` for deterministic run IDs
 /// 5. Sets `__NEXTEST_REDACT=1` to produce fixed-width placeholders for

--- a/internal-docs/record-replay.md
+++ b/internal-docs/record-replay.md
@@ -9,8 +9,7 @@ Implement a record and replay feature that captures test run events and outputs 
 1. **Activation mechanism**: Experimental feature + config flag
    - The `record` experimental feature must be enabled via:
      - Environment variable: `NEXTEST_EXPERIMENTAL_RECORD=1`
-     - User config: `experimental = ["record"]` in `~/.config/nextest/config.toml`
-     - Project config: `experimental = ["record"]` in `.config/nextest.toml`
+     - User config: `[experimental] record = true` in `~/.config/nextest/config.toml`
    - Additionally, `[record] enabled = true` must be set in the config
    - Recording only occurs when BOTH conditions are met
    - No CLI flag initially (keeps it experimental)
@@ -219,9 +218,10 @@ Note: Progress bars are not shown during replay since events are processed insta
 
 ### Phase 5: Configuration
 
-**Config file options** (`.config/nextest.toml` or `~/.config/nextest/config.toml`):
+**Config file options** (`~/.config/nextest/config.toml`):
 ```toml
-experimental = ["record"]
+[experimental]
+record = true
 
 [record]
 # Enable recording (required in addition to the experimental feature)

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -814,19 +814,6 @@ pub enum UserConfigError {
         #[source]
         error: target_spec::Error,
     },
-
-    /// Unknown experimental features in the user config.
-    #[error(
-        "for user config at {path}, unknown experimental features: {unknown:?} (known features: {known:?})"
-    )]
-    UnknownExperimentalFeatures {
-        /// The path to the config file.
-        path: Utf8PathBuf,
-        /// The unknown features.
-        unknown: BTreeSet<String>,
-        /// The known features.
-        known: Vec<&'static str>,
-    },
 }
 
 /// Error returned while parsing a [`MaxFail`](crate::config::elements::MaxFail) input.

--- a/nextest-runner/src/user_config/experimental.rs
+++ b/nextest-runner/src/user_config/experimental.rs
@@ -7,7 +7,35 @@
 //! or via environment variables. They are separate from the repository-level experimental
 //! features in [`ConfigExperimental`](crate::config::core::ConfigExperimental).
 
+use serde::Deserialize;
 use std::{collections::BTreeSet, env, fmt, str::FromStr};
+
+/// Deserialized experimental config from user config file.
+///
+/// This represents the `[experimental]` table in user config:
+///
+/// ```toml
+/// [experimental]
+/// record = true
+/// ```
+#[derive(Clone, Copy, Debug, Default, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ExperimentalConfig {
+    /// Enable recording of test runs.
+    #[serde(default)]
+    pub record: bool,
+}
+
+impl ExperimentalConfig {
+    /// Converts to a set of enabled experimental features.
+    pub fn to_set(self) -> BTreeSet<UserConfigExperimental> {
+        let mut set = BTreeSet::new();
+        if self.record {
+            set.insert(UserConfigExperimental::Record);
+        }
+        set
+    }
+}
 
 /// User-level experimental features.
 ///

--- a/site/src/docs/features/record-replay.md
+++ b/site/src/docs/features/record-replay.md
@@ -10,7 +10,7 @@ description: Recording test runs and replaying them later.
 
 !!! experimental "Experimental: This feature is not yet stable"
 
-    - **Enable with:** Add `experimental = ["record"]` to [`~/.config/nextest/config.toml`](../user-config/index.md), or set `NEXTEST_EXPERIMENTAL_RECORD=1` in the environment
+    - **Enable with:** Add `[experimental]` with `record = true` to [`~/.config/nextest/config.toml`](../user-config/index.md), or set `NEXTEST_EXPERIMENTAL_RECORD=1` in the environment
     - **Tracking issue:** TBD
 
 Nextest supports recording test runs to replay them later. Recorded runs are stored locally in the system cache.

--- a/site/src/docs/user-config/index.md
+++ b/site/src/docs/user-config/index.md
@@ -60,7 +60,8 @@ Overrides are evaluated against the *host* platform (where nextest is running). 
 
 ```toml title="User configuration in ~/.config/nextest/config.toml"
 # Enable experimental features.
-experimental = ["record"]
+[experimental]
+record = true
 
 [ui]
 # Always show a progress bar.
@@ -76,7 +77,7 @@ input-handler = false
 output-indent = false
 
 [record]
-# Enable recording (requires experimental = ["record"]).
+# Enable recording (requires [experimental] record = true).
 enabled = true
 ```
 

--- a/site/src/docs/user-config/reference.md
+++ b/site/src/docs/user-config/reference.md
@@ -22,27 +22,28 @@ For more information about configuration hierarchy, see [_Configuration hierarch
 
 ## Experimental features
 
-### `experimental`
-
 <!-- md:version 0.9.123 -->
 
-- **Type**: Array of strings
-- **Description**: Enables experimental features
+Experimental features are configured under `[experimental]`.
+
+### `experimental.record`
+
+- **Type**: Boolean
+- **Description**: Enables the record and replay feature
 - **Documentation**: [_Record and replay_](../features/record-replay.md)
-- **Default**: `[]`: no experimental features are enabled
-- **Valid values**:
-  - `"record"`: Enable the record and replay feature
-- **Environment variable**: `NEXTEST_EXPERIMENTAL_RECORD=1` (for record only)
+- **Default**: `false`
+- **Environment variable**: `NEXTEST_EXPERIMENTAL_RECORD=1`
 - **Example**:
   ```toml
-  experimental = ["record"]
+  [experimental]
+  record = true
   ```
 
 ## Record configuration
 
 <!-- md:version 0.9.123 -->
 
-Record configuration is specified under `[record]`. Recording requires both the `"record"` experimental feature and `enabled = true`.
+Record configuration is specified under `[record]`. Recording requires both `[experimental] record = true` and `[record] enabled = true`.
 
 For detailed information, see [_Record and replay_](../features/record-replay.md).
 


### PR DESCRIPTION
A table is much easier to alter via a future `user-config set` command than an array.