### PR TITLE
[nextest-runner] support repo-config experimental as a table

### DIFF
--- a/cargo-nextest/src/errors.rs
+++ b/cargo-nextest/src/errors.rs
@@ -828,7 +828,7 @@ impl ExpectedError {
                             .join(", ");
 
                         error!(
-                            "for config file `{}`{}, unknown experimental features defined:
+                            "for config file `{}`{}, unknown experimental features defined: \
                              {unknown_str} (known features: {known_str}):",
                             err.config_file(),
                             provided_by_tool(err.tool()),

--- a/nextest-runner/src/config/core/imp.rs
+++ b/nextest-runner/src/config/core/imp.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use super::{NextestVersionDeserialize, ToolConfigFile, ToolName};
+use super::{ExperimentalDeserialize, NextestVersionDeserialize, ToolConfigFile, ToolName};
 use crate::{
     config::{
         core::ConfigExperimental,
@@ -1442,7 +1442,7 @@ struct NextestConfigDeserialize {
     nextest_version: Option<NextestVersionDeserialize>,
     #[expect(unused)]
     #[serde(default)]
-    experimental: BTreeSet<String>,
+    experimental: ExperimentalDeserialize,
 
     #[serde(default)]
     test_groups: BTreeMap<CustomTestGroup, TestGroupConfig>,

--- a/nextest-runner/src/user_config/experimental.rs
+++ b/nextest-runner/src/user_config/experimental.rs
@@ -29,8 +29,9 @@ pub struct ExperimentalConfig {
 impl ExperimentalConfig {
     /// Converts to a set of enabled experimental features.
     pub fn to_set(self) -> BTreeSet<UserConfigExperimental> {
+        let Self { record } = self;
         let mut set = BTreeSet::new();
-        if self.record {
+        if record {
             set.insert(UserConfigExperimental::Record);
         }
         set


### PR DESCRIPTION
Support `[experimental]` in repo-config for consistency with user config, since it's easier to do `user-config set` over the command line -- we're going to deprecate the array-style experimental config.