### PR TITLE
[cargo-nextest] make run ID mandatory for cargo nextest store info

### DIFF
--- a/integration-tests/tests/integration/record_replay.rs
+++ b/integration-tests/tests/integration/record_replay.rs
@@ -254,7 +254,7 @@ fn test_record_replay_cycle() {
 
     // Verify store info shows detailed run info including CLI and env vars.
     let info_output = cli_with_recording(&env_info, &p, &cache_dir, &user_config_path, None)
-        .args(["store", "info"])
+        .args(["store", "info", "latest"])
         .output();
     assert!(
         info_output.exit_status.success(),

--- a/internal-docs/record-replay.md
+++ b/internal-docs/record-replay.md
@@ -168,6 +168,8 @@ Store management and inspection:
 ```
 cargo nextest store list             # List all recorded runs (includes total size)
 cargo nextest store list -v          # Also show store location
+cargo nextest store info <run-id>    # Show details for a specific run
+cargo nextest store info -r <run-id> # Equivalent (flag is optional)
 cargo nextest store prune            # Prune old runs per retention policy
 ```
 

--- a/nextest-runner/src/record/display.rs
+++ b/nextest-runner/src/record/display.rs
@@ -697,7 +697,7 @@ impl<'a> DisplayRecordedRunInfoDetailed<'a> {
             self.redactor
                 .redact_size(sizes.log.uncompressed)
                 .style(self.styles.size),
-            sizes.log.entries.style(self.styles.count),
+            sizes.log.entries.style(self.styles.size),
         )?;
 
         writeln!(
@@ -710,7 +710,7 @@ impl<'a> DisplayRecordedRunInfoDetailed<'a> {
             self.redactor
                 .redact_size(sizes.store.uncompressed)
                 .style(self.styles.size),
-            sizes.store.entries.style(self.styles.count),
+            sizes.store.entries.style(self.styles.size),
         )?;
 
         // Draw a horizontal line before "total".


### PR DESCRIPTION
Accept the run ID as both a positional and an option argument.