### PR TITLE
[nextest-runner] simplify replay code a bit

### DIFF
--- a/cargo-nextest/src/dispatch/core/replay.rs
+++ b/cargo-nextest/src/dispatch/core/replay.rs
@@ -16,11 +16,11 @@ use guppy::{graph::PackageGraph, platform::Platform};
 use nextest_metadata::NextestExitCode;
 use nextest_runner::{
     errors::DisplayErrorChain,
-    list::TestList,
+    list::{OwnedTestInstanceId, TestList},
     pager::PagedOutput,
     record::{
         RecordReader, ReplayContext, ReplayHeader, ReplayReporterBuilder, RunIdSelector, RunStore,
-        TestInstanceSummary, format::RECORD_FORMAT_VERSION, records_cache_dir,
+        format::RECORD_FORMAT_VERSION, records_cache_dir,
     },
     reporter::ReporterOutput,
     user_config::UserConfig,
@@ -161,11 +161,10 @@ pub(crate) fn exec_replay(
     let mut replay_cx = ReplayContext::new(&test_list);
     for (binary_id, suite) in &test_list_summary.rust_suites {
         for test_name in suite.test_cases.keys() {
-            let test_instance = TestInstanceSummary {
+            replay_cx.register_test(OwnedTestInstanceId {
                 binary_id: binary_id.clone(),
-                name: test_name.to_string(),
-            };
-            replay_cx.register_test(&test_instance);
+                test_name: test_name.clone(),
+            });
         }
     }
 

--- a/nextest-metadata/src/test_list.rs
+++ b/nextest-metadata/src/test_list.rs
@@ -990,6 +990,15 @@ mod proptest_impls {
             .boxed()
         }
     }
+
+    impl Arbitrary for TestCaseName {
+        type Parameters = ();
+        type Strategy = BoxedStrategy<Self>;
+
+        fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+            any::<String>().prop_map(|s| TestCaseName::new(&s)).boxed()
+        }
+    }
 }
 
 #[cfg(test)]

--- a/nextest-runner/src/list/test_list.rs
+++ b/nextest-runner/src/list/test_list.rs
@@ -38,7 +38,7 @@ use nextest_metadata::{
 };
 use owo_colors::OwoColorize;
 use quick_junit::ReportUuid;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
     collections::{BTreeMap, BTreeSet},
@@ -1518,12 +1518,15 @@ impl fmt::Display for TestInstanceId<'_> {
 }
 
 /// An owned version of [`TestInstanceId`].
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "kebab-case")]
+#[cfg_attr(test, derive(test_strategy::Arbitrary))]
 pub struct OwnedTestInstanceId {
     /// The binary ID.
     pub binary_id: RustBinaryId,
 
     /// The name of the test.
+    #[serde(rename = "name")]
     pub test_name: TestCaseName,
 }
 

--- a/nextest-runner/src/record/mod.rs
+++ b/nextest-runner/src/record/mod.rs
@@ -65,5 +65,5 @@ pub use store::{
 pub use summary::{
     CoreEventKind, NoTestsBehavior, OutputEventKind, OutputFileName, RecordOpts,
     StressConditionSummary, StressIndexSummary, TestEventKindSummary, TestEventSummary,
-    TestInstanceSummary, ZipStoreOutput,
+    ZipStoreOutput,
 };


### PR DESCRIPTION
No reason to have all these different copies of OwnedTestInstanceId.