### PR TITLE
[nextest-runner] remove Eq requirement from TestFilterBuilder

### DIFF
--- a/cargo-nextest/src/dispatch/core/tests.rs
+++ b/cargo-nextest/src/dispatch/core/tests.rs
@@ -497,7 +497,12 @@ fn test_test_binary_argument_parsing() {
         )
         .unwrap_or_else(|_| panic!("failed to build TestFilterBuilder"));
 
-        assert_eq!(builder, builder2, "{args} matches expected");
+        assert!(
+            builder.patterns_eq(&builder2),
+            "{args} matches expected (from TestCli: {:?}, from direct construction: {:?})",
+            builder,
+            builder2,
+        );
     }
 
     for (s, r) in invalid {

--- a/nextest-runner/src/test_filter.rs
+++ b/nextest-runner/src/test_filter.rs
@@ -102,7 +102,7 @@ impl BinaryFilter {
 }
 
 /// A builder for `TestFilter` instances.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct TestFilterBuilder {
     mode: NextestRunMode,
     run_ignored: RunIgnored,
@@ -473,6 +473,11 @@ impl TestFilterBuilder {
     /// Returns the nextest execution mode.
     pub fn mode(&self) -> NextestRunMode {
         self.mode
+    }
+
+    /// Compares the patterns between two `TestFilterBuilder`s.
+    pub fn patterns_eq(&self, other: &Self) -> bool {
+        self.patterns == other.patterns
     }
 
     /// Creates a new test filter scoped to a single binary.


### PR DESCRIPTION
We only care about comparing patterns, and we need to store some information here that can't be compared for equality.