### PR TITLE
[cargo-nextest] add NoTestsBehaviorOpt::Auto

### DIFF
--- a/cargo-nextest/src/dispatch/core/value_enums.rs
+++ b/cargo-nextest/src/dispatch/core/value_enums.rs
@@ -6,7 +6,6 @@
 use clap::ValueEnum;
 use nextest_metadata::BuildPlatform;
 use nextest_runner::{
-    record::NoTestsBehavior,
     reporter::{FinalStatusLevel, StatusLevel, TestOutputDisplay},
     user_config::elements::UiShowProgress,
 };
@@ -114,8 +113,12 @@ impl From<RunIgnoredOpt> for nextest_runner::test_filter::RunIgnored {
 }
 
 /// No tests behavior options.
-#[derive(Clone, Copy, Debug, ValueEnum)]
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
 pub(crate) enum NoTestsBehaviorOpt {
+    /// Use the default behavior (error with exit code 4).
+    #[default]
+    Auto,
+
     /// Silently exit with code 0.
     Pass,
 
@@ -125,17 +128,6 @@ pub(crate) enum NoTestsBehaviorOpt {
     /// Produce an error message and exit with code 4.
     #[clap(alias = "error")]
     Fail,
-}
-
-impl NoTestsBehaviorOpt {
-    /// Converts to the record-layer `NoTestsBehavior` type.
-    pub(crate) fn to_record(self) -> NoTestsBehavior {
-        match self {
-            Self::Pass => NoTestsBehavior::Pass,
-            Self::Warn => NoTestsBehavior::Warn,
-            Self::Fail => NoTestsBehavior::Fail,
-        }
-    }
 }
 
 /// Test output display options.

--- a/nextest-runner/src/record/mod.rs
+++ b/nextest-runner/src/record/mod.rs
@@ -63,7 +63,6 @@ pub use store::{
     StressCompletedRunStats,
 };
 pub use summary::{
-    CoreEventKind, NoTestsBehavior, OutputEventKind, OutputFileName, RecordOpts,
-    StressConditionSummary, StressIndexSummary, TestEventKindSummary, TestEventSummary,
-    ZipStoreOutput,
+    CoreEventKind, OutputEventKind, OutputFileName, RecordOpts, StressConditionSummary,
+    StressIndexSummary, TestEventKindSummary, TestEventSummary, ZipStoreOutput,
 };

--- a/nextest-runner/src/record/summary.rs
+++ b/nextest-runner/src/record/summary.rs
@@ -29,7 +29,7 @@ use chrono::{DateTime, FixedOffset};
 use nextest_metadata::MismatchReason;
 use quick_junit::ReportUuid;
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, fmt, num::NonZero, time::Duration};
+use std::{fmt, num::NonZero, time::Duration};
 
 // ---
 // Record options
@@ -46,49 +46,13 @@ pub struct RecordOpts {
     /// The run mode (test or benchmark).
     #[serde(default)]
     pub run_mode: NextestRunMode,
-
-    /// The behavior when no tests are run.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub no_tests: Option<NoTestsBehavior>,
-
-    /// The command-line arguments used to invoke nextest.
-    pub cli_args: Vec<String>,
-
-    /// Environment variables that affect nextest behavior (NEXTEST_* and CARGO_*).
-    pub env_vars: BTreeMap<String, String>,
 }
 
 impl RecordOpts {
     /// Creates a new `RecordOpts` with the given settings.
-    pub fn new(
-        run_mode: NextestRunMode,
-        no_tests: Option<NoTestsBehavior>,
-        cli_args: Vec<String>,
-        env_vars: BTreeMap<String, String>,
-    ) -> Self {
-        Self {
-            run_mode,
-            no_tests,
-            cli_args,
-            env_vars,
-        }
+    pub fn new(run_mode: NextestRunMode) -> Self {
+        Self { run_mode }
     }
-}
-
-/// Behavior when no tests are selected to run.
-///
-/// This is a serializable version of the CLI's `--no-tests` option.
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "kebab-case")]
-pub enum NoTestsBehavior {
-    /// Silently exit with code 0.
-    Pass,
-
-    /// Produce a warning and exit with code 0.
-    Warn,
-
-    /// Produce an error and exit with a non-zero code.
-    Fail,
 }
 
 // ---


### PR DESCRIPTION
`Auto` means the same thing as `Fail` right now, but in upcoming rerun work it can result in a pass in some instances.

Also clean up some unused code.