### PR TITLE
[cargo-nextest] factor out Cargo build scope args, store in recorded runs

### DIFF
--- a/cargo-nextest/src/dispatch/core/base.rs
+++ b/cargo-nextest/src/dispatch/core/base.rs
@@ -5,6 +5,7 @@
 
 use crate::{
     ExpectedError, Result, ReuseBuildKind,
+    cargo_cli::CargoOptions,
     dispatch::{
         EarlyArgs,
         common::ConfigOpts,
@@ -48,7 +49,7 @@ pub(crate) struct BaseApp {
     pub(crate) workspace_root: Utf8PathBuf,
     manifest_path: Option<Utf8PathBuf>,
     pub(crate) reuse_build: ReuseBuildInfo,
-    cargo_opts: crate::cargo_cli::CargoOptions,
+    pub(crate) cargo_opts: CargoOptions,
     pub(crate) config_opts: ConfigOpts,
     pub(crate) current_version: Version,
 
@@ -376,6 +377,15 @@ impl BaseApp {
                 &self.output.stderr_styles(),
             )
         })
+    }
+
+    pub(crate) fn build_scope_args(&self) -> Vec<String> {
+        self.cargo_opts
+            .build_scope
+            .to_cli_args()
+            .into_iter()
+            .map(|s| s.to_owned())
+            .collect()
     }
 
     pub(crate) fn build_binary_list(&self, cargo_command: &str) -> Result<Arc<BinaryList>> {

--- a/cargo-nextest/src/dispatch/core/run.rs
+++ b/cargo-nextest/src/dispatch/core/run.rs
@@ -1000,6 +1000,7 @@ impl App {
                 nextest_version: self.base.current_version.clone(),
                 started_at: runner.started_at().fixed_offset(),
                 cli_args: cli_args_for_recording,
+                build_scope_args: self.base.build_scope_args(),
                 env_vars: env_vars_for_recording,
                 max_output_size: resolved_user_config.record.max_output_size,
             };
@@ -1221,6 +1222,7 @@ impl App {
                 nextest_version: self.base.current_version.clone(),
                 started_at: runner.started_at().fixed_offset(),
                 cli_args: cli_args_for_recording,
+                build_scope_args: self.base.build_scope_args(),
                 env_vars: env_vars_for_recording,
                 max_output_size: resolved_user_config.record.max_output_size,
             };

--- a/nextest-runner/src/record/display.rs
+++ b/nextest-runner/src/record/display.rs
@@ -1013,6 +1013,7 @@ mod tests {
             last_written_at: started_at,
             duration_secs: Some(duration_secs),
             cli_args: Vec::new(),
+            build_scope_args: Vec::new(),
             env_vars: BTreeMap::new(),
             sizes: RecordedSizes {
                 log: ComponentSizes::default(),
@@ -1044,6 +1045,7 @@ mod tests {
             last_written_at: started_at,
             duration_secs: Some(12.345),
             cli_args,
+            build_scope_args: Vec::new(),
             env_vars,
             sizes: RecordedSizes {
                 log: ComponentSizes {

--- a/nextest-runner/src/record/format.rs
+++ b/nextest-runner/src/record/format.rs
@@ -141,6 +141,12 @@ pub(super) struct RecordedRun {
     /// The command-line arguments used to invoke nextest.
     #[serde(default)]
     pub(super) cli_args: Vec<String>,
+    /// Build scope arguments (package and target selection).
+    ///
+    /// These determine which packages and targets are built. In a rerun chain,
+    /// these are inherited from the original run unless explicitly overridden.
+    #[serde(default)]
+    pub(super) build_scope_args: Vec<String>,
     /// Environment variables that affect nextest behavior (NEXTEST_* and CARGO_*).
     ///
     /// This has a default for deserializing old runs.json.zst files that don't have this field.
@@ -283,6 +289,7 @@ impl From<RecordedRun> for RecordedRunInfo {
             last_written_at: run.last_written_at,
             duration_secs: run.duration_secs,
             cli_args: run.cli_args,
+            build_scope_args: run.build_scope_args,
             env_vars: run.env_vars,
             sizes: run.sizes.into(),
             status: run.status.into(),
@@ -300,6 +307,7 @@ impl From<&RecordedRunInfo> for RecordedRun {
             last_written_at: run.last_written_at,
             duration_secs: run.duration_secs,
             cli_args: run.cli_args.clone(),
+            build_scope_args: run.build_scope_args.clone(),
             env_vars: run.env_vars.clone(),
             sizes: run.sizes.into(),
             status: (&run.status).into(),
@@ -621,6 +629,7 @@ mod tests {
                 "run".to_owned(),
                 "--workspace".to_owned(),
             ],
+            build_scope_args: vec!["--workspace".to_owned()],
             env_vars: BTreeMap::from([
                 ("CARGO_TERM_COLOR".to_owned(), "always".to_owned()),
                 ("NEXTEST_PROFILE".to_owned(), "ci".to_owned()),

--- a/nextest-runner/src/record/retention.rs
+++ b/nextest-runner/src/record/retention.rs
@@ -425,6 +425,7 @@ mod tests {
             last_written_at: started_at,
             duration_secs: Some(1.0),
             cli_args: Vec::new(),
+            build_scope_args: Vec::new(),
             env_vars: BTreeMap::new(),
             sizes: RecordedSizes {
                 log: ComponentSizes::default(),

--- a/nextest-runner/src/record/run_id_index.rs
+++ b/nextest-runner/src/record/run_id_index.rs
@@ -304,6 +304,7 @@ mod tests {
             last_written_at: started_at,
             duration_secs: None,
             cli_args: Vec::new(),
+            build_scope_args: Vec::new(),
             env_vars: BTreeMap::new(),
             sizes: RecordedSizes::default(),
             status: RecordedRunStatus::Incomplete,

--- a/nextest-runner/src/record/session.rs
+++ b/nextest-runner/src/record/session.rs
@@ -41,6 +41,11 @@ pub struct RecordSessionConfig<'a> {
     pub started_at: DateTime<FixedOffset>,
     /// The command-line arguments used to invoke nextest.
     pub cli_args: Vec<String>,
+    /// Build scope arguments (package and target selection).
+    ///
+    /// These determine which packages and targets are built. In a rerun chain,
+    /// these are inherited from the original run unless explicitly overridden.
+    pub build_scope_args: Vec<String>,
     /// Environment variables that affect nextest behavior (NEXTEST_* and CARGO_*).
     pub env_vars: BTreeMap<String, String>,
     /// Maximum size per output file before truncation.
@@ -90,6 +95,7 @@ impl RecordSession {
                 config.nextest_version,
                 config.started_at,
                 config.cli_args,
+                config.build_scope_args,
                 config.env_vars,
                 config.max_output_size,
             )

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_cancelled.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_cancelled.snap
@@ -15,6 +15,9 @@ expression: json
     "run",
     "--workspace"
   ],
+  "build-scope-args": [
+    "--workspace"
+  ],
   "env-vars": {
     "CARGO_TERM_COLOR": "always",
     "NEXTEST_PROFILE": "ci"

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_completed.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_completed.snap
@@ -15,6 +15,9 @@ expression: json
     "run",
     "--workspace"
   ],
+  "build-scope-args": [
+    "--workspace"
+  ],
   "env-vars": {
     "CARGO_TERM_COLOR": "always",
     "NEXTEST_PROFILE": "ci"

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_incomplete.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_incomplete.snap
@@ -15,6 +15,9 @@ expression: json
     "run",
     "--workspace"
   ],
+  "build-scope-args": [
+    "--workspace"
+  ],
   "env-vars": {
     "CARGO_TERM_COLOR": "always",
     "NEXTEST_PROFILE": "ci"

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_cancelled.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_cancelled.snap
@@ -15,6 +15,9 @@ expression: json
     "run",
     "--workspace"
   ],
+  "build-scope-args": [
+    "--workspace"
+  ],
   "env-vars": {
     "CARGO_TERM_COLOR": "always",
     "NEXTEST_PROFILE": "ci"

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_completed.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_completed.snap
@@ -15,6 +15,9 @@ expression: json
     "run",
     "--workspace"
   ],
+  "build-scope-args": [
+    "--workspace"
+  ],
   "env-vars": {
     "CARGO_TERM_COLOR": "always",
     "NEXTEST_PROFILE": "ci"

--- a/nextest-runner/src/record/store.rs
+++ b/nextest-runner/src/record/store.rs
@@ -352,12 +352,14 @@ impl<'store> ExclusiveLockedRunStore<'store> {
     /// before truncation.
     ///
     /// Returns an error if writing is denied due to a format version mismatch.
+    #[expect(clippy::too_many_arguments)]
     pub fn create_run_recorder(
         mut self,
         run_id: ReportUuid,
         nextest_version: Version,
         started_at: DateTime<FixedOffset>,
         cli_args: Vec<String>,
+        build_scope_args: Vec<String>,
         env_vars: BTreeMap<String, String>,
         max_output_size: bytesize::ByteSize,
     ) -> Result<RunRecorder, RunStoreError> {
@@ -385,6 +387,7 @@ impl<'store> ExclusiveLockedRunStore<'store> {
             last_written_at: Local::now().fixed_offset(),
             duration_secs: None,
             cli_args,
+            build_scope_args,
             env_vars,
             sizes: RecordedSizes::default(),
             status: RecordedRunStatus::Incomplete,
@@ -427,6 +430,11 @@ pub struct RecordedRunInfo {
     pub duration_secs: Option<f64>,
     /// The command-line arguments used to invoke nextest.
     pub cli_args: Vec<String>,
+    /// Build scope arguments (package and target selection).
+    ///
+    /// These determine which packages and targets are built. In a rerun chain,
+    /// these are inherited from the original run unless explicitly overridden.
+    pub build_scope_args: Vec<String>,
     /// Environment variables that affect nextest behavior (NEXTEST_* and CARGO_*).
     pub env_vars: BTreeMap<String, String>,
     /// Sizes broken down by component (log and store).


### PR DESCRIPTION
For reruns, we need to be able to extract Cargo build scope arguments.