### PR TITLE
[cargo-nextest] support --cargo-message-format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "buf-list"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6b175f9cf8fffedd4c4b18bcfef092356e952b81f596e148f18e98280994593"
+dependencies = [
+ "bytes",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +398,8 @@ dependencies = [
 name = "cargo-nextest"
 version = "0.9.123-b.3"
 dependencies = [
+ "buf-list",
+ "bytes",
  "camino",
  "camino-tempfile",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ async-scoped = { version = "0.9.0", features = ["use-tokio"] }
 atomicwrites = "0.4.4"
 bstr = { version = "1.12.1", default-features = false, features = ["std"] }
 bitflags = "2.10.0"
+buf-list = "1.1.2"
 bytesize = { version = "2.3.1", features = ["serde"] }
 bytes = "1.11.0"
 camino = "1.2.2"

--- a/cargo-nextest/Cargo.toml
+++ b/cargo-nextest/Cargo.toml
@@ -12,6 +12,8 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+buf-list.workspace = true
+bytes.workspace = true
 camino.workspace = true
 cfg-if.workspace = true
 chrono.workspace = true

--- a/cargo-nextest/src/cargo_cli.rs
+++ b/cargo-nextest/src/cargo_cli.rs
@@ -3,7 +3,7 @@
 
 //! Cargo CLI support.
 
-use crate::output::OutputContext;
+use crate::{dispatch::CargoMessageFormatOpt, output::OutputContext};
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::{ArgAction, Args};
 use std::{borrow::Cow, path::PathBuf};
@@ -321,6 +321,20 @@ pub(crate) struct CargoOptions {
     /// Run without accessing the network
     #[arg(long, group = "cargo-opts", help_heading = "Manifest options")]
     offline: bool,
+
+    /// Cargo message format.
+    ///
+    /// Controls how Cargo reports build messages and whether to forward JSON to
+    /// stdout. Multiple JSON options can be comma-separated or repeated.
+    #[arg(
+        long,
+        value_enum,
+        value_name = "FMT",
+        value_delimiter = ',',
+        group = "cargo-opts",
+        help_heading = "Other Cargo options"
+    )]
+    pub(crate) cargo_message_format: Vec<CargoMessageFormatOpt>,
 
     //  TODO: doc?
     // no-run is handled by test runner

--- a/cargo-nextest/src/dispatch/core/mod.rs
+++ b/cargo-nextest/src/dispatch/core/mod.rs
@@ -22,3 +22,4 @@ pub(crate) use filter::TestBuildFilter;
 pub(crate) use list::ListOpts;
 pub(crate) use replay::{ReplayOpts, exec_replay};
 pub(crate) use run::{App, BenchOpts, RunOpts};
+pub(crate) use value_enums::CargoMessageFormatOpt;

--- a/cargo-nextest/src/dispatch/core/tests.rs
+++ b/cargo-nextest/src/dispatch/core/tests.rs
@@ -71,6 +71,16 @@ fn test_argument_parsing() {
         "cargo nextest list --lib --bins",
         "cargo nextest run --ignore-rust-version --unit-graph",
         // ---
+        // Cargo message format options
+        // ---
+        "cargo nextest list --cargo-message-format human",
+        "cargo nextest list --cargo-message-format short",
+        "cargo nextest list --cargo-message-format json",
+        "cargo nextest list --cargo-message-format json-diagnostic-short",
+        "cargo nextest list --cargo-message-format json-diagnostic-rendered-ansi",
+        "cargo nextest list --cargo-message-format json-render-diagnostics",
+        "cargo nextest run --cargo-message-format json",
+        // ---
         // Pager options
         // ---
         "cargo nextest list --no-pager",

--- a/cargo-nextest/src/dispatch/core/value_enums.rs
+++ b/cargo-nextest/src/dispatch/core/value_enums.rs
@@ -3,12 +3,14 @@
 
 //! Value enums shared across core commands.
 
+use crate::errors::CargoMessageFormatError;
 use clap::ValueEnum;
 use nextest_metadata::BuildPlatform;
 use nextest_runner::{
     reporter::{FinalStatusLevel, StatusLevel, TestOutputDisplay},
     user_config::elements::UiShowProgress,
 };
+use std::collections::HashSet;
 
 /// Platform filter options.
 #[derive(Copy, Clone, Debug, ValueEnum, Default)]
@@ -260,4 +262,730 @@ pub(crate) enum MessageFormat {
     /// Output test information in the same format as libtest, with a `nextest` subobject that
     /// includes additional metadata.
     LibtestJsonPlus,
+}
+
+/// Configuration for how to invoke Cargo and handle its output.
+///
+/// This type controls:
+///
+/// - What `--message-format` arguments to pass to Cargo.
+/// - Whether to forward JSON output to stdout.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum CargoMessageFormat {
+    /// Human-readable diagnostics rendered by Cargo.
+    ///
+    /// Cargo args: `json-render-diagnostics`
+    ///
+    /// Note: `--cargo-message-format short` also maps to this variant, since
+    /// `cargo test --message-format short` produces the same output as human.
+    #[default]
+    Human,
+
+    /// JSON output forwarded to stdout.
+    ///
+    /// Cargo args: combinations of `json`, `json-diagnostic-short`,
+    /// `json-diagnostic-rendered-ansi`, and/or `json-render-diagnostics`
+    Json {
+        /// Whether to also render diagnostics to stderr via Cargo.
+        ///
+        /// When true, Cargo uses `json-render-diagnostics`, which:
+        /// - Renders compiler messages to stderr
+        /// - **Removes** `compiler-message` entries from the JSON stdout
+        ///
+        /// When false, `compiler-message` entries remain in the JSON output.
+        render_diagnostics: bool,
+
+        /// Whether to use short diagnostic format.
+        ///
+        /// Cargo arg: `json-diagnostic-short`
+        short: bool,
+
+        /// Whether to include ANSI color codes in the `rendered` field.
+        ///
+        /// Cargo arg: `json-diagnostic-rendered-ansi`
+        ansi: bool,
+    },
+}
+
+impl CargoMessageFormat {
+    /// Returns the `--message-format` argument(s) to pass to Cargo.
+    pub(crate) fn cargo_arg(&self) -> &'static str {
+        match self {
+            Self::Human => "json-render-diagnostics",
+            Self::Json {
+                render_diagnostics: false,
+                short: false,
+                ansi: false,
+            } => "json",
+            Self::Json {
+                render_diagnostics: false,
+                short: true,
+                ansi: false,
+            } => "json-diagnostic-short",
+            Self::Json {
+                render_diagnostics: false,
+                short: false,
+                ansi: true,
+            } => "json-diagnostic-rendered-ansi",
+            Self::Json {
+                render_diagnostics: false,
+                short: true,
+                ansi: true,
+            } => "json-diagnostic-short,json-diagnostic-rendered-ansi",
+            Self::Json {
+                render_diagnostics: true,
+                short: false,
+                ansi: false,
+            } => "json-render-diagnostics",
+            Self::Json {
+                render_diagnostics: true,
+                short: true,
+                ansi: false,
+            } => "json-render-diagnostics,json-diagnostic-short",
+            Self::Json {
+                render_diagnostics: true,
+                short: false,
+                ansi: true,
+            } => "json-render-diagnostics,json-diagnostic-rendered-ansi",
+            Self::Json {
+                render_diagnostics: true,
+                short: true,
+                ansi: true,
+            } => "json-render-diagnostics,json-diagnostic-short,json-diagnostic-rendered-ansi",
+        }
+    }
+
+    /// Returns whether JSON should be forwarded to stdout.
+    pub(crate) fn forward_json(&self) -> bool {
+        matches!(self, Self::Json { .. })
+    }
+}
+
+/// Cargo message format CLI options.
+///
+/// Controls the format of Cargo's build output and whether to forward JSON
+/// messages to stdout.
+///
+/// JSON modifiers can be combined:
+/// `json,json-diagnostic-short,json-diagnostic-rendered-ansi`
+#[derive(Clone, Copy, Debug, ValueEnum, Default, PartialEq, Eq, Hash)]
+pub(crate) enum CargoMessageFormatOpt {
+    /// Render diagnostics in the default human-readable format.
+    #[default]
+    Human,
+
+    /// Alias for `human`.
+    Short,
+
+    /// Emit JSON messages to stdout.
+    Json,
+
+    /// Ensure the `rendered` field of JSON messages contains the "short"
+    /// rendering from rustc.
+    JsonDiagnosticShort,
+
+    /// Ensure the `rendered` field of JSON messages contains ANSI color codes.
+    JsonDiagnosticRenderedAnsi,
+
+    /// Output JSON messages with human-readable diagnostics.
+    JsonRenderDiagnostics,
+}
+
+impl CargoMessageFormatOpt {
+    /// Returns the string representation of this option.
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Human => "human",
+            Self::Short => "short",
+            Self::Json => "json",
+            Self::JsonDiagnosticShort => "json-diagnostic-short",
+            Self::JsonDiagnosticRenderedAnsi => "json-diagnostic-rendered-ansi",
+            Self::JsonRenderDiagnostics => "json-render-diagnostics",
+        }
+    }
+
+    /// Combines CLI options into a single domain model.
+    pub(crate) fn combine(opts: &[Self]) -> Result<CargoMessageFormat, CargoMessageFormatError> {
+        let mut base_format: Option<Self> = None;
+        let mut short = false;
+        let mut ansi = false;
+        let mut render_diagnostics = false;
+        let mut seen = HashSet::new();
+
+        for &opt in opts {
+            if !seen.insert(opt) {
+                return Err(CargoMessageFormatError::Duplicate {
+                    option: opt.as_str(),
+                });
+            }
+
+            match opt {
+                Self::Human | Self::Short | Self::Json => {
+                    if let Some(existing) = base_format {
+                        return Err(CargoMessageFormatError::ConflictingBaseFormats {
+                            first: existing.as_str(),
+                            second: opt.as_str(),
+                        });
+                    }
+                    base_format = Some(opt);
+                }
+                Self::JsonDiagnosticShort => short = true,
+                Self::JsonDiagnosticRenderedAnsi => ansi = true,
+                Self::JsonRenderDiagnostics => render_diagnostics = true,
+            }
+        }
+
+        let has_json_modifiers = short || ansi || render_diagnostics;
+
+        match base_format {
+            None if has_json_modifiers => {
+                // JSON modifiers without explicit base imply JSON.
+                Ok(CargoMessageFormat::Json {
+                    render_diagnostics,
+                    short,
+                    ansi,
+                })
+            }
+            None => {
+                // No options specified, use default.
+                Ok(CargoMessageFormat::Human)
+            }
+            Some(fmt @ Self::Human) | Some(fmt @ Self::Short) => {
+                if has_json_modifiers {
+                    return Err(CargoMessageFormatError::JsonModifierWithNonJson {
+                        modifiers: json_modifiers_str(short, ansi, render_diagnostics),
+                        base: fmt.as_str(),
+                    });
+                }
+                // Both human and short map to Human (short produces same output
+                // as human for `cargo test`).
+                Ok(CargoMessageFormat::Human)
+            }
+            Some(Self::Json) => Ok(CargoMessageFormat::Json {
+                render_diagnostics,
+                short,
+                ansi,
+            }),
+            Some(_) => unreachable!(),
+        }
+    }
+}
+
+/// Returns a formatted string listing all JSON modifiers that are set.
+fn json_modifiers_str(short: bool, ansi: bool, render_diagnostics: bool) -> &'static str {
+    match (short, ansi, render_diagnostics) {
+        (true, false, false) => "`json-diagnostic-short`",
+        (false, true, false) => "`json-diagnostic-rendered-ansi`",
+        (false, false, true) => "`json-render-diagnostics`",
+        (true, true, false) => "`json-diagnostic-short` and `json-diagnostic-rendered-ansi`",
+        (true, false, true) => "`json-diagnostic-short` and `json-render-diagnostics`",
+        (false, true, true) => "`json-diagnostic-rendered-ansi` and `json-render-diagnostics`",
+        (true, true, true) => {
+            "`json-diagnostic-short`, `json-diagnostic-rendered-ansi`, \
+             and `json-render-diagnostics`"
+        }
+        (false, false, false) => unreachable!("at least one modifier must be set"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use CargoMessageFormatOpt::*;
+
+    /// Helper to assert successful combination.
+    fn assert_combine(opts: &[CargoMessageFormatOpt], expected: CargoMessageFormat) {
+        let result = CargoMessageFormatOpt::combine(opts);
+        assert_eq!(result, Ok(expected), "opts={opts:?}");
+    }
+
+    /// Helper to assert conflicting base formats error.
+    fn assert_conflicting(
+        opts: &[CargoMessageFormatOpt],
+        first: &'static str,
+        second: &'static str,
+    ) {
+        let result = CargoMessageFormatOpt::combine(opts);
+        assert_eq!(
+            result,
+            Err(CargoMessageFormatError::ConflictingBaseFormats { first, second }),
+            "opts={opts:?}"
+        );
+    }
+
+    /// Helper to assert JSON modifier with non-JSON base error.
+    fn assert_modifier_with_non_json(
+        opts: &[CargoMessageFormatOpt],
+        modifiers: &'static str,
+        base: &'static str,
+    ) {
+        let result = CargoMessageFormatOpt::combine(opts);
+        assert_eq!(
+            result,
+            Err(CargoMessageFormatError::JsonModifierWithNonJson { modifiers, base }),
+            "opts={opts:?}"
+        );
+    }
+
+    /// Helper to assert duplicate error.
+    fn assert_duplicate(opts: &[CargoMessageFormatOpt], option: &'static str) {
+        let result = CargoMessageFormatOpt::combine(opts);
+        assert_eq!(
+            result,
+            Err(CargoMessageFormatError::Duplicate { option }),
+            "opts={opts:?}"
+        );
+    }
+
+    #[test]
+    fn test_cargo_message_format_opt_combine() {
+        // ---
+        // Empty input
+        // ---
+        assert_combine(&[], CargoMessageFormat::Human);
+
+        // ---
+        // Single base formats
+        // ---
+
+        assert_combine(&[Human], CargoMessageFormat::Human);
+
+        // Short maps to Human (cargo test --message-format short produces the
+        // same output as human).
+        assert_combine(&[Short], CargoMessageFormat::Human);
+
+        assert_combine(
+            &[Json],
+            CargoMessageFormat::Json {
+                render_diagnostics: false,
+                short: false,
+                ansi: false,
+            },
+        );
+
+        // ---
+        // Single JSON modifiers (imply Json base)
+        // ---
+
+        assert_combine(
+            &[JsonDiagnosticShort],
+            CargoMessageFormat::Json {
+                render_diagnostics: false,
+                short: true,
+                ansi: false,
+            },
+        );
+
+        assert_combine(
+            &[JsonDiagnosticRenderedAnsi],
+            CargoMessageFormat::Json {
+                render_diagnostics: false,
+                short: false,
+                ansi: true,
+            },
+        );
+
+        assert_combine(
+            &[JsonRenderDiagnostics],
+            CargoMessageFormat::Json {
+                render_diagnostics: true,
+                short: false,
+                ansi: false,
+            },
+        );
+
+        // ---
+        // Json base + one modifier
+        // ---
+
+        assert_combine(
+            &[Json, JsonDiagnosticShort],
+            CargoMessageFormat::Json {
+                render_diagnostics: false,
+                short: true,
+                ansi: false,
+            },
+        );
+
+        assert_combine(
+            &[Json, JsonDiagnosticRenderedAnsi],
+            CargoMessageFormat::Json {
+                render_diagnostics: false,
+                short: false,
+                ansi: true,
+            },
+        );
+
+        assert_combine(
+            &[Json, JsonRenderDiagnostics],
+            CargoMessageFormat::Json {
+                render_diagnostics: true,
+                short: false,
+                ansi: false,
+            },
+        );
+
+        // ---
+        // Json base + two modifiers
+        // ---
+
+        assert_combine(
+            &[Json, JsonDiagnosticShort, JsonDiagnosticRenderedAnsi],
+            CargoMessageFormat::Json {
+                render_diagnostics: false,
+                short: true,
+                ansi: true,
+            },
+        );
+
+        assert_combine(
+            &[Json, JsonDiagnosticShort, JsonRenderDiagnostics],
+            CargoMessageFormat::Json {
+                render_diagnostics: true,
+                short: true,
+                ansi: false,
+            },
+        );
+
+        assert_combine(
+            &[Json, JsonDiagnosticRenderedAnsi, JsonRenderDiagnostics],
+            CargoMessageFormat::Json {
+                render_diagnostics: true,
+                short: false,
+                ansi: true,
+            },
+        );
+
+        // ---
+        // Json base + all three modifiers
+        // ---
+
+        assert_combine(
+            &[
+                Json,
+                JsonDiagnosticShort,
+                JsonDiagnosticRenderedAnsi,
+                JsonRenderDiagnostics,
+            ],
+            CargoMessageFormat::Json {
+                render_diagnostics: true,
+                short: true,
+                ansi: true,
+            },
+        );
+
+        // ---
+        // Two modifiers without explicit Json base
+        // ---
+
+        assert_combine(
+            &[JsonDiagnosticShort, JsonDiagnosticRenderedAnsi],
+            CargoMessageFormat::Json {
+                render_diagnostics: false,
+                short: true,
+                ansi: true,
+            },
+        );
+
+        assert_combine(
+            &[JsonDiagnosticShort, JsonRenderDiagnostics],
+            CargoMessageFormat::Json {
+                render_diagnostics: true,
+                short: true,
+                ansi: false,
+            },
+        );
+
+        assert_combine(
+            &[JsonDiagnosticRenderedAnsi, JsonRenderDiagnostics],
+            CargoMessageFormat::Json {
+                render_diagnostics: true,
+                short: false,
+                ansi: true,
+            },
+        );
+
+        // ---
+        // Three modifiers without explicit Json base
+        // ---
+
+        assert_combine(
+            &[
+                JsonDiagnosticShort,
+                JsonDiagnosticRenderedAnsi,
+                JsonRenderDiagnostics,
+            ],
+            CargoMessageFormat::Json {
+                render_diagnostics: true,
+                short: true,
+                ansi: true,
+            },
+        );
+
+        // ---
+        // Order independence: same combinations in different orders
+        // ---
+
+        assert_combine(
+            &[JsonDiagnosticRenderedAnsi, JsonDiagnosticShort],
+            CargoMessageFormat::Json {
+                render_diagnostics: false,
+                short: true,
+                ansi: true,
+            },
+        );
+
+        assert_combine(
+            &[JsonDiagnosticShort, Json],
+            CargoMessageFormat::Json {
+                render_diagnostics: false,
+                short: true,
+                ansi: false,
+            },
+        );
+
+        assert_combine(
+            &[
+                JsonRenderDiagnostics,
+                JsonDiagnosticShort,
+                JsonDiagnosticRenderedAnsi,
+                Json,
+            ],
+            CargoMessageFormat::Json {
+                render_diagnostics: true,
+                short: true,
+                ansi: true,
+            },
+        );
+
+        // ---
+        // Error: conflicting base formats
+        // ---
+
+        assert_conflicting(&[Human, Json], "human", "json");
+        assert_conflicting(&[Human, Short], "human", "short");
+        assert_conflicting(&[Short, Json], "short", "json");
+        assert_conflicting(&[Json, Human], "json", "human");
+        assert_conflicting(&[Json, Short], "json", "short");
+        assert_conflicting(&[Short, Human], "short", "human");
+
+        // ---
+        // Error: JSON modifier with Human base
+        // ---
+
+        assert_modifier_with_non_json(
+            &[Human, JsonDiagnosticShort],
+            "`json-diagnostic-short`",
+            "human",
+        );
+        assert_modifier_with_non_json(
+            &[Human, JsonDiagnosticRenderedAnsi],
+            "`json-diagnostic-rendered-ansi`",
+            "human",
+        );
+        assert_modifier_with_non_json(
+            &[Human, JsonRenderDiagnostics],
+            "`json-render-diagnostics`",
+            "human",
+        );
+        assert_modifier_with_non_json(
+            &[Human, JsonDiagnosticShort, JsonDiagnosticRenderedAnsi],
+            "`json-diagnostic-short` and `json-diagnostic-rendered-ansi`",
+            "human",
+        );
+        assert_modifier_with_non_json(
+            &[Human, JsonDiagnosticShort, JsonRenderDiagnostics],
+            "`json-diagnostic-short` and `json-render-diagnostics`",
+            "human",
+        );
+        assert_modifier_with_non_json(
+            &[Human, JsonDiagnosticRenderedAnsi, JsonRenderDiagnostics],
+            "`json-diagnostic-rendered-ansi` and `json-render-diagnostics`",
+            "human",
+        );
+        assert_modifier_with_non_json(
+            &[
+                Human,
+                JsonDiagnosticShort,
+                JsonDiagnosticRenderedAnsi,
+                JsonRenderDiagnostics,
+            ],
+            "`json-diagnostic-short`, `json-diagnostic-rendered-ansi`, \
+             and `json-render-diagnostics`",
+            "human",
+        );
+
+        // ---
+        // Error: JSON modifier with Short base
+        // ---
+
+        assert_modifier_with_non_json(
+            &[Short, JsonDiagnosticShort],
+            "`json-diagnostic-short`",
+            "short",
+        );
+        assert_modifier_with_non_json(
+            &[Short, JsonDiagnosticRenderedAnsi],
+            "`json-diagnostic-rendered-ansi`",
+            "short",
+        );
+        assert_modifier_with_non_json(
+            &[Short, JsonRenderDiagnostics],
+            "`json-render-diagnostics`",
+            "short",
+        );
+        assert_modifier_with_non_json(
+            &[Short, JsonDiagnosticShort, JsonDiagnosticRenderedAnsi],
+            "`json-diagnostic-short` and `json-diagnostic-rendered-ansi`",
+            "short",
+        );
+        assert_modifier_with_non_json(
+            &[Short, JsonDiagnosticShort, JsonRenderDiagnostics],
+            "`json-diagnostic-short` and `json-render-diagnostics`",
+            "short",
+        );
+        assert_modifier_with_non_json(
+            &[Short, JsonDiagnosticRenderedAnsi, JsonRenderDiagnostics],
+            "`json-diagnostic-rendered-ansi` and `json-render-diagnostics`",
+            "short",
+        );
+        assert_modifier_with_non_json(
+            &[
+                Short,
+                JsonDiagnosticShort,
+                JsonDiagnosticRenderedAnsi,
+                JsonRenderDiagnostics,
+            ],
+            "`json-diagnostic-short`, `json-diagnostic-rendered-ansi`, \
+             and `json-render-diagnostics`",
+            "short",
+        );
+
+        // ---
+        // Error: duplicate options
+        // ---
+
+        assert_duplicate(&[Human, Human], "human");
+        assert_duplicate(&[Short, Short], "short");
+        assert_duplicate(&[Json, Json], "json");
+        assert_duplicate(
+            &[JsonDiagnosticShort, JsonDiagnosticShort],
+            "json-diagnostic-short",
+        );
+        assert_duplicate(
+            &[JsonDiagnosticRenderedAnsi, JsonDiagnosticRenderedAnsi],
+            "json-diagnostic-rendered-ansi",
+        );
+        assert_duplicate(
+            &[JsonRenderDiagnostics, JsonRenderDiagnostics],
+            "json-render-diagnostics",
+        );
+
+        // Duplicates with other options present.
+        assert_duplicate(&[Json, JsonDiagnosticShort, Json], "json");
+        assert_duplicate(
+            &[
+                JsonDiagnosticShort,
+                JsonDiagnosticRenderedAnsi,
+                JsonDiagnosticShort,
+            ],
+            "json-diagnostic-short",
+        );
+    }
+
+    #[test]
+    fn test_cargo_message_format_to_cargo_arg() {
+        // Test the domain model's to_cargo_arg method.
+        assert_eq!(
+            CargoMessageFormat::Human.cargo_arg(),
+            "json-render-diagnostics"
+        );
+
+        assert_eq!(
+            CargoMessageFormat::Json {
+                render_diagnostics: false,
+                short: false,
+                ansi: false
+            }
+            .cargo_arg(),
+            "json"
+        );
+        assert_eq!(
+            CargoMessageFormat::Json {
+                render_diagnostics: false,
+                short: true,
+                ansi: false
+            }
+            .cargo_arg(),
+            "json-diagnostic-short"
+        );
+        assert_eq!(
+            CargoMessageFormat::Json {
+                render_diagnostics: false,
+                short: false,
+                ansi: true
+            }
+            .cargo_arg(),
+            "json-diagnostic-rendered-ansi"
+        );
+        assert_eq!(
+            CargoMessageFormat::Json {
+                render_diagnostics: false,
+                short: true,
+                ansi: true
+            }
+            .cargo_arg(),
+            "json-diagnostic-short,json-diagnostic-rendered-ansi"
+        );
+        assert_eq!(
+            CargoMessageFormat::Json {
+                render_diagnostics: true,
+                short: false,
+                ansi: false
+            }
+            .cargo_arg(),
+            "json-render-diagnostics"
+        );
+        assert_eq!(
+            CargoMessageFormat::Json {
+                render_diagnostics: true,
+                short: true,
+                ansi: false
+            }
+            .cargo_arg(),
+            "json-render-diagnostics,json-diagnostic-short"
+        );
+        assert_eq!(
+            CargoMessageFormat::Json {
+                render_diagnostics: true,
+                short: false,
+                ansi: true
+            }
+            .cargo_arg(),
+            "json-render-diagnostics,json-diagnostic-rendered-ansi"
+        );
+        assert_eq!(
+            CargoMessageFormat::Json {
+                render_diagnostics: true,
+                short: true,
+                ansi: true
+            }
+            .cargo_arg(),
+            "json-render-diagnostics,json-diagnostic-short,json-diagnostic-rendered-ansi"
+        );
+    }
+
+    #[test]
+    fn test_cargo_message_format_predicates() {
+        // Test forward_json.
+        assert!(!CargoMessageFormat::Human.forward_json());
+        assert!(
+            CargoMessageFormat::Json {
+                render_diagnostics: false,
+                short: false,
+                ansi: false
+            }
+            .forward_json()
+        );
+    }
 }

--- a/cargo-nextest/src/dispatch/mod.rs
+++ b/cargo-nextest/src/dispatch/mod.rs
@@ -12,5 +12,6 @@ mod imp;
 mod utility;
 
 pub(crate) use clap_error::EarlyArgs;
+pub(crate) use core::CargoMessageFormatOpt;
 pub use imp::main_impl;
 pub(crate) use utility::ExtractOutputFormat;

--- a/fixtures/nextest-tests/src/lib.rs
+++ b/fixtures/nextest-tests/src/lib.rs
@@ -5,6 +5,29 @@
 
 use std::path::Path;
 
+/// This function is deprecated to generate a compiler warning.
+#[deprecated(
+    since = "0.1.0",
+    note = "this is a test warning for --cargo-message-format"
+)]
+pub fn deprecated_function() -> u32 {
+    42
+}
+
+/// This function calls the deprecated function to trigger the warning.
+pub fn trigger_warning() -> u32 {
+    #[allow(deprecated)]
+    deprecated_function()
+}
+
+/// This function generates a warning by calling the deprecated function
+/// without suppressing the warning.
+#[allow(dead_code)]
+fn generate_warning_for_tests() -> u32 {
+    // This call will generate a deprecation warning.
+    deprecated_function()
+}
+
 /// This method is called by integration tests and benchmarks to ensure that NEXTEST_BIN_EXE
 /// environment variables are properly set.
 pub fn test_execute_bin_helper() {

--- a/integration-tests/tests/integration/cargo_message_format.rs
+++ b/integration-tests/tests/integration/cargo_message_format.rs
@@ -1,0 +1,532 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Integration tests for `--cargo-message-format`.
+
+use crate::temp_project::TempProject;
+use integration_tests::{env::set_env_vars_for_test, nextest_cli::CargoNextestCli};
+use serde_json::Value;
+
+/// The deprecation warning message that should appear in compiler output.
+const DEPRECATION_WARNING_SUBSTRING: &str = "use of deprecated function `deprecated_function`";
+
+/// The note that appears in the warning about the deprecation reason.
+const DEPRECATION_NOTE_SUBSTRING: &str = "this is a test warning for --cargo-message-format";
+
+/// ANSI escape sequence prefix.
+const ANSI_ESCAPE: &str = "\x1b[";
+
+/// Tests human format (both default and explicit), with and without color.
+#[test]
+fn test_cargo_message_format_human() {
+    let env_info = set_env_vars_for_test();
+    let p = TempProject::new(&env_info).unwrap();
+
+    // Test 1: Default (no --cargo-message-format) without forced color.
+    let output = CargoNextestCli::for_test(&env_info)
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "list",
+            "--workspace",
+            "--all-targets",
+            "--message-format",
+            "json",
+        ])
+        .output();
+
+    let stderr = output.stderr_as_str();
+    let stdout = output.stdout_as_str();
+
+    // Human format: diagnostics should appear on stderr, rendered by Cargo.
+    assert!(
+        stderr.contains(DEPRECATION_WARNING_SUBSTRING),
+        "stderr should contain deprecation warning:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(DEPRECATION_NOTE_SUBSTRING),
+        "stderr should contain deprecation note:\n{stderr}"
+    );
+    // stdout should be the test list JSON, not cargo messages.
+    assert!(
+        !stdout.contains("compiler-message"),
+        "stdout should not contain compiler-message JSON:\n{stdout}"
+    );
+    // Without --color=always, ANSI codes should not be present (CARGO_TERM_COLOR=never is set).
+    assert!(
+        !stderr.contains(ANSI_ESCAPE),
+        "stderr should not contain ANSI codes without --color=always:\n{stderr}"
+    );
+
+    // Test 2: Explicit --cargo-message-format human with --color=always.
+    let output = CargoNextestCli::for_test(&env_info)
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "--color=always",
+            "list",
+            "--workspace",
+            "--all-targets",
+            "--message-format",
+            "json",
+            "--cargo-message-format",
+            "human",
+        ])
+        .output();
+
+    let stderr = output.stderr_as_str();
+
+    assert!(
+        stderr.contains(DEPRECATION_WARNING_SUBSTRING),
+        "stderr should contain deprecation warning:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(DEPRECATION_NOTE_SUBSTRING),
+        "stderr should contain deprecation note:\n{stderr}"
+    );
+    // With --color=always, ANSI codes should be present.
+    assert!(
+        stderr.contains(ANSI_ESCAPE),
+        "stderr should contain ANSI codes with --color=always:\n{stderr}"
+    );
+}
+
+/// Tests short format (alias for human).
+///
+/// `cargo test --message-format short` produces the same output as human, so
+/// `--cargo-message-format short` is treated as an alias for human.
+#[test]
+fn test_cargo_message_format_short() {
+    let env_info = set_env_vars_for_test();
+    let p = TempProject::new(&env_info).unwrap();
+
+    // Short is an alias for human - Cargo renders diagnostics to stderr.
+    let output = CargoNextestCli::for_test(&env_info)
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "list",
+            "--workspace",
+            "--all-targets",
+            "--message-format",
+            "json",
+            "--cargo-message-format",
+            "short",
+        ])
+        .output();
+
+    let stderr = output.stderr_as_str();
+    let stdout = output.stdout_as_str();
+
+    // Diagnostics should appear on stderr (rendered by Cargo).
+    assert!(
+        stderr.contains(DEPRECATION_WARNING_SUBSTRING),
+        "stderr should contain deprecation warning:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(DEPRECATION_NOTE_SUBSTRING),
+        "stderr should contain deprecation note:\n{stderr}"
+    );
+    // stdout should be the test list JSON, not cargo messages.
+    assert!(
+        !stdout.contains("compiler-message"),
+        "stdout should not contain compiler-message JSON:\n{stdout}"
+    );
+}
+
+/// Tests all JSON format variants and their combinations.
+#[test]
+fn test_cargo_message_format_json_variants() {
+    let env_info = set_env_vars_for_test();
+    let p = TempProject::new(&env_info).unwrap();
+
+    // Test 1: Plain json - compiler messages in stdout, nothing rendered to stderr.
+    let output = CargoNextestCli::for_test(&env_info)
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "list",
+            "--workspace",
+            "--all-targets",
+            "--message-format",
+            "json",
+            "--cargo-message-format",
+            "json",
+        ])
+        .output();
+
+    let stdout = output.stdout_as_str();
+    let stderr = output.stderr_as_str();
+
+    assert!(
+        !stderr.contains(DEPRECATION_WARNING_SUBSTRING),
+        "stderr should not contain deprecation warning in json format:\n{stderr}"
+    );
+
+    let compiler_messages = extract_compiler_messages(&stdout);
+    assert!(
+        !compiler_messages.is_empty(),
+        "stdout should contain compiler-message entries:\n{stdout}"
+    );
+    assert!(
+        has_deprecation_warning(&compiler_messages),
+        "should find deprecation warning in compiler messages"
+    );
+    // Plain json should not have ANSI in rendered field.
+    let rendered = get_rendered_from_messages(&compiler_messages);
+    assert!(
+        !rendered.iter().any(|r| r.contains(ANSI_ESCAPE)),
+        "plain json should not have ANSI codes in rendered field"
+    );
+
+    // Test 2: json-diagnostic-short - short diagnostics in JSON, no stderr rendering.
+    let output = CargoNextestCli::for_test(&env_info)
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "list",
+            "--workspace",
+            "--all-targets",
+            "--message-format",
+            "json",
+            "--cargo-message-format",
+            "json-diagnostic-short",
+        ])
+        .output();
+
+    let stdout = output.stdout_as_str();
+    let stderr = output.stderr_as_str();
+
+    assert!(
+        !stderr.contains(DEPRECATION_WARNING_SUBSTRING),
+        "stderr should not contain warning:\n{stderr}"
+    );
+
+    let compiler_messages = extract_compiler_messages(&stdout);
+    assert!(
+        !compiler_messages.is_empty(),
+        "stdout should contain compiler-message entries"
+    );
+    assert!(
+        has_deprecation_warning(&compiler_messages),
+        "should find deprecation warning"
+    );
+
+    // Test 3: json-diagnostic-rendered-ansi - ANSI codes in rendered field.
+    let output = CargoNextestCli::for_test(&env_info)
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "list",
+            "--workspace",
+            "--all-targets",
+            "--message-format",
+            "json",
+            "--cargo-message-format",
+            "json-diagnostic-rendered-ansi",
+        ])
+        .output();
+
+    let stdout = output.stdout_as_str();
+    let compiler_messages = extract_compiler_messages(&stdout);
+    assert!(
+        !compiler_messages.is_empty(),
+        "stdout should contain compiler-message entries"
+    );
+
+    let rendered = get_rendered_from_messages(&compiler_messages);
+    assert!(
+        rendered.iter().any(|r| r.contains(ANSI_ESCAPE)),
+        "json-diagnostic-rendered-ansi should have ANSI codes in rendered field"
+    );
+
+    // Test 4: json-render-diagnostics - Cargo renders to stderr, messages
+    // removed from stdout.
+    let output = CargoNextestCli::for_test(&env_info)
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "list",
+            "--workspace",
+            "--all-targets",
+            "--message-format",
+            "json",
+            "--cargo-message-format",
+            "json-render-diagnostics",
+        ])
+        .output();
+
+    let stdout = output.stdout_as_str();
+    let stderr = output.stderr_as_str();
+
+    assert!(
+        stderr.contains(DEPRECATION_WARNING_SUBSTRING),
+        "stderr should contain warning with json-render-diagnostics:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(DEPRECATION_NOTE_SUBSTRING),
+        "stderr should contain note with json-render-diagnostics:\n{stderr}"
+    );
+
+    let compiler_messages = extract_compiler_messages(&stdout);
+    assert!(
+        compiler_messages.is_empty(),
+        "stdout should not contain compiler-message entries with json-render-diagnostics:\n{stdout}"
+    );
+}
+
+/// Tests combined JSON modifiers.
+#[test]
+fn test_cargo_message_format_json_combined() {
+    let env_info = set_env_vars_for_test();
+    let p = TempProject::new(&env_info).unwrap();
+
+    // Test 1: json-diagnostic-short,json-diagnostic-rendered-ansi
+    let output = CargoNextestCli::for_test(&env_info)
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "list",
+            "--workspace",
+            "--all-targets",
+            "--message-format",
+            "json",
+            "--cargo-message-format",
+            "json-diagnostic-short,json-diagnostic-rendered-ansi",
+        ])
+        .output();
+
+    let stdout = output.stdout_as_str();
+    let stderr = output.stderr_as_str();
+
+    assert!(
+        !stderr.contains(DEPRECATION_WARNING_SUBSTRING),
+        "stderr should not contain warning:\n{stderr}"
+    );
+
+    let compiler_messages = extract_compiler_messages(&stdout);
+    assert!(
+        !compiler_messages.is_empty(),
+        "should have compiler messages"
+    );
+
+    let rendered = get_rendered_from_messages(&compiler_messages);
+    assert!(
+        rendered.iter().any(|r| r.contains(ANSI_ESCAPE)),
+        "combined short+ansi should have ANSI codes in rendered field"
+    );
+
+    // Test 2: json-render-diagnostics,json-diagnostic-short - renders short to stderr.
+    let output = CargoNextestCli::for_test(&env_info)
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "list",
+            "--workspace",
+            "--all-targets",
+            "--message-format",
+            "json",
+            "--cargo-message-format",
+            "json-render-diagnostics,json-diagnostic-short",
+        ])
+        .output();
+
+    let stdout = output.stdout_as_str();
+    let stderr = output.stderr_as_str();
+
+    assert!(
+        stderr.contains(DEPRECATION_WARNING_SUBSTRING),
+        "stderr should contain warning:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(DEPRECATION_NOTE_SUBSTRING),
+        "stderr should contain note:\n{stderr}"
+    );
+
+    let compiler_messages = extract_compiler_messages(&stdout);
+    assert!(
+        compiler_messages.is_empty(),
+        "stdout should not contain compiler-message entries"
+    );
+
+    // Test 3: All three modifiers combined.
+    let output = CargoNextestCli::for_test(&env_info)
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "list",
+            "--workspace",
+            "--all-targets",
+            "--message-format",
+            "json",
+            "--cargo-message-format",
+            "json-render-diagnostics,json-diagnostic-short,json-diagnostic-rendered-ansi",
+        ])
+        .output();
+
+    let stdout = output.stdout_as_str();
+    let stderr = output.stderr_as_str();
+
+    assert!(
+        stderr.contains(DEPRECATION_WARNING_SUBSTRING),
+        "stderr should contain warning:\n{stderr}"
+    );
+
+    let compiler_messages = extract_compiler_messages(&stdout);
+    assert!(
+        compiler_messages.is_empty(),
+        "stdout should not contain compiler-message entries"
+    );
+
+    // Test 4: Multiple --cargo-message-format arguments instead of comma-separated.
+    let output = CargoNextestCli::for_test(&env_info)
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "list",
+            "--workspace",
+            "--all-targets",
+            "--message-format",
+            "json",
+            "--cargo-message-format",
+            "json-diagnostic-short",
+            "--cargo-message-format",
+            "json-diagnostic-rendered-ansi",
+        ])
+        .output();
+
+    let stdout = output.stdout_as_str();
+
+    let compiler_messages = extract_compiler_messages(&stdout);
+    assert!(
+        !compiler_messages.is_empty(),
+        "should have compiler messages"
+    );
+
+    let rendered = get_rendered_from_messages(&compiler_messages);
+    assert!(
+        rendered.iter().any(|r| r.contains(ANSI_ESCAPE)),
+        "multiple args should work like comma-separated"
+    );
+}
+
+/// Tests error cases for invalid format combinations.
+#[test]
+fn test_cargo_message_format_errors() {
+    let env_info = set_env_vars_for_test();
+    let p = TempProject::new(&env_info).unwrap();
+
+    // Test 1: Conflicting base formats (human,json).
+    let output = CargoNextestCli::for_test(&env_info)
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "list",
+            "--cargo-message-format",
+            "human,json",
+        ])
+        .unchecked(true)
+        .output();
+
+    assert!(
+        !output.exit_status.success(),
+        "should fail with conflicting formats"
+    );
+    insta::assert_snapshot!(
+        "error_conflicting_base_formats",
+        redact_dynamic_fields(&output.stderr_as_str())
+    );
+
+    // Test 2: JSON modifier with non-JSON base (human,json-diagnostic-short).
+    let output = CargoNextestCli::for_test(&env_info)
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "list",
+            "--cargo-message-format",
+            "human,json-diagnostic-short",
+        ])
+        .unchecked(true)
+        .output();
+
+    assert!(
+        !output.exit_status.success(),
+        "should fail with JSON modifier on human format"
+    );
+    insta::assert_snapshot!(
+        "error_json_modifier_with_non_json",
+        redact_dynamic_fields(&output.stderr_as_str())
+    );
+
+    // Test 3: Duplicate option (json,json).
+    let output = CargoNextestCli::for_test(&env_info)
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "list",
+            "--cargo-message-format",
+            "json,json",
+        ])
+        .unchecked(true)
+        .output();
+
+    assert!(!output.exit_status.success(), "should fail with duplicate");
+    insta::assert_snapshot!(
+        "error_duplicate_option",
+        redact_dynamic_fields(&output.stderr_as_str())
+    );
+}
+
+/// Redacts dynamic fields from output for snapshot testing.
+///
+/// Filters out lines that vary between runs, such as:
+/// - "Blocking waiting for file lock"
+/// - "info: experimental features enabled"
+fn redact_dynamic_fields(output: &str) -> String {
+    output
+        .lines()
+        .filter(|line| {
+            !line.contains("Blocking waiting for file lock")
+                && !line.starts_with("info: experimental features enabled")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Extracts all compiler-message JSON objects from the output.
+fn extract_compiler_messages(output: &str) -> Vec<Value> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let value: Value = serde_json::from_str(line).ok()?;
+            if value.get("reason")?.as_str()? == "compiler-message" {
+                Some(value)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Checks if any compiler message contains a deprecation warning.
+fn has_deprecation_warning(messages: &[Value]) -> bool {
+    messages.iter().any(|msg| {
+        msg.get("message")
+            .and_then(|m| m.get("message"))
+            .and_then(|m| m.as_str())
+            .is_some_and(|s| s.contains("deprecated"))
+    })
+}
+
+/// Extracts the `rendered` field from all compiler messages.
+fn get_rendered_from_messages(messages: &[Value]) -> Vec<String> {
+    messages
+        .iter()
+        .filter_map(|msg| {
+            msg.get("message")?
+                .get("rendered")?
+                .as_str()
+                .map(|s| s.to_string())
+        })
+        .collect()
+}

--- a/integration-tests/tests/integration/main.rs
+++ b/integration-tests/tests/integration/main.rs
@@ -34,6 +34,7 @@ use nextest_metadata::{
 use std::{borrow::Cow, fs::File, io::Write};
 use target_spec::{Platform, summaries::TargetFeaturesSummary};
 
+mod cargo_message_format;
 mod fixtures;
 mod interceptor;
 mod large_alloc;

--- a/integration-tests/tests/integration/record_replay.rs
+++ b/integration-tests/tests/integration/record_replay.rs
@@ -1509,6 +1509,8 @@ fn test_rerun_all_pass() {
         cli_with_recording(&env_info, &p, &cache_dir, &user_config_path, Some(RERUN_ID))
             .args([
                 "run",
+                // This squelches Cargo warnings from stderr.
+                "--cargo-message-format=json",
                 "--rerun",
                 INITIAL_RUN_ID,
                 "-E",
@@ -1851,6 +1853,8 @@ fn test_rerun_tests_outstanding() {
         cli_with_recording(&env_info, &p, &cache_dir, &user_config_path, Some(RERUN_ID))
             .args([
                 "run",
+                // This squelches Cargo warnings from stderr.
+                "--cargo-message-format=json",
                 "--rerun",
                 INITIAL_RUN_ID,
                 "-E",

--- a/integration-tests/tests/integration/snapshots/integration__cargo_message_format__error_conflicting_base_formats.snap
+++ b/integration-tests/tests/integration/snapshots/integration__cargo_message_format__error_conflicting_base_formats.snap
@@ -1,0 +1,6 @@
+---
+source: integration-tests/tests/integration/cargo_message_format.rs
+expression: redact_dynamic_fields(&output.stderr_as_str())
+---
+error: invalid --cargo-message-format: conflicting message formats: `human` and `json` cannot be combined
+(only JSON modifiers like `json-diagnostic-short` can be combined)

--- a/integration-tests/tests/integration/snapshots/integration__cargo_message_format__error_duplicate_option.snap
+++ b/integration-tests/tests/integration/snapshots/integration__cargo_message_format__error_duplicate_option.snap
@@ -1,0 +1,5 @@
+---
+source: integration-tests/tests/integration/cargo_message_format.rs
+expression: redact_dynamic_fields(&output.stderr_as_str())
+---
+error: invalid --cargo-message-format: duplicate message format option: `json`

--- a/integration-tests/tests/integration/snapshots/integration__cargo_message_format__error_json_modifier_with_non_json.snap
+++ b/integration-tests/tests/integration/snapshots/integration__cargo_message_format__error_json_modifier_with_non_json.snap
@@ -1,0 +1,6 @@
+---
+source: integration-tests/tests/integration/cargo_message_format.rs
+expression: redact_dynamic_fields(&output.stderr_as_str())
+---
+error: invalid --cargo-message-format: cannot combine `json-diagnostic-short` with `human` format
+(JSON modifiers can only be used with JSON output)


### PR DESCRIPTION
Supporting this option is quite tricky because of the different number of possibilities involved. Luckily, `cargo nextest run --message-format short` doesn't have to be supported, because (unlike `cargo build --message-format short`) `cargo test --message-format short` appears to be an alias for `human`.