### PR TITLE
[nextest-runner] add support for reading archives

### DIFF
--- a/cargo-nextest/src/dispatch/core/tests.rs
+++ b/cargo-nextest/src/dispatch/core/tests.rs
@@ -173,6 +173,9 @@ fn test_argument_parsing() {
         "cargo nextest store info abc123",
         "cargo nextest store info -R latest",
         "cargo nextest store info --run-id abc123",
+        "cargo nextest store info archive.zip",
+        "cargo nextest store info /path/to/run.zip",
+        "cargo nextest store info -R ./relative/path.zip",
         "cargo nextest store export latest",
         "cargo nextest store export abc123",
         "cargo nextest store export -R latest",
@@ -181,6 +184,13 @@ fn test_argument_parsing() {
         "cargo nextest store export --run-id abc123 --archive-file /path/to/archive.zip",
         "cargo nextest store prune",
         "cargo nextest store prune --dry-run",
+        // ---
+        // Rerun with archive paths
+        // ---
+        "cargo nextest run --rerun archive.zip",
+        "cargo nextest run --rerun /path/to/run.zip",
+        "cargo nextest run -R ./relative/path.zip",
+        "cargo nextest run --rerun ../parent/run.zip",
     ];
 
     let invalid: &[(&'static str, ErrorKind)] = &[
@@ -362,6 +372,17 @@ fn test_argument_parsing() {
         (
             "cargo nextest store export latest --run-id abc123",
             ArgumentConflict,
+        ),
+        // store export does not accept archive paths (uses RunIdSelector, not
+        // RunIdOrArchiveSelector).
+        ("cargo nextest store export archive.zip", ValueValidation),
+        (
+            "cargo nextest store export /path/to/run.zip",
+            ValueValidation,
+        ),
+        (
+            "cargo nextest store export -R ./relative.zip",
+            ValueValidation,
         ),
     ];
 

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__debug_extract_portable_archive.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__debug_extract_portable_archive.snap
@@ -1,0 +1,12 @@
+---
+source: integration-tests/tests/integration/record_replay.rs
+expression: "redact_dynamic_fields(&extract_output.stdout_as_str(), temp_root)"
+---
+wrote [TEMP_DIR]/extracted/manifest.json (<size>)
+wrote [TEMP_DIR]/extracted/run.log.zst (<size>)
+wrote [TEMP_DIR]/extracted/store.zip (<size>)
+wrote [TEMP_DIR]/extracted/meta/cargo-metadata.json (<size>)
+wrote [TEMP_DIR]/extracted/meta/test-list.json (<size>)
+wrote [TEMP_DIR]/extracted/meta/record-opts.json (<size>)
+wrote [TEMP_DIR]/extracted/meta/stdout.dict (<size>)
+wrote [TEMP_DIR]/extracted/meta/stderr.dict (<size>)

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__error_replay_invalid_run_id.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__error_replay_invalid_run_id.snap
@@ -2,6 +2,6 @@
 source: integration-tests/tests/integration/record_replay.rs
 expression: "redact_dynamic_fields(&replay_invalid.stderr_as_str(), temp_root)"
 ---
-error: invalid value 'not-a-uuid!!!' for '--run-id <RUN_ID>': invalid run ID selector `not-a-uuid!!!`: expected `latest` or hex digits
+error: invalid value 'not-a-uuid!!!' for '--run-id <RUN_ID_OR_ARCHIVE>': invalid run ID selector `not-a-uuid!!!`: expected `latest`, hex digits, or a path ending in `.zip`
 
 For more information, try '--help'.

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__rerun_error_invalid_run_id.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__rerun_error_invalid_run_id.snap
@@ -2,6 +2,6 @@
 source: integration-tests/tests/integration/record_replay.rs
 expression: "redact_dynamic_fields(&invalid_output.stderr_as_str(), temp_root)"
 ---
-error: invalid value 'not-a-uuid!!!' for '--rerun <RUN_ID>': invalid run ID selector `not-a-uuid!!!`: expected `latest` or hex digits
+error: invalid value 'not-a-uuid!!!' for '--rerun <RUN_ID_OR_ARCHIVE>': invalid run ID selector `not-a-uuid!!!`: expected `latest`, hex digits, or a path ending in `.zip`
 
 For more information, try '--help'.

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__store_info_portable_archive.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__store_info_portable_archive.snap
@@ -1,0 +1,23 @@
+---
+source: integration-tests/tests/integration/record_replay.rs
+expression: "redact_dynamic_fields(&info_str, temp_root)"
+---
+Run 79000001-0000-0000-0000-000000000001
+
+  nextest version:  <version>
+  command:          '[EXE]' nextest --no-pager --manifest-path '[PATH]' --user-config-file '[PATH]' run -E 'test(=test_success) | test(=test_cwd)'
+  env:              CARGO_TERM_COLOR=never NEXTEST_CACHE_DIR='[PATH]' NEXTEST_SHOW_PROGRESS=counter NEXTEST_USER_CONFIG_FILE=none
+  status:           completed (exit code 0)
+  started at:       XXXX-XX-XX XX:XX:XX (<ago> ago)
+  last written at:  XXXX-XX-XX XX:XX:XX (<ago> ago)
+  duration:         <duration>
+  replayable:       yes
+
+  tests:
+    passed:         2
+
+  sizes:            compressed  uncompressed  entries
+    log                 <size>        <size>       34
+    store               <size>        <size>        7
+                    ──────────  ────────────  ───────
+    total               <size>        <size>       41

--- a/nextest-runner/src/record/format.rs
+++ b/nextest-runner/src/record/format.rs
@@ -673,17 +673,25 @@ impl IdOrdItem for RerunTestSuiteInfo {
 // Archive format types
 // ---
 
-// Archive file names.
-pub(super) static STORE_ZIP_FILE_NAME: &str = "store.zip";
-pub(super) static RUN_LOG_FILE_NAME: &str = "run.log.zst";
+/// File name for the store archive.
+pub static STORE_ZIP_FILE_NAME: &str = "store.zip";
+
+/// File name for the run log.
+pub static RUN_LOG_FILE_NAME: &str = "run.log.zst";
 
 // Paths within the zip archive.
-pub(super) static CARGO_METADATA_JSON_PATH: &str = "meta/cargo-metadata.json";
-pub(super) static TEST_LIST_JSON_PATH: &str = "meta/test-list.json";
-pub(super) static RECORD_OPTS_JSON_PATH: &str = "meta/record-opts.json";
-pub(super) static RERUN_INFO_JSON_PATH: &str = "meta/rerun-info.json";
-pub(super) static STDOUT_DICT_PATH: &str = "meta/stdout.dict";
-pub(super) static STDERR_DICT_PATH: &str = "meta/stderr.dict";
+/// Path to cargo metadata within the store archive.
+pub static CARGO_METADATA_JSON_PATH: &str = "meta/cargo-metadata.json";
+/// Path to the test list within the store archive.
+pub static TEST_LIST_JSON_PATH: &str = "meta/test-list.json";
+/// Path to record options within the store archive.
+pub static RECORD_OPTS_JSON_PATH: &str = "meta/record-opts.json";
+/// Path to rerun info within the store archive (only present for reruns).
+pub static RERUN_INFO_JSON_PATH: &str = "meta/rerun-info.json";
+/// Path to the stdout dictionary within the store archive.
+pub static STDOUT_DICT_PATH: &str = "meta/stdout.dict";
+/// Path to the stderr dictionary within the store archive.
+pub static STDERR_DICT_PATH: &str = "meta/stderr.dict";
 
 // ---
 // Portable archive format types
@@ -720,7 +728,6 @@ impl PortableArchiveFormatVersion {
 
     /// Checks if an archive with version `self` can be read by a reader that
     /// supports `supported`.
-    #[cfg_attr(not(test), expect(dead_code))]
     pub fn check_readable_by(
         self,
         supported: Self,
@@ -801,8 +808,8 @@ pub const PORTABLE_ARCHIVE_FORMAT_VERSION: PortableArchiveFormatVersion =
         PortableArchiveFormatMinorVersion::new(0),
     );
 
-/// File name for the manifest in a portable archive.
-pub(super) static PORTABLE_MANIFEST_FILE_NAME: &str = "manifest.json";
+/// File name for the manifest within a portable archive.
+pub static PORTABLE_MANIFEST_FILE_NAME: &str = "manifest.json";
 
 /// The manifest for a portable archive.
 ///
@@ -810,20 +817,33 @@ pub(super) static PORTABLE_MANIFEST_FILE_NAME: &str = "manifest.json";
 /// zip file for sharing and import.
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
-pub(super) struct PortableManifest {
+pub(crate) struct PortableManifest {
     /// The format version of this portable archive.
-    pub(super) format_version: PortableArchiveFormatVersion,
+    pub(crate) format_version: PortableArchiveFormatVersion,
     /// The run metadata.
     pub(super) run: RecordedRun,
 }
 
 impl PortableManifest {
     /// Creates a new manifest for the given run.
-    pub(super) fn new(run: &RecordedRunInfo) -> Self {
+    pub(crate) fn new(run: &RecordedRunInfo) -> Self {
         Self {
             format_version: PORTABLE_ARCHIVE_FORMAT_VERSION,
             run: RecordedRun::from(run),
         }
+    }
+
+    /// Returns the run info extracted from this manifest.
+    pub(crate) fn run_info(&self) -> RecordedRunInfo {
+        RecordedRunInfo::from(self.run.clone())
+    }
+
+    /// Returns the store format version from the run metadata.
+    pub(crate) fn store_format_version(&self) -> StoreFormatVersion {
+        StoreFormatVersion::new(
+            self.run.store_format_version,
+            self.run.store_format_minor_version,
+        )
     }
 }
 

--- a/nextest-runner/src/record/mod.rs
+++ b/nextest-runner/src/record/mod.rs
@@ -48,19 +48,25 @@ pub use display::{
     DisplayRunList, RunListAlignment, Styles,
 };
 pub use format::{
-    OutputDict, RerunInfo, RerunRootInfo, RunsJsonFormatVersion, RunsJsonWritePermission,
-    STORE_FORMAT_VERSION, StoreFormatMajorVersion, StoreFormatMinorVersion, StoreFormatVersion,
-    StoreVersionIncompatibility,
+    CARGO_METADATA_JSON_PATH, OutputDict, PORTABLE_MANIFEST_FILE_NAME,
+    PortableArchiveFormatVersion, PortableArchiveVersionIncompatibility, RECORD_OPTS_JSON_PATH,
+    RERUN_INFO_JSON_PATH, RUN_LOG_FILE_NAME, RerunInfo, RerunRootInfo, RunsJsonFormatVersion,
+    RunsJsonWritePermission, STDERR_DICT_PATH, STDOUT_DICT_PATH, STORE_FORMAT_VERSION,
+    STORE_ZIP_FILE_NAME, StoreFormatMajorVersion, StoreFormatMinorVersion, StoreFormatVersion,
+    StoreVersionIncompatibility, TEST_LIST_JSON_PATH,
 };
-pub use portable::{PortableArchiveResult, PortableArchiveWriter};
-pub use reader::{RecordEventIter, RecordReader};
+pub use portable::{
+    ExtractOuterFileResult, PortableArchive, PortableArchiveEventIter, PortableArchiveResult,
+    PortableArchiveRunLog, PortableArchiveWriter, PortableStoreReader,
+};
+pub use reader::{RecordEventIter, RecordReader, StoreReader};
 pub use recorder::{RunRecorder, StoreSizes};
 pub use replay::{
     ReplayContext, ReplayConversionError, ReplayHeader, ReplayReporter, ReplayReporterBuilder,
 };
 pub use rerun::ComputedRerunInfo;
 pub use retention::{PruneKind, PrunePlan, PruneResult, RecordRetentionPolicy};
-pub use run_id_index::{RunIdIndex, RunIdSelector, ShortestRunIdPrefix};
+pub use run_id_index::{RunIdIndex, RunIdOrArchiveSelector, RunIdSelector, ShortestRunIdPrefix};
 pub use session::{
     RecordFinalizeResult, RecordFinalizeWarning, RecordSession, RecordSessionConfig,
     RecordSessionSetup,
@@ -68,8 +74,8 @@ pub use session::{
 pub use store::{
     CompletedRunStats, ComponentSizes, ExclusiveLockedRunStore, NonReplayableReason,
     RecordedRunInfo, RecordedRunStatus, RecordedSizes, ReplayabilityStatus, ResolveRunIdResult,
-    RunStore, RunStoreSnapshot, SharedLockedRunStore, SnapshotWithReplayability, StoreRunsDir,
-    StressCompletedRunStats,
+    RunFilesExist, RunStore, RunStoreSnapshot, SharedLockedRunStore, SnapshotWithReplayability,
+    StoreRunFiles, StoreRunsDir, StressCompletedRunStats,
 };
 pub use summary::{
     CoreEventKind, OutputEventKind, OutputFileName, RecordOpts, StressConditionSummary,

--- a/nextest-runner/src/record/portable.rs
+++ b/nextest-runner/src/record/portable.rs
@@ -1,26 +1,51 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-//! Portable archive creation for recorded runs.
+//! Portable archive creation and reading for recorded runs.
 //!
 //! A portable archive packages a single recorded run into a self-contained zip
 //! file that can be shared and imported elsewhere.
+//!
+//! # Reading portable archives
+//!
+//! Use [`PortableArchive::open`] to open a portable archive for reading. The
+//! archive contains:
+//!
+//! - A manifest (`manifest.json`) with run metadata.
+//! - A run log (`run.log.zst`) with test events.
+//! - An inner store (`store.zip`) with metadata and test output.
+//!
+//! To read from the inner store, call [`PortableArchive::open_store`] to get a
+//! [`PortableStoreReader`] that implements [`StoreReader`](super::reader::StoreReader).
 
 use super::{
     format::{
-        PORTABLE_MANIFEST_FILE_NAME, PortableManifest, RUN_LOG_FILE_NAME, STORE_ZIP_FILE_NAME,
+        CARGO_METADATA_JSON_PATH, OutputDict, PORTABLE_ARCHIVE_FORMAT_VERSION,
+        PORTABLE_MANIFEST_FILE_NAME, PortableManifest, RECORD_OPTS_JSON_PATH, RERUN_INFO_JSON_PATH,
+        RUN_LOG_FILE_NAME, RerunInfo, STDERR_DICT_PATH, STDOUT_DICT_PATH, STORE_FORMAT_VERSION,
+        STORE_ZIP_FILE_NAME, TEST_LIST_JSON_PATH,
     },
-    store::{RecordedRunInfo, StoreRunsDir},
+    reader::{StoreReader, decompress_with_dict},
+    store::{RecordedRunInfo, RunFilesExist, StoreRunsDir},
+    summary::{RecordOpts, TestEventSummary, ZipStoreOutput},
 };
-use crate::errors::PortableArchiveError;
+use crate::{
+    errors::{PortableArchiveError, PortableArchiveReadError, RecordReadError},
+    user_config::elements::MAX_MAX_OUTPUT_SIZE,
+};
 use atomicwrites::{AtomicFile, OverwriteBehavior};
 use camino::{Utf8Path, Utf8PathBuf};
 use countio::Counter;
+use debug_ignore::DebugIgnore;
+use nextest_metadata::TestListSummary;
 use std::{
     fs::File,
-    io::{self, Write},
+    io::{self, BufRead, BufReader, Read, Write},
 };
-use zip::{CompressionMethod, ZipWriter, write::SimpleFileOptions};
+use zip::{
+    CompressionMethod, ZipArchive, ZipWriter, read::ZipFileSeek, result::ZipError,
+    write::SimpleFileOptions,
+};
 
 /// Result of writing a portable archive.
 #[derive(Debug)]
@@ -29,6 +54,18 @@ pub struct PortableArchiveResult {
     pub path: Utf8PathBuf,
     /// The total size of the archive in bytes.
     pub size: u64,
+}
+
+/// Result of extracting a file from a portable archive.
+#[derive(Debug)]
+pub struct ExtractOuterFileResult {
+    /// The number of bytes written to the output file.
+    pub bytes_written: u64,
+    /// If the file size exceeded the limit threshold, contains the claimed size.
+    ///
+    /// This is informational only; the full file is always extracted regardless
+    /// of whether this is `Some`.
+    pub exceeded_limit: Option<u64>,
 }
 
 /// Writer to create a portable archive from a recorded run.
@@ -190,6 +227,520 @@ impl<'a> PortableArchiveWriter<'a> {
     }
 }
 
+// ---
+// Portable archive reading
+// ---
+
+/// A portable archive opened for reading.
+#[derive(Debug)]
+pub struct PortableArchive {
+    archive_path: Utf8PathBuf,
+    manifest: PortableManifest,
+    outer_archive: ZipArchive<File>,
+}
+
+impl RunFilesExist for PortableArchive {
+    fn store_zip_exists(&self) -> bool {
+        self.outer_archive
+            .index_for_name(STORE_ZIP_FILE_NAME)
+            .is_some()
+    }
+
+    fn run_log_exists(&self) -> bool {
+        self.outer_archive
+            .index_for_name(RUN_LOG_FILE_NAME)
+            .is_some()
+    }
+}
+
+impl PortableArchive {
+    /// Opens a portable archive from a file path.
+    ///
+    /// Validates the format and store versions on open to fail fast if the
+    /// archive cannot be read by this version of nextest.
+    pub fn open(path: &Utf8Path) -> Result<Self, PortableArchiveReadError> {
+        let file = File::open(path).map_err(|error| PortableArchiveReadError::OpenArchive {
+            path: path.to_owned(),
+            error,
+        })?;
+
+        let mut outer_archive =
+            ZipArchive::new(file).map_err(|error| PortableArchiveReadError::ReadArchive {
+                path: path.to_owned(),
+                error,
+            })?;
+
+        // Read and parse the manifest.
+        let manifest_bytes =
+            read_outer_file(&mut outer_archive, PORTABLE_MANIFEST_FILE_NAME, path)?;
+        let manifest: PortableManifest =
+            serde_json::from_slice(&manifest_bytes).map_err(|error| {
+                PortableArchiveReadError::ParseManifest {
+                    path: path.to_owned(),
+                    error,
+                }
+            })?;
+
+        // Validate format version.
+        if let Err(incompatibility) = manifest
+            .format_version
+            .check_readable_by(PORTABLE_ARCHIVE_FORMAT_VERSION)
+        {
+            return Err(PortableArchiveReadError::UnsupportedFormatVersion {
+                path: path.to_owned(),
+                found: manifest.format_version,
+                supported: PORTABLE_ARCHIVE_FORMAT_VERSION,
+                incompatibility,
+            });
+        }
+
+        // Validate store format version.
+        let store_version = manifest.store_format_version();
+        if let Err(incompatibility) = store_version.check_readable_by(STORE_FORMAT_VERSION) {
+            return Err(PortableArchiveReadError::UnsupportedStoreFormatVersion {
+                path: path.to_owned(),
+                found: store_version,
+                supported: STORE_FORMAT_VERSION,
+                incompatibility,
+            });
+        }
+
+        Ok(Self {
+            archive_path: path.to_owned(),
+            manifest,
+            outer_archive,
+        })
+    }
+
+    /// Returns the path to the archive file.
+    pub fn archive_path(&self) -> &Utf8Path {
+        &self.archive_path
+    }
+
+    /// Returns run info extracted from the manifest.
+    pub fn run_info(&self) -> RecordedRunInfo {
+        self.manifest.run_info()
+    }
+
+    /// Reads the run log into memory and returns it as an owned struct.
+    ///
+    /// The returned [`PortableArchiveRunLog`] can be used to iterate over events
+    /// independently of this archive, avoiding borrow conflicts with
+    /// [`open_store`](Self::open_store).
+    pub fn read_run_log(&mut self) -> Result<PortableArchiveRunLog, PortableArchiveReadError> {
+        let run_log_bytes = read_outer_file(
+            &mut self.outer_archive,
+            RUN_LOG_FILE_NAME,
+            &self.archive_path,
+        )?;
+        Ok(PortableArchiveRunLog {
+            archive_path: self.archive_path.clone(),
+            run_log_bytes,
+        })
+    }
+
+    /// Extracts a file from the outer archive to a path, streaming directly.
+    ///
+    /// This avoids loading the entire file into memory. The full file is always
+    /// extracted regardless of size.
+    ///
+    /// If `check_limit` is true, the result will indicate whether the file
+    /// exceeded [`MAX_MAX_OUTPUT_SIZE`]. This is informational only and does
+    /// not affect extraction.
+    pub fn extract_outer_file_to_path(
+        &mut self,
+        file_name: &'static str,
+        output_path: &Utf8Path,
+        check_limit: bool,
+    ) -> Result<ExtractOuterFileResult, PortableArchiveReadError> {
+        extract_outer_file_to_path(
+            &mut self.outer_archive,
+            file_name,
+            &self.archive_path,
+            output_path,
+            check_limit,
+        )
+    }
+
+    /// Opens the inner store.zip for reading.
+    ///
+    /// The returned reader borrows from this archive and implements [`StoreReader`].
+    pub fn open_store(&mut self) -> Result<PortableStoreReader<'_>, PortableArchiveReadError> {
+        // Use by_name_seek to get a seekable handle to store.zip.
+        let store_handle = self
+            .outer_archive
+            .by_name_seek(STORE_ZIP_FILE_NAME)
+            .map_err(|error| match error {
+                ZipError::FileNotFound => PortableArchiveReadError::MissingFile {
+                    path: self.archive_path.clone(),
+                    file_name: STORE_ZIP_FILE_NAME,
+                },
+                _ => PortableArchiveReadError::ReadArchive {
+                    path: self.archive_path.clone(),
+                    error,
+                },
+            })?;
+
+        let store_archive = ZipArchive::new(store_handle).map_err(|error| {
+            PortableArchiveReadError::ReadArchive {
+                path: self.archive_path.clone(),
+                error,
+            }
+        })?;
+
+        Ok(PortableStoreReader {
+            archive_path: &self.archive_path,
+            store_archive,
+            stdout_dict: None,
+            stderr_dict: None,
+        })
+    }
+}
+
+/// Reads a file from the outer archive into memory, with size limits.
+fn read_outer_file(
+    archive: &mut ZipArchive<File>,
+    file_name: &'static str,
+    archive_path: &Utf8Path,
+) -> Result<Vec<u8>, PortableArchiveReadError> {
+    let limit = MAX_MAX_OUTPUT_SIZE.as_u64();
+    let file = archive.by_name(file_name).map_err(|error| match error {
+        ZipError::FileNotFound => PortableArchiveReadError::MissingFile {
+            path: archive_path.to_owned(),
+            file_name,
+        },
+        _ => PortableArchiveReadError::ReadArchive {
+            path: archive_path.to_owned(),
+            error,
+        },
+    })?;
+
+    let claimed_size = file.size();
+    if claimed_size > limit {
+        return Err(PortableArchiveReadError::FileTooLarge {
+            path: archive_path.to_owned(),
+            file_name,
+            size: claimed_size,
+            limit,
+        });
+    }
+
+    let capacity = usize::try_from(claimed_size).unwrap_or(usize::MAX);
+    let mut contents = Vec::with_capacity(capacity);
+
+    file.take(limit)
+        .read_to_end(&mut contents)
+        .map_err(|error| PortableArchiveReadError::ReadArchive {
+            path: archive_path.to_owned(),
+            error: ZipError::Io(error),
+        })?;
+
+    Ok(contents)
+}
+
+/// Extracts a file from the outer archive to a path, streaming directly.
+fn extract_outer_file_to_path(
+    archive: &mut ZipArchive<File>,
+    file_name: &'static str,
+    archive_path: &Utf8Path,
+    output_path: &Utf8Path,
+    check_limit: bool,
+) -> Result<ExtractOuterFileResult, PortableArchiveReadError> {
+    let limit = MAX_MAX_OUTPUT_SIZE.as_u64();
+    let mut file = archive.by_name(file_name).map_err(|error| match error {
+        ZipError::FileNotFound => PortableArchiveReadError::MissingFile {
+            path: archive_path.to_owned(),
+            file_name,
+        },
+        _ => PortableArchiveReadError::ReadArchive {
+            path: archive_path.to_owned(),
+            error,
+        },
+    })?;
+
+    let claimed_size = file.size();
+    let exceeded_limit = if check_limit && claimed_size > limit {
+        Some(claimed_size)
+    } else {
+        None
+    };
+
+    let mut output_file =
+        File::create(output_path).map_err(|error| PortableArchiveReadError::ExtractFile {
+            archive_path: archive_path.to_owned(),
+            file_name,
+            output_path: output_path.to_owned(),
+            error,
+        })?;
+
+    let bytes_written = io::copy(&mut file, &mut output_file).map_err(|error| {
+        PortableArchiveReadError::ExtractFile {
+            archive_path: archive_path.to_owned(),
+            file_name,
+            output_path: output_path.to_owned(),
+            error,
+        }
+    })?;
+
+    Ok(ExtractOuterFileResult {
+        bytes_written,
+        exceeded_limit,
+    })
+}
+
+/// The run log from a portable archive, read into memory.
+///
+/// This struct owns the run log bytes and can create event iterators
+/// independently of the [`PortableArchive`] it came from.
+#[derive(Debug)]
+pub struct PortableArchiveRunLog {
+    archive_path: Utf8PathBuf,
+    run_log_bytes: Vec<u8>,
+}
+
+impl PortableArchiveRunLog {
+    /// Returns an iterator over events from the run log.
+    pub fn events(&self) -> Result<PortableArchiveEventIter<'_>, RecordReadError> {
+        // The run log is zstd-compressed JSON Lines. Use with_buffer since the
+        // data is already in memory (no need for Decoder's internal BufReader).
+        let decoder =
+            zstd::stream::Decoder::with_buffer(&self.run_log_bytes[..]).map_err(|error| {
+                RecordReadError::OpenRunLog {
+                    path: self.archive_path.join(RUN_LOG_FILE_NAME),
+                    error,
+                }
+            })?;
+        Ok(PortableArchiveEventIter {
+            // BufReader is still needed for read_line().
+            reader: DebugIgnore(BufReader::new(decoder)),
+            line_buf: String::new(),
+            line_number: 0,
+        })
+    }
+}
+
+/// Iterator over events from a portable archive's run log.
+#[derive(Debug)]
+pub struct PortableArchiveEventIter<'a> {
+    reader: DebugIgnore<BufReader<zstd::stream::Decoder<'static, &'a [u8]>>>,
+    line_buf: String,
+    line_number: usize,
+}
+
+impl Iterator for PortableArchiveEventIter<'_> {
+    type Item = Result<TestEventSummary<ZipStoreOutput>, RecordReadError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            self.line_buf.clear();
+            self.line_number += 1;
+
+            match self.reader.read_line(&mut self.line_buf) {
+                Ok(0) => return None,
+                Ok(_) => {
+                    let trimmed = self.line_buf.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    return Some(serde_json::from_str(trimmed).map_err(|error| {
+                        RecordReadError::ParseEvent {
+                            line_number: self.line_number,
+                            error,
+                        }
+                    }));
+                }
+                Err(error) => {
+                    return Some(Err(RecordReadError::ReadRunLog {
+                        line_number: self.line_number,
+                        error,
+                    }));
+                }
+            }
+        }
+    }
+}
+
+/// Reader for the inner store.zip within a portable archive.
+///
+/// Borrows from [`PortableArchive`] and implements [`StoreReader`].
+pub struct PortableStoreReader<'a> {
+    archive_path: &'a Utf8Path,
+    store_archive: ZipArchive<ZipFileSeek<'a, File>>,
+    /// Cached stdout dictionary loaded from the archive.
+    stdout_dict: Option<Vec<u8>>,
+    /// Cached stderr dictionary loaded from the archive.
+    stderr_dict: Option<Vec<u8>>,
+}
+
+impl std::fmt::Debug for PortableStoreReader<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PortableStoreReader")
+            .field("archive_path", &self.archive_path)
+            .field("stdout_dict", &self.stdout_dict.as_ref().map(|d| d.len()))
+            .field("stderr_dict", &self.stderr_dict.as_ref().map(|d| d.len()))
+            .finish_non_exhaustive()
+    }
+}
+
+impl PortableStoreReader<'_> {
+    /// Reads a file from the store archive as bytes, with size limit.
+    fn read_store_file(&mut self, file_name: &str) -> Result<Vec<u8>, RecordReadError> {
+        let limit = MAX_MAX_OUTPUT_SIZE.as_u64();
+        let file = self.store_archive.by_name(file_name).map_err(|error| {
+            RecordReadError::ReadArchiveFile {
+                file_name: file_name.to_string(),
+                error,
+            }
+        })?;
+
+        let claimed_size = file.size();
+        if claimed_size > limit {
+            return Err(RecordReadError::FileTooLarge {
+                file_name: file_name.to_string(),
+                size: claimed_size,
+                limit,
+            });
+        }
+
+        let capacity = usize::try_from(claimed_size).unwrap_or(usize::MAX);
+        let mut contents = Vec::with_capacity(capacity);
+
+        file.take(limit)
+            .read_to_end(&mut contents)
+            .map_err(|error| RecordReadError::Decompress {
+                file_name: file_name.to_string(),
+                error,
+            })?;
+
+        let actual_size = contents.len() as u64;
+        if actual_size != claimed_size {
+            return Err(RecordReadError::SizeMismatch {
+                file_name: file_name.to_string(),
+                claimed_size,
+                actual_size,
+            });
+        }
+
+        Ok(contents)
+    }
+
+    /// Returns the dictionary bytes for the given output file name, if known.
+    fn get_dict_for_output(&self, file_name: &str) -> Option<&[u8]> {
+        match OutputDict::for_output_file_name(file_name) {
+            OutputDict::Stdout => Some(
+                self.stdout_dict
+                    .as_ref()
+                    .expect("load_dictionaries must be called first"),
+            ),
+            OutputDict::Stderr => Some(
+                self.stderr_dict
+                    .as_ref()
+                    .expect("load_dictionaries must be called first"),
+            ),
+            OutputDict::None => None,
+        }
+    }
+}
+
+impl StoreReader for PortableStoreReader<'_> {
+    fn read_cargo_metadata(&mut self) -> Result<String, RecordReadError> {
+        let bytes = self.read_store_file(CARGO_METADATA_JSON_PATH)?;
+        String::from_utf8(bytes).map_err(|e| RecordReadError::Decompress {
+            file_name: CARGO_METADATA_JSON_PATH.to_string(),
+            error: std::io::Error::new(std::io::ErrorKind::InvalidData, e),
+        })
+    }
+
+    fn read_test_list(&mut self) -> Result<TestListSummary, RecordReadError> {
+        let bytes = self.read_store_file(TEST_LIST_JSON_PATH)?;
+        serde_json::from_slice(&bytes).map_err(|error| RecordReadError::DeserializeMetadata {
+            file_name: TEST_LIST_JSON_PATH.to_string(),
+            error,
+        })
+    }
+
+    fn read_record_opts(&mut self) -> Result<RecordOpts, RecordReadError> {
+        let bytes = self.read_store_file(RECORD_OPTS_JSON_PATH)?;
+        serde_json::from_slice(&bytes).map_err(|error| RecordReadError::DeserializeMetadata {
+            file_name: RECORD_OPTS_JSON_PATH.to_string(),
+            error,
+        })
+    }
+
+    fn read_rerun_info(&mut self) -> Result<Option<RerunInfo>, RecordReadError> {
+        match self.read_store_file(RERUN_INFO_JSON_PATH) {
+            Ok(bytes) => {
+                let info = serde_json::from_slice(&bytes).map_err(|error| {
+                    RecordReadError::DeserializeMetadata {
+                        file_name: RERUN_INFO_JSON_PATH.to_string(),
+                        error,
+                    }
+                })?;
+                Ok(Some(info))
+            }
+            Err(RecordReadError::ReadArchiveFile {
+                error: ZipError::FileNotFound,
+                ..
+            }) => {
+                // File doesn't exist; this is not a rerun.
+                Ok(None)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    fn load_dictionaries(&mut self) -> Result<(), RecordReadError> {
+        self.stdout_dict = Some(self.read_store_file(STDOUT_DICT_PATH)?);
+        self.stderr_dict = Some(self.read_store_file(STDERR_DICT_PATH)?);
+        Ok(())
+    }
+
+    fn read_output(&mut self, file_name: &str) -> Result<Vec<u8>, RecordReadError> {
+        let path = format!("out/{file_name}");
+        let compressed = self.read_store_file(&path)?;
+        let limit = MAX_MAX_OUTPUT_SIZE.as_u64();
+
+        let dict_bytes = self.get_dict_for_output(file_name).ok_or_else(|| {
+            RecordReadError::UnknownOutputType {
+                file_name: file_name.to_owned(),
+            }
+        })?;
+
+        decompress_with_dict(&compressed, dict_bytes, limit).map_err(|error| {
+            RecordReadError::Decompress {
+                file_name: path,
+                error,
+            }
+        })
+    }
+
+    fn extract_file_to_path(
+        &mut self,
+        store_path: &str,
+        output_path: &Utf8Path,
+    ) -> Result<u64, RecordReadError> {
+        let mut file = self.store_archive.by_name(store_path).map_err(|error| {
+            RecordReadError::ReadArchiveFile {
+                file_name: store_path.to_owned(),
+                error,
+            }
+        })?;
+
+        let mut output_file =
+            File::create(output_path).map_err(|error| RecordReadError::ExtractFile {
+                store_path: store_path.to_owned(),
+                output_path: output_path.to_owned(),
+                error,
+            })?;
+
+        io::copy(&mut file, &mut output_file).map_err(|error| RecordReadError::ExtractFile {
+            store_path: store_path.to_owned(),
+            output_path: output_path.to_owned(),
+            error,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -197,13 +748,14 @@ mod tests {
         format::{PORTABLE_ARCHIVE_FORMAT_VERSION, STORE_FORMAT_VERSION},
         store::{CompletedRunStats, RecordedRunStatus, RecordedSizes},
     };
+    use camino_tempfile::Utf8TempDir;
     use chrono::Local;
     use quick_junit::ReportUuid;
     use semver::Version;
     use std::{collections::BTreeMap, io::Read};
     use zip::ZipArchive;
 
-    fn create_test_run_dir(run_id: ReportUuid) -> (camino_tempfile::Utf8TempDir, Utf8PathBuf) {
+    fn create_test_run_dir(run_id: ReportUuid) -> (Utf8TempDir, Utf8PathBuf) {
         let temp_dir = camino_tempfile::tempdir().expect("create temp dir");
         let runs_dir = temp_dir.path().to_owned();
         let run_dir = runs_dir.join(run_id.to_string());


### PR DESCRIPTION
Add support for the `-R` option to `cargo nextest run`, `cargo nextest store info`, and `cargo nextest replay`.

I've already used this to debug a test leak on Windows (#3020).