### PR TITLE
[nextest-runner] add newtypes for format versions, add major + minor store versions

### DIFF
--- a/cargo-nextest/src/dispatch/core/replay.rs
+++ b/cargo-nextest/src/dispatch/core/replay.rs
@@ -20,7 +20,7 @@ use nextest_runner::{
     pager::PagedOutput,
     record::{
         RecordReader, ReplayContext, ReplayHeader, ReplayReporterBuilder, RunIdSelector, RunStore,
-        format::RECORD_FORMAT_VERSION, records_cache_dir,
+        STORE_FORMAT_VERSION, records_cache_dir,
     },
     reporter::ReporterOutput,
     user_config::{UserConfig, UserConfigExperimental},
@@ -141,11 +141,13 @@ pub(crate) fn exec_replay(
         .expect("we just looked up the run ID so the info should be available");
 
     // Check the store format version before opening the archive.
-    if run_info.store_format_version != RECORD_FORMAT_VERSION {
-        return Err(ExpectedError::UnsupportedStoreFormatVersion {
+    if let Err(incompatibility) = run_info
+        .store_format_version
+        .check_readable_by(STORE_FORMAT_VERSION)
+    {
+        return Err(ExpectedError::StoreVersionIncompatible {
             run_id,
-            found: run_info.store_format_version,
-            supported: RECORD_FORMAT_VERSION,
+            incompatibility,
         });
     }
 

--- a/internal-tools/zstd-dict/src/main.rs
+++ b/internal-tools/zstd-dict/src/main.rs
@@ -13,7 +13,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use clap::{Parser, Subcommand};
 use color_eyre::eyre::{Context, Result, bail};
 use etcetera::BaseStrategy;
-use nextest_runner::record::format::OutputDict;
+use nextest_runner::record::OutputDict;
 use std::{
     collections::HashMap,
     fs::{self, File},

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     helpers::{display_exited_with, dylib_path_envvar},
     indenter::{DisplayIndented, indented},
-    record::{RecordedRunInfo, RunIdIndex},
+    record::{RecordedRunInfo, RunIdIndex, RunsJsonFormatVersion},
     redact::Redactor,
     reuse_build::{ArchiveFormat, ArchiveStep},
     target_runner::PlatformRunnerSource,
@@ -2144,9 +2144,9 @@ pub enum RunStoreError {
     )]
     FormatVersionTooNew {
         /// The format version in the file.
-        file_version: u32,
+        file_version: RunsJsonFormatVersion,
         /// The maximum version this nextest can write.
-        max_supported_version: u32,
+        max_supported_version: RunsJsonFormatVersion,
     },
 }
 

--- a/nextest-runner/src/record/AGENTS.md
+++ b/nextest-runner/src/record/AGENTS.md
@@ -50,9 +50,9 @@ A zstd-compressed JSON Lines file containing test events. Each line is a `TestEv
 
 There are **two separate format versions**:
 
-1. **`RUNS_JSON_FORMAT_VERSION`** (in `format.rs`): Version of `runs.json.zst` format. Controls backward/forward compatibility of the run list itself.
+1. **`RUNS_JSON_FORMAT_VERSION`** (in `format.rs`): Version of `runs.json.zst` format (newtype `RunsJsonFormatVersion`). Controls backward/forward compatibility of the run list itself.
 
-2. **`RECORD_FORMAT_VERSION`** (in `format.rs`): Version of the archive format (`store.zip` + `run.log.zst`). Stored per-run in `runs.json.zst` to enable checking replayability without opening archives.
+2. **`STORE_FORMAT_VERSION`** (in `format.rs`): Version of the archive format (`store.zip` + `run.log.zst`). This is a `StoreFormatVersion` combining a major version (`StoreFormatMajorVersion`) and minor version (`StoreFormatMinorVersion`). Stored per-run in `runs.json.zst` to enable checking replayability without opening archives. Major versions must match exactly; minor versions allow reading older archives but not newer ones.
 
 **Write permission model**: When reading `runs.json.zst`, if its format version is newer than the current nextest supports, writing is denied (`RunsJsonWritePermission::Denied`) to prevent data loss. Reading always proceeds.
 

--- a/nextest-runner/src/record/mod.rs
+++ b/nextest-runner/src/record/mod.rs
@@ -27,7 +27,7 @@
 mod cache_dir;
 pub mod dicts;
 mod display;
-pub mod format;
+mod format;
 mod reader;
 mod recorder;
 pub mod replay;
@@ -38,7 +38,7 @@ mod session;
 mod store;
 mod summary;
 #[cfg(test)]
-pub(crate) mod test_helpers;
+mod test_helpers;
 mod tree;
 
 pub use cache_dir::{NEXTEST_CACHE_DIR_ENV, records_cache_dir};
@@ -46,7 +46,11 @@ pub use display::{
     DisplayPrunePlan, DisplayPruneResult, DisplayRecordedRunInfo, DisplayRecordedRunInfoDetailed,
     DisplayRunList, RunListAlignment, Styles,
 };
-pub use format::RunsJsonWritePermission;
+pub use format::{
+    OutputDict, RerunInfo, RerunRootInfo, RunsJsonFormatVersion, RunsJsonWritePermission,
+    STORE_FORMAT_VERSION, StoreFormatMajorVersion, StoreFormatMinorVersion, StoreFormatVersion,
+    StoreVersionIncompatibility,
+};
 pub use reader::{RecordEventIter, RecordReader};
 pub use recorder::{RunRecorder, StoreSizes};
 pub use replay::{

--- a/nextest-runner/src/record/retention.rs
+++ b/nextest-runner/src/record/retention.rs
@@ -404,7 +404,7 @@ mod tests {
     use super::*;
     use crate::record::{
         CompletedRunStats, ComponentSizes, RecordedRunStatus, RecordedSizes,
-        format::RECORD_FORMAT_VERSION,
+        format::STORE_FORMAT_VERSION,
     };
     use chrono::{FixedOffset, TimeZone};
     use semver::Version;
@@ -419,7 +419,7 @@ mod tests {
         // For simplicity in tests, put all size in the store component.
         RecordedRunInfo {
             run_id,
-            store_format_version: RECORD_FORMAT_VERSION,
+            store_format_version: STORE_FORMAT_VERSION,
             nextest_version: Version::new(0, 1, 0),
             started_at,
             last_written_at: started_at,

--- a/nextest-runner/src/record/run_id_index.rs
+++ b/nextest-runner/src/record/run_id_index.rs
@@ -285,7 +285,7 @@ pub enum PrefixResolutionError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::record::{RecordedRunStatus, RecordedSizes, format::RECORD_FORMAT_VERSION};
+    use crate::record::{RecordedRunStatus, RecordedSizes, format::STORE_FORMAT_VERSION};
     use chrono::TimeZone;
     use semver::Version;
     use std::collections::BTreeMap;
@@ -298,7 +298,7 @@ mod tests {
             .unwrap();
         RecordedRunInfo {
             run_id,
-            store_format_version: RECORD_FORMAT_VERSION,
+            store_format_version: STORE_FORMAT_VERSION,
             nextest_version: Version::new(0, 1, 0),
             started_at,
             last_written_at: started_at,

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__display__tests__replayability_format_too_new.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__display__tests__replayability_format_too_new.snap
@@ -9,7 +9,7 @@ Run 550e8400-e29b-41d4-a716-446655440000
   started at:       2024-06-15 10:30:00 +00:00 (10d ago)
   last written at:  2024-06-15 10:30:00 +00:00 (10d ago)
   duration:         1.000s
-  replayable:       no: store format version 5 is newer than supported (version 1)
+  replayable:       no: store format version incompatible: major version 5 differs from supported version 1
 
   tests:
     passed:         100

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_cancelled.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_cancelled.snap
@@ -5,6 +5,7 @@ expression: json
 {
   "run-id": "550e8400-e29b-41d4-a716-446655440000",
   "store-format-version": 1,
+  "store-format-minor-version": 0,
   "nextest-version": "0.9.111",
   "started-at": "2024-12-19T14:22:33-08:00",
   "last-written-at": "2024-12-19T22:22:33Z",

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_completed.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_completed.snap
@@ -5,6 +5,7 @@ expression: json
 {
   "run-id": "550e8400-e29b-41d4-a716-446655440000",
   "store-format-version": 1,
+  "store-format-minor-version": 0,
   "nextest-version": "0.9.111",
   "started-at": "2024-12-19T14:22:33-08:00",
   "last-written-at": "2024-12-19T22:22:33Z",

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_incomplete.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_incomplete.snap
@@ -5,6 +5,7 @@ expression: json
 {
   "run-id": "550e8400-e29b-41d4-a716-446655440000",
   "store-format-version": 1,
+  "store-format-minor-version": 0,
   "nextest-version": "0.9.111",
   "started-at": "2024-12-19T14:22:33-08:00",
   "last-written-at": "2024-12-19T22:22:33Z",

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_cancelled.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_cancelled.snap
@@ -5,6 +5,7 @@ expression: json
 {
   "run-id": "550e8400-e29b-41d4-a716-446655440000",
   "store-format-version": 1,
+  "store-format-minor-version": 0,
   "nextest-version": "0.9.111",
   "started-at": "2024-12-19T14:22:33-08:00",
   "last-written-at": "2024-12-19T22:22:33Z",

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_completed.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_completed.snap
@@ -5,6 +5,7 @@ expression: json
 {
   "run-id": "550e8400-e29b-41d4-a716-446655440000",
   "store-format-version": 1,
+  "store-format-minor-version": 0,
   "nextest-version": "0.9.111",
   "started-at": "2024-12-19T14:22:33-08:00",
   "last-written-at": "2024-12-19T22:22:33Z",


### PR DESCRIPTION
It's easy to mix these versions up, so add newtypes around them.

Also bump the runs.json format version to 2, since we're adding a new optional field.