### PR TITLE
[integration-tests] replace [TEMP_DIR] properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,6 +1882,7 @@ dependencies = [
  "libc",
  "libtest-mimic",
  "nextest-metadata",
+ "nextest-runner",
  "nextest-workspace-hack",
  "num_threads",
  "pathdiff",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -77,6 +77,7 @@ insta.workspace = true
 itertools.workspace = true
 libtest-mimic.workspace = true
 nextest-metadata.workspace = true
+nextest-runner.workspace = true
 pathdiff.workspace = true
 quick-junit.workspace = true
 regex.workspace = true

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_verbose_empty.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_verbose_empty.snap
@@ -2,4 +2,4 @@
 source: integration-tests/tests/integration/record_replay.rs
 expression: "redact_dynamic_fields(&list_verbose_empty.stdout_as_str(), temp_root)"
 ---
-store: [TEMP_DIR]
+store: [TEMP_DIR]/cache/projects/[TEMP_DIR_ENCODED][SEP_ENCODED]src/records

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_verbose_multiple_runs.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_verbose_multiple_runs.snap
@@ -2,7 +2,7 @@
 source: integration-tests/tests/integration/record_replay.rs
 expression: "redact_dynamic_fields(&list_verbose_output.stdout_as_str(), temp_root)"
 ---
-store: [TEMP_DIR]
+store: [TEMP_DIR]/cache/projects/[TEMP_DIR_ENCODED][SEP_ENCODED]src/records
 
 3 recorded runs:
 

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_verbose_single_run.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__store_list_verbose_single_run.snap
@@ -2,7 +2,7 @@
 source: integration-tests/tests/integration/record_replay.rs
 expression: "redact_dynamic_fields(&list_verbose_output.stdout_as_str(), temp_root)"
 ---
-store: [TEMP_DIR]
+store: [TEMP_DIR]/cache/projects/[TEMP_DIR_ENCODED][SEP_ENCODED]src/records
 
 1 recorded run:
 

--- a/nextest-runner/src/record/mod.rs
+++ b/nextest-runner/src/record/mod.rs
@@ -42,7 +42,7 @@ mod summary;
 mod test_helpers;
 mod tree;
 
-pub use cache_dir::{NEXTEST_CACHE_DIR_ENV, records_cache_dir};
+pub use cache_dir::{NEXTEST_CACHE_DIR_ENV, encode_workspace_path, records_cache_dir};
 pub use display::{
     DisplayPrunePlan, DisplayPruneResult, DisplayRecordedRunInfo, DisplayRecordedRunInfoDetailed,
     DisplayRunList, RunListAlignment, Styles,


### PR DESCRIPTION
Thought I could get away with not doing a proper replacement here, but it is quite valuable for upcoming tests for [TEMP_DIR] to be replaced properly.