### PR TITLE
[integration-tests] use an outer job object for Windows tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,6 +1896,8 @@ dependencies = [
  "target-spec-miette",
  "tokio",
  "whoami",
+ "win32job",
+ "windows-sys 0.61.2",
  "zip",
  "zstd",
 ]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -91,5 +91,9 @@ zip = { workspace = true, features = ["zstd"] }
 [target.'cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd", target_os = "macos", target_os = "ios", target_os = "aix"))'.dev-dependencies]
 num_threads.workspace = true
 
+[target.'cfg(windows)'.dependencies]
+win32job.workspace = true
+windows-sys = { workspace = true, features = ["Win32_System_JobObjects"] }
+
 [lints]
 workspace = true


### PR DESCRIPTION
I realized that handle inheritance is causing screwups here I'm pretty sure. Let's use an outer job object so the background processes created by nextest exit properly.

I guess a better fix is to do this via a teardown script, but we don't have those yet.