### PR TITLE
[nextest-runner] show information about output not being captured in replay mode

### DIFF
--- a/integration-tests/tests/integration/snapshots/integration__record_replay__replay_output_not_captured.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__replay_output_not_captured.snap
@@ -1,0 +1,16 @@
+---
+source: integration-tests/tests/integration/record_replay.rs
+assertion_line: 2727
+expression: "redact_dynamic_fields(&stdout, temp_root)"
+---
+   Replaying recorded run 50000001-0000-0000-0000-000000000001
+     Started XXXX-XX-XX XX:XX:XX  status: completed
+────────────
+ Nextest run ID 50000001-0000-0000-0000-000000000001 with nextest profile: default
+    Starting 1 test across 7 binaries (29 tests skipped)
+        FAIL [ duration] (1/1) nextest-tests::basic test_failure_assert
+    (output not captured)
+
+────────────
+     Summary [ duration] 1 test run: 0 passed, 1 failed, 29 skipped
+        FAIL [ duration] (1/1) nextest-tests::basic test_failure_assert

--- a/nextest-runner/src/record/recorder.rs
+++ b/nextest-runner/src/record/recorder.rs
@@ -631,8 +631,15 @@ impl SerializeTestEventContext<'_> {
     ) -> Result<ChildOutputDescription<ZipStoreOutput>, StoreWriterError> {
         match output {
             ChildOutputDescription::Split { stdout, stderr } => Ok(ChildOutputDescription::Split {
-                stdout: Some(self.write_single_output(stdout.as_ref(), OutputKind::Stdout)?),
-                stderr: Some(self.write_single_output(stderr.as_ref(), OutputKind::Stderr)?),
+                // Preserve None (not captured) vs Some (captured, possibly empty).
+                stdout: stdout
+                    .as_ref()
+                    .map(|o| self.write_single_output(Some(o), OutputKind::Stdout))
+                    .transpose()?,
+                stderr: stderr
+                    .as_ref()
+                    .map(|o| self.write_single_output(Some(o), OutputKind::Stderr))
+                    .transpose()?,
             }),
             ChildOutputDescription::Combined { output } => Ok(ChildOutputDescription::Combined {
                 output: self.write_single_output(Some(output), OutputKind::Combined)?,

--- a/nextest-runner/src/record/replay.rs
+++ b/nextest-runner/src/record/replay.rs
@@ -576,9 +576,9 @@ use crate::{
         store::{RecordedRunInfo, RecordedRunStatus},
     },
     reporter::{
-        DisplayReporter, DisplayReporterBuilder, FinalStatusLevel, MaxProgressRunning,
-        ReporterOutput, ShowProgress, ShowTerminalProgress, StatusLevel, StatusLevels,
-        TestOutputDisplay,
+        DisplayReporter, DisplayReporterBuilder, DisplayerKind, FinalStatusLevel,
+        MaxProgressRunning, ReporterOutput, ShowProgress, ShowTerminalProgress, StatusLevel,
+        StatusLevels, TestOutputDisplay,
     },
 };
 use chrono::{DateTime, FixedOffset};
@@ -743,6 +743,7 @@ impl ReplayReporterBuilder {
             // For replay, we don't show terminal progress (OSC 9;4 codes) since
             // we're replaying events, not running live tests.
             show_term_progress: ShowTerminalProgress::No,
+            displayer_kind: DisplayerKind::Replay,
         }
         .build(output);
 

--- a/nextest-runner/src/reporter/displayer/imp.rs
+++ b/nextest-runner/src/reporter/displayer/imp.rs
@@ -56,6 +56,19 @@ use std::{
     time::Duration,
 };
 
+/// The kind of displayer being used.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum DisplayerKind {
+    /// The displayer is showing output from a live test run.
+    Live,
+
+    /// The displayer is showing output from a replay of a recorded run.
+    ///
+    /// In replay mode, if output was not captured during the original run, a
+    /// helpful message is displayed to indicate this.
+    Replay,
+}
+
 pub(crate) struct DisplayReporterBuilder {
     pub(crate) mode: NextestRunMode,
     pub(crate) default_filter: CompiledDefaultFilter,
@@ -70,6 +83,7 @@ pub(crate) struct DisplayReporterBuilder {
     pub(crate) no_output_indent: bool,
     pub(crate) max_progress_running: MaxProgressRunning,
     pub(crate) show_term_progress: ShowTerminalProgress,
+    pub(crate) displayer_kind: DisplayerKind,
 }
 
 impl DisplayReporterBuilder {
@@ -166,6 +180,7 @@ impl DisplayReporterBuilder {
                     force_success_output,
                     force_failure_output,
                     force_exec_fail_output,
+                    self.displayer_kind,
                 ),
                 final_outputs: DebugIgnore(Vec::new()),
                 run_id_unique_prefix: None,
@@ -2666,6 +2681,7 @@ mod tests {
             no_output_indent: false,
             max_progress_running: MaxProgressRunning::default(),
             show_term_progress: ShowTerminalProgress::No,
+            displayer_kind: DisplayerKind::Live,
         };
 
         let output = ReporterOutput::Writer {

--- a/nextest-runner/src/reporter/displayer/snapshots/nextest_runner__reporter__displayer__unit_output__tests__live_neither_captured.snap
+++ b/nextest-runner/src/reporter/displayer/snapshots/nextest_runner__reporter__displayer__unit_output__tests__live_neither_captured.snap
@@ -1,0 +1,5 @@
+---
+source: nextest-runner/src/reporter/displayer/unit_output.rs
+expression: buf
+---
+

--- a/nextest-runner/src/reporter/displayer/snapshots/nextest_runner__reporter__displayer__unit_output__tests__replay_both_captured.snap
+++ b/nextest-runner/src/reporter/displayer/snapshots/nextest_runner__reporter__displayer__unit_output__tests__replay_both_captured.snap
@@ -1,0 +1,8 @@
+---
+source: nextest-runner/src/reporter/displayer/unit_output.rs
+expression: buf
+---
+--- STDOUT ---
+    stdout output
+--- STDERR ---
+    stderr output

--- a/nextest-runner/src/reporter/displayer/snapshots/nextest_runner__reporter__displayer__unit_output__tests__replay_neither_captured.snap
+++ b/nextest-runner/src/reporter/displayer/snapshots/nextest_runner__reporter__displayer__unit_output__tests__replay_neither_captured.snap
@@ -1,0 +1,5 @@
+---
+source: nextest-runner/src/reporter/displayer/unit_output.rs
+expression: buf
+---
+    (output not captured)

--- a/nextest-runner/src/reporter/displayer/snapshots/nextest_runner__reporter__displayer__unit_output__tests__replay_stderr_not_captured.snap
+++ b/nextest-runner/src/reporter/displayer/snapshots/nextest_runner__reporter__displayer__unit_output__tests__replay_stderr_not_captured.snap
@@ -1,0 +1,7 @@
+---
+source: nextest-runner/src/reporter/displayer/unit_output.rs
+expression: buf
+---
+--- STDOUT ---
+    stdout output
+    (stderr not captured)

--- a/nextest-runner/src/reporter/displayer/snapshots/nextest_runner__reporter__displayer__unit_output__tests__replay_stdout_not_captured.snap
+++ b/nextest-runner/src/reporter/displayer/snapshots/nextest_runner__reporter__displayer__unit_output__tests__replay_stdout_not_captured.snap
@@ -1,0 +1,7 @@
+---
+source: nextest-runner/src/reporter/displayer/unit_output.rs
+expression: buf
+---
+    (stdout not captured)
+--- STDERR ---
+    stderr output

--- a/nextest-runner/src/reporter/imp.rs
+++ b/nextest-runner/src/reporter/imp.rs
@@ -6,7 +6,7 @@
 //! The main structure in this module is [`TestReporter`].
 
 use super::{
-    FinalStatusLevel, MaxProgressRunning, StatusLevel, TestOutputDisplay,
+    DisplayerKind, FinalStatusLevel, MaxProgressRunning, StatusLevel, TestOutputDisplay,
     displayer::{DisplayReporter, DisplayReporterBuilder, ShowTerminalProgress, StatusLevels},
 };
 use crate::{
@@ -195,6 +195,7 @@ impl ReporterBuilder {
             no_output_indent: self.no_output_indent,
             max_progress_running: self.max_progress_running,
             show_term_progress,
+            displayer_kind: DisplayerKind::Live,
         }
         .build(output);
 

--- a/nextest-runner/src/reporter/mod.rs
+++ b/nextest-runner/src/reporter/mod.rs
@@ -15,7 +15,7 @@ pub mod structured;
 #[cfg(test)]
 pub(crate) mod test_helpers;
 
-pub(crate) use displayer::{DisplayReporter, DisplayReporterBuilder, StatusLevels};
+pub(crate) use displayer::{DisplayReporter, DisplayReporterBuilder, DisplayerKind, StatusLevels};
 pub use displayer::{
     FinalStatusLevel, MaxProgressRunning, ShowProgress, ShowTerminalProgress, StatusLevel,
     TestOutputDisplay,


### PR DESCRIPTION
Not showing anything at all can be confusing, so show a line of text.

Also fix recordings to correctly be `None`. This is a case we missed. Luckily this doesn't need a format bump because old nextest can read new data and vice versa.