### PR TITLE
[nextest-runner] store records in the state dir, not the cache dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,14 +139,14 @@ jobs:
       - name: Test with locally built nextest
         shell: bash
         env:
-          NEXTEST_CACHE_DIR: ${{ runner.temp }}/nextest-cache
+          NEXTEST_STATE_DIR: ${{ runner.temp }}/nextest-state
         run: cargo local-nt run --profile ci --user-config-file "$RUNNER_TEMP/nextest-config/config.toml"
 
       - name: Create portable archive from recorded run
         # Run this step even if the test step fails.
         if: "!cancelled()"
         env:
-          NEXTEST_CACHE_DIR: ${{ runner.temp }}/nextest-cache
+          NEXTEST_STATE_DIR: ${{ runner.temp }}/nextest-state
         shell: bash
         run: |
           cargo local-nt store export latest \

--- a/cargo-nextest/src/dispatch/core/replay.rs
+++ b/cargo-nextest/src/dispatch/core/replay.rs
@@ -21,7 +21,7 @@ use nextest_runner::{
     record::{
         PortableRecording, RecordReader, RecordedRunInfo, ReplayContext, ReplayHeader,
         ReplayReporterBuilder, RunIdIndex, RunIdOrRecordingSelector, RunStore,
-        STORE_FORMAT_VERSION, StoreReader, TestEventSummary, ZipStoreOutput, records_cache_dir,
+        STORE_FORMAT_VERSION, StoreReader, TestEventSummary, ZipStoreOutput, records_state_dir,
     },
     reporter::ReporterOutput,
     user_config::{UserConfig, UserConfigExperimental},
@@ -139,10 +139,10 @@ pub(crate) fn exec_replay(
                 workspace_root: workspace_root.to_owned(),
             })?;
 
-    let cache_dir = records_cache_dir(workspace_root)
-        .map_err(|err| ExpectedError::RecordCacheDirNotFound { err })?;
+    let state_dir = records_state_dir(workspace_root)
+        .map_err(|err| ExpectedError::RecordStateDirNotFound { err })?;
 
-    let store = RunStore::new(&cache_dir).map_err(|err| ExpectedError::RecordSetupError { err })?;
+    let store = RunStore::new(&state_dir).map_err(|err| ExpectedError::RecordSetupError { err })?;
     let snapshot = store
         .lock_shared()
         .map_err(|err| ExpectedError::RecordSetupError { err })?

--- a/cargo-nextest/src/dispatch/core/run.rs
+++ b/cargo-nextest/src/dispatch/core/run.rs
@@ -32,7 +32,7 @@ use nextest_runner::{
     record::{
         ComputedRerunInfo, PortableRecording, RecordOpts, RecordReader, RecordRetentionPolicy,
         RecordSession, RecordSessionConfig, RerunRootInfo, RunIdOrRecordingSelector, RunIdSelector,
-        RunStore, STORE_FORMAT_VERSION, Styles as RecordStyles, records_cache_dir,
+        RunStore, STORE_FORMAT_VERSION, Styles as RecordStyles, records_state_dir,
     },
     reporter::{
         FinalStatusLevel, MaxProgressRunning, ReporterBuilder, ShowTerminalProgress, StatusLevel,
@@ -1424,11 +1424,11 @@ impl App {
         &self,
         run_id_selector: &RunIdSelector,
     ) -> Result<(RerunState, ComputedRerunInfo), ExpectedError> {
-        let cache_dir = records_cache_dir(&self.base.workspace_root)
-            .map_err(|err| ExpectedError::RecordCacheDirNotFound { err })?;
+        let state_dir = records_state_dir(&self.base.workspace_root)
+            .map_err(|err| ExpectedError::RecordStateDirNotFound { err })?;
 
         let store =
-            RunStore::new(&cache_dir).map_err(|err| ExpectedError::RecordSetupError { err })?;
+            RunStore::new(&state_dir).map_err(|err| ExpectedError::RecordSetupError { err })?;
 
         // First, acquire a shared lock to resolve the run ID and read the
         // parent run.

--- a/cargo-nextest/src/errors.rs
+++ b/cargo-nextest/src/errors.rs
@@ -9,8 +9,8 @@ use nextest_metadata::NextestExitCode;
 use nextest_runner::{
     config::core::{ConfigExperimental, ToolName},
     errors::{
-        CacheDirError, PortableRecordingError, PortableRecordingReadError, RecordReadError,
-        RecordSetupError, RunIdResolutionError, RunStoreError, TestListFromSummaryError,
+        PortableRecordingError, PortableRecordingReadError, RecordReadError, RecordSetupError,
+        RunIdResolutionError, RunStoreError, StateDirError, TestListFromSummaryError,
         UserConfigError, *,
     },
     helpers::{format_interceptor_too_many_tests, plural},
@@ -355,10 +355,10 @@ pub enum ExpectedError {
         config_file: Utf8PathBuf,
         missing: Vec<ConfigExperimental>,
     },
-    #[error("could not determine cache directory for recording")]
-    RecordCacheDirNotFound {
+    #[error("could not determine state directory for recording")]
+    RecordStateDirNotFound {
         #[source]
-        err: CacheDirError,
+        err: StateDirError,
     },
     #[error("error setting up recording")]
     RecordSetupError {
@@ -641,7 +641,7 @@ impl ExpectedError {
             | Self::ConfigExperimentalFeaturesNotEnabled { .. } => {
                 NextestExitCode::EXPERIMENTAL_FEATURE_NOT_ENABLED
             }
-            Self::RecordCacheDirNotFound { .. }
+            Self::RecordStateDirNotFound { .. }
             | Self::RecordSetupError { .. }
             | Self::RecordSessionSetupError { .. }
             | Self::RunIdResolutionError { .. }
@@ -1208,8 +1208,8 @@ impl ExpectedError {
                 );
                 None
             }
-            Self::RecordCacheDirNotFound { err } => {
-                error!("could not determine cache directory for recording test runs");
+            Self::RecordStateDirNotFound { err } => {
+                error!("could not determine state directory for recording test runs");
                 Some(err as &dyn Error)
             }
             Self::RecordSetupError { err } => {

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__store_info_missing_run_log.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__store_info_missing_run_log.snap
@@ -6,7 +6,7 @@ Run 81000001-0000-0000-0000-000000000001
 
   nextest version:  <version>
   command:          '[EXE]' nextest --no-pager --manifest-path '[PATH]' --user-config-file '[PATH]' run -E 'test(=test_success)'
-  env:              CARGO_TERM_COLOR=never NEXTEST_CACHE_DIR='[PATH]' NEXTEST_SHOW_PROGRESS=counter NEXTEST_USER_CONFIG_FILE=none
+  env:              CARGO_TERM_COLOR=never NEXTEST_SHOW_PROGRESS=counter NEXTEST_STATE_DIR='[PATH]' NEXTEST_USER_CONFIG_FILE=none
   status:           completed (exit code 0)
   started at:       XXXX-XX-XX XX:XX:XX (<ago> ago)
   last written at:  XXXX-XX-XX XX:XX:XX (<ago> ago)

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__store_info_missing_store_zip.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__store_info_missing_store_zip.snap
@@ -6,7 +6,7 @@ Run 80000001-0000-0000-0000-000000000001
 
   nextest version:  <version>
   command:          '[EXE]' nextest --no-pager --manifest-path '[PATH]' --user-config-file '[PATH]' run -E 'test(=test_success)'
-  env:              CARGO_TERM_COLOR=never NEXTEST_CACHE_DIR='[PATH]' NEXTEST_SHOW_PROGRESS=counter NEXTEST_USER_CONFIG_FILE=none
+  env:              CARGO_TERM_COLOR=never NEXTEST_SHOW_PROGRESS=counter NEXTEST_STATE_DIR='[PATH]' NEXTEST_USER_CONFIG_FILE=none
   status:           completed (exit code 0)
   started at:       XXXX-XX-XX XX:XX:XX (<ago> ago)
   last written at:  XXXX-XX-XX XX:XX:XX (<ago> ago)

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__store_info_portable_recording.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__store_info_portable_recording.snap
@@ -6,7 +6,7 @@ Run 79000001-0000-0000-0000-000000000001
 
   nextest version:  <version>
   command:          '[EXE]' nextest --no-pager --manifest-path '[PATH]' --user-config-file '[PATH]' run -E 'test(=test_success) | test(=test_cwd)'
-  env:              CARGO_TERM_COLOR=never NEXTEST_CACHE_DIR='[PATH]' NEXTEST_SHOW_PROGRESS=counter NEXTEST_USER_CONFIG_FILE=none
+  env:              CARGO_TERM_COLOR=never NEXTEST_SHOW_PROGRESS=counter NEXTEST_STATE_DIR='[PATH]' NEXTEST_USER_CONFIG_FILE=none
   status:           completed (exit code 0)
   started at:       XXXX-XX-XX XX:XX:XX (<ago> ago)
   last written at:  XXXX-XX-XX XX:XX:XX (<ago> ago)

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__store_info_single_run.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__store_info_single_run.snap
@@ -6,7 +6,7 @@ Run 10000001-0000-0000-0000-000000000001
 
   nextest version:  <version>
   command:          '[EXE]' nextest --no-pager --manifest-path '[PATH]' --user-config-file '[PATH]' run --workspace --all-targets
-  env:              CARGO_TERM_COLOR=never NEXTEST_CACHE_DIR='[PATH]' NEXTEST_SHOW_PROGRESS=counter NEXTEST_USER_CONFIG_FILE=none
+  env:              CARGO_TERM_COLOR=never NEXTEST_SHOW_PROGRESS=counter NEXTEST_STATE_DIR='[PATH]' NEXTEST_USER_CONFIG_FILE=none
   status:           completed (exit code 100)
   started at:       XXXX-XX-XX XX:XX:XX (<ago> ago)
   last written at:  XXXX-XX-XX XX:XX:XX (<ago> ago)

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -2012,7 +2012,7 @@ pub enum RunStoreError {
 
     /// Timed out waiting to acquire a file lock.
     #[error(
-        "timed out acquiring lock on `{path}` after {timeout_secs}s (is the cache directory \
+        "timed out acquiring lock on `{path}` after {timeout_secs}s (is the state directory \
          on a networked filesystem?)"
     )]
     FileLockTimeout {
@@ -2230,18 +2230,18 @@ pub enum RecordReporterError {
     },
 }
 
-/// An error determining the cache directory for recordings.
+/// An error determining the state directory for recordings.
 #[derive(Debug, Error)]
-pub enum CacheDirError {
+pub enum StateDirError {
     /// The platform base strategy could not be determined.
     ///
     /// This typically means the platform doesn't support standard directory layouts.
     #[error("could not determine platform base directory strategy")]
     BaseDirStrategy(#[source] HomeDirError),
 
-    /// The platform cache directory path is not valid UTF-8.
-    #[error("platform cache directory is not valid UTF-8: {path:?}")]
-    CacheDirNotUtf8 {
+    /// The platform state directory path is not valid UTF-8.
+    #[error("platform state directory is not valid UTF-8: {path:?}")]
+    StateDirNotUtf8 {
         /// The path that was not valid UTF-8.
         path: PathBuf,
     },
@@ -2260,9 +2260,9 @@ pub enum CacheDirError {
 /// An error during recording session setup.
 #[derive(Debug, Error)]
 pub enum RecordSetupError {
-    /// The platform cache directory could not be determined.
-    #[error("could not determine platform cache directory for recording")]
-    CacheDirNotFound(#[source] CacheDirError),
+    /// The platform state directory could not be determined.
+    #[error("could not determine platform state directory for recording")]
+    StateDirNotFound(#[source] StateDirError),
 
     /// Failed to create the run store.
     #[error("failed to create run store")]

--- a/nextest-runner/src/record/mod.rs
+++ b/nextest-runner/src/record/mod.rs
@@ -15,7 +15,7 @@
 //!   and the list of recorded runs.
 //! - [`RunRecorder`]: Writes a single run's data to disk, including metadata and events.
 //! - [`RecordReader`]: Reads a recorded run from disk for replay or inspection.
-//! - [`records_cache_dir`]: Returns the platform-specific cache directory for recordings.
+//! - [`records_state_dir`]: Returns the platform-specific state directory for recordings.
 //!
 //! # Archive format
 //!
@@ -24,7 +24,6 @@
 //! - `store.zip`: A zstd-compressed archive containing metadata and test outputs.
 //! - `run.log.zst`: A zstd-compressed JSON Lines file of test events.
 
-mod cache_dir;
 pub mod dicts;
 mod display;
 mod format;
@@ -36,13 +35,13 @@ mod rerun;
 mod retention;
 mod run_id_index;
 mod session;
+mod state_dir;
 mod store;
 mod summary;
 #[cfg(test)]
 mod test_helpers;
 mod tree;
 
-pub use cache_dir::{NEXTEST_CACHE_DIR_ENV, encode_workspace_path, records_cache_dir};
 pub use display::{
     DisplayPrunePlan, DisplayPruneResult, DisplayRecordedRunInfo, DisplayRecordedRunInfoDetailed,
     DisplayRunList, RunListAlignment, Styles,
@@ -71,6 +70,7 @@ pub use session::{
     RecordFinalizeResult, RecordFinalizeWarning, RecordSession, RecordSessionConfig,
     RecordSessionSetup,
 };
+pub use state_dir::{NEXTEST_STATE_DIR_ENV, encode_workspace_path, records_state_dir};
 pub use store::{
     CompletedRunStats, ComponentSizes, ExclusiveLockedRunStore, NonReplayableReason,
     RecordedRunInfo, RecordedRunStatus, RecordedSizes, ReplayabilityStatus, ResolveRunIdResult,

--- a/site/src/docs/features/record-replay-rerun.md
+++ b/site/src/docs/features/record-replay-rerun.md
@@ -297,10 +297,10 @@ The store location is platform-dependent:
 
 | Platform | Path |
 |----------|------|
-| Linux, macOS, and other Unix | `$XDG_CACHE_HOME/nextest/` or `~/.cache/nextest/` |
+| Linux, macOS, and other Unix | `$XDG_STATE_HOME/nextest/` or `~/.local/state/nextest/` |
 | Windows | `%LOCALAPPDATA%\nextest\` |
 
-The store location can be overridden via the `NEXTEST_CACHE_DIR` environment variable.
+The store location can be overridden via the `NEXTEST_STATE_DIR` environment variable.
 
 Within the store, recorded runs are indexed by canonicalized workspace path.
 


### PR DESCRIPTION
The state dir is a more reasonable place to put records, since they're not regenerable.

Also add a migration path. This won't affect too many folks but I want to put it in place while the impact is minimal. I'll remove the migration soon.