### PR TITLE
[nextest-runner] factor partitioning into a post-filtering pass

### DIFF
--- a/cargo-nextest/src/dispatch/core/list.rs
+++ b/cargo-nextest/src/dispatch/core/list.rs
@@ -73,9 +73,9 @@ impl App {
         let profile = self.base.load_profile(&config)?;
         let filter_exprs =
             build_filtersets(&pcx, &self.build_filter.filterset, FiltersetKind::Test)?;
-        let test_filter_builder = self
+        let test_filter = self
             .build_filter
-            .make_test_filter_builder(NextestRunMode::Test, filter_exprs)?;
+            .make_test_filter(NextestRunMode::Test, filter_exprs)?;
 
         let binary_list = self.base.build_binary_list("test")?;
 
@@ -127,8 +127,7 @@ impl App {
                     target_runner,
                 };
 
-                let test_list =
-                    self.build_test_list(&ctx, binary_list, &test_filter_builder, &profile)?;
+                let test_list = self.build_test_list(&ctx, binary_list, &test_filter, &profile)?;
 
                 test_list.write(
                     message_format.to_output_format(self.base.output.verbose, is_interactive),
@@ -168,9 +167,9 @@ impl App {
 
         let filter_exprs =
             build_filtersets(&pcx, &self.build_filter.filterset, FiltersetKind::Test)?;
-        let test_filter_builder = self
+        let test_filter = self
             .build_filter
-            .make_test_filter_builder(NextestRunMode::Test, filter_exprs)?;
+            .make_test_filter(NextestRunMode::Test, filter_exprs)?;
 
         let binary_list = self.base.build_binary_list("test")?;
         let build_platforms = binary_list.rust_build_meta.build_platforms.clone();
@@ -184,7 +183,7 @@ impl App {
             target_runner,
         };
 
-        let test_list = self.build_test_list(&ctx, binary_list, &test_filter_builder, &profile)?;
+        let test_list = self.build_test_list(&ctx, binary_list, &test_filter, &profile)?;
 
         let resolved_user_config = resolve_user_config(
             &self.base.build_platforms.host.platform,

--- a/cargo-nextest/src/errors.rs
+++ b/cargo-nextest/src/errors.rs
@@ -139,9 +139,9 @@ pub enum ExpectedError {
         err: Box<UserConfigError>,
     },
     #[error("test filter build error")]
-    TestFilterBuilderError {
+    TestFilterBuildError {
         #[from]
-        err: TestFilterBuilderError,
+        err: TestFilterBuildError,
     },
     #[error("unknown host platform")]
     HostPlatformDetectError {
@@ -581,7 +581,7 @@ impl ExpectedError {
             | Self::RootManifestNotFound { .. }
             | Self::CargoConfigError { .. }
             | Self::UserConfigError { .. }
-            | Self::TestFilterBuilderError { .. }
+            | Self::TestFilterBuildError { .. }
             | Self::HostPlatformDetectError { .. }
             | Self::TargetTripleError { .. }
             | Self::RemapAbsoluteError { .. }
@@ -915,7 +915,7 @@ impl ExpectedError {
                 error!("{err}");
                 err.source()
             }
-            Self::TestFilterBuilderError { err } => {
+            Self::TestFilterBuildError { err } => {
                 error!("{err}");
                 err.source()
             }

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -936,10 +936,10 @@ impl fmt::Display for PartitionerBuilderParseError {
     }
 }
 
-/// An error that occurs while operating on a
-/// [`TestFilterBuilder`](crate::test_filter::TestFilterBuilder).
+/// An error that occurs while building a
+/// [`TestFilter`](crate::test_filter::TestFilter).
 #[derive(Clone, Debug, Error)]
-pub enum TestFilterBuilderError {
+pub enum TestFilterBuildError {
     /// An error that occurred while constructing test filters.
     #[error("error constructing test filters")]
     Construct {

--- a/nextest-runner/src/record/mod.rs
+++ b/nextest-runner/src/record/mod.rs
@@ -49,10 +49,10 @@ pub use display::{
 pub use format::{
     CARGO_METADATA_JSON_PATH, OutputDict, PORTABLE_MANIFEST_FILE_NAME,
     PortableRecordingFormatVersion, PortableRecordingVersionIncompatibility, RECORD_OPTS_JSON_PATH,
-    RERUN_INFO_JSON_PATH, RUN_LOG_FILE_NAME, RerunInfo, RerunRootInfo, RunsJsonFormatVersion,
-    RunsJsonWritePermission, STDERR_DICT_PATH, STDOUT_DICT_PATH, STORE_FORMAT_VERSION,
-    STORE_ZIP_FILE_NAME, StoreFormatMajorVersion, StoreFormatMinorVersion, StoreFormatVersion,
-    StoreVersionIncompatibility, TEST_LIST_JSON_PATH, has_zip_extension,
+    RERUN_INFO_JSON_PATH, RUN_LOG_FILE_NAME, RerunInfo, RerunRootInfo, RerunTestSuiteInfo,
+    RunsJsonFormatVersion, RunsJsonWritePermission, STDERR_DICT_PATH, STDOUT_DICT_PATH,
+    STORE_FORMAT_VERSION, STORE_ZIP_FILE_NAME, StoreFormatMajorVersion, StoreFormatMinorVersion,
+    StoreFormatVersion, StoreVersionIncompatibility, TEST_LIST_JSON_PATH, has_zip_extension,
 };
 pub use portable::{
     ExtractOuterFileResult, PortableRecording, PortableRecordingEventIter, PortableRecordingResult,


### PR DESCRIPTION
Previously, partitioning was applied inline within TestFilter::filter_match, which made the filter stateful (via a mutable Partitioner). This commit moves partitioning out of TestFilter and into a post-processing step on TestList, applied after all other filtering (name, expression, ignored) is complete.

This removes the horrible old `TestFilterBuilder`/`TestFilter` split. Test filtering is now stateless, since partitioning is a post-processing step.

This is a refactoring-only change that preserves the exact behavior of count and hash partitioning. The new apply_cross_binary_partitioning method is not yet reachable (no partitioner returns CrossBinary scope), but is included to prepare for the slice partitioner in the next commit.

There is one minor behavioral change: in the old code, a `RerunAlreadyPassed` test that also failed ignored/name/expression filters would not be counted by the partitioner (because `filter_match_base` returned early before reaching the partition step). In the new code, `apply_partition_to_test` unconditionally counts `RerunAlreadyPassed` tests. This is the correct behavior: these tests should always participate in bucketing to keep shard assignments stable across reruns, regardless of whether other filter criteria happen to match.