### PR TITLE
Updated zip dependency to version 8.0.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5213,9 +5213,9 @@ checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zip"
-version = "7.3.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "268bf6f9ceb991e07155234071501490bb41fd1e39c6a588106dad10ae2a5804"
+checksum = "79b32dd4ad3aca14ae109f8cce0495ac1c57f6f4f00ad459a40e582f89440d97"
 dependencies = [
  "crc32fast",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ win32job = "2.0.3"
 windows-sys = "0.61.2"
 winnow = "0.7.14"
 xxhash-rust = { version = "0.8.15", features = ["xxh3", "xxh64"] }
-zip = { version = "7.3.0", default-features = false, features = ["zstd"] }
+zip = { version = "8.0.0", default-features = false, features = ["zstd"] }
 zstd = { version = "0.13.3", features = ["zstdmt"] }
 
 [workspace.lints.clippy]


### PR DESCRIPTION
This fixes the following warning when `cargo install`:
```plain
warning: package `zip v7.3.0` in Cargo.lock is yanked in registry `crates-io`, consider running without --locked
```

Closes #3073