### PR TITLE
[nextest-runner] restrict --show-progress=only to interactive scenarios

### DIFF
--- a/cargo-nextest/src/dispatch/core/value_enums.rs
+++ b/cargo-nextest/src/dispatch/core/value_enums.rs
@@ -6,10 +6,7 @@
 use crate::errors::CargoMessageFormatError;
 use clap::ValueEnum;
 use nextest_metadata::BuildPlatform;
-use nextest_runner::{
-    reporter::{FinalStatusLevel, StatusLevel, TestOutputDisplay},
-    user_config::elements::UiShowProgress,
-};
+use nextest_runner::reporter::{FinalStatusLevel, ShowProgress, StatusLevel, TestOutputDisplay};
 use std::collections::HashSet;
 
 /// Platform filter options.
@@ -226,20 +223,26 @@ pub(crate) enum ShowProgressOpt {
     /// Display a counter next to each completed test.
     Counter,
 
-    /// Display a progress bar with running tests, and hide successful test
-    /// output; equivalent to `--show-progress=running --status-level=slow
-    /// --final-status-level=none`.
+    /// In interactive terminals, display a progress bar with running tests and
+    /// hide successful test output (equivalent to `--show-progress=bar
+    /// --status-level=slow --final-status-level=none`). In non-interactive
+    /// contexts (piped output, CI), behaves like `auto`: successful test output
+    /// is shown normally.
     Only,
 }
 
-impl From<ShowProgressOpt> for UiShowProgress {
+impl From<ShowProgressOpt> for ShowProgress {
     fn from(opt: ShowProgressOpt) -> Self {
         match opt {
-            ShowProgressOpt::Auto => UiShowProgress::Auto,
-            ShowProgressOpt::None => UiShowProgress::None,
-            ShowProgressOpt::Bar => UiShowProgress::Bar,
-            ShowProgressOpt::Counter => UiShowProgress::Counter,
-            ShowProgressOpt::Only => UiShowProgress::Only,
+            ShowProgressOpt::Auto => ShowProgress::Auto {
+                suppress_success: false,
+            },
+            ShowProgressOpt::None => ShowProgress::None,
+            ShowProgressOpt::Bar => ShowProgress::Running,
+            ShowProgressOpt::Counter => ShowProgress::Counter,
+            ShowProgressOpt::Only => ShowProgress::Auto {
+                suppress_success: true,
+            },
         }
     }
 }

--- a/integration-tests/tests/integration/user_config.rs
+++ b/integration-tests/tests/integration/user_config.rs
@@ -83,7 +83,7 @@ max-progress-running = 4
     let stderr = output.stderr_as_str();
     // Verify show_progress was set from user config.
     assert!(
-        stderr.contains("ui_show_progress = Counter"),
+        stderr.contains("show_progress = Counter"),
         "show_progress should be Counter from user config\n{output}"
     );
     // Verify max_progress_running was set from user config.
@@ -130,8 +130,8 @@ max-progress-running = 4
     let stderr = output.stderr_as_str();
     // CLI values should override user config.
     assert!(
-        stderr.contains("ui_show_progress = Bar"),
-        "ui_show_progress should be Bar from CLI (bar)\n{output}"
+        stderr.contains("show_progress = Running"),
+        "show_progress should be Running from CLI (bar)\n{output}"
     );
     assert!(
         stderr.contains("max_progress_running = Count(12)"),
@@ -174,7 +174,7 @@ max-progress-running = 4
     let stderr = output.stderr_as_str();
     // Environment variable values should override user config.
     assert!(
-        stderr.contains("ui_show_progress = Counter"),
+        stderr.contains("show_progress = Counter"),
         "show_progress should be Counter from env var\n{output}"
     );
     assert!(
@@ -209,7 +209,7 @@ fn test_user_config_missing_uses_defaults() {
     let stderr = output.stderr_as_str();
     // Should use default values.
     assert!(
-        stderr.contains("ui_show_progress = Auto"),
+        stderr.contains("show_progress = Auto"),
         "show_progress should be Auto (default)\n{output}"
     );
     assert!(
@@ -396,8 +396,8 @@ some-key = "some-value"
     let stderr = output.stderr_as_str();
     // Should still apply the known settings.
     assert!(
-        stderr.contains("ui_show_progress = Bar"),
-        "ui_show_progress should be Bar despite unknown section\n{output}"
+        stderr.contains("show_progress = Running"),
+        "show_progress should be Running despite unknown section\n{output}"
     );
 }
 

--- a/nextest-runner/src/record/replay.rs
+++ b/nextest-runner/src/record/replay.rs
@@ -576,9 +576,9 @@ use crate::{
         store::{RecordedRunInfo, RecordedRunStatus},
     },
     reporter::{
-        DisplayReporter, DisplayReporterBuilder, DisplayerKind, FinalStatusLevel,
+        DisplayConfig, DisplayReporter, DisplayReporterBuilder, DisplayerKind, FinalStatusLevel,
         MaxProgressRunning, ReporterOutput, ShowProgress, ShowTerminalProgress, StatusLevel,
-        StatusLevels, TestOutputDisplay,
+        TestOutputDisplay,
     },
 };
 use chrono::{DateTime, FixedOffset};
@@ -647,7 +647,7 @@ impl Default for ReplayReporterBuilder {
             failure_output: None,
             should_colorize: false,
             verbose: false,
-            show_progress: ShowProgress::Auto,
+            show_progress: ShowProgress::default(),
             max_progress_running: MaxProgressRunning::default(),
             no_output_indent: false,
         }
@@ -727,17 +727,17 @@ impl ReplayReporterBuilder {
         let display_reporter = DisplayReporterBuilder {
             mode,
             default_filter: CompiledDefaultFilter::for_default_config(),
-            status_levels: StatusLevels {
-                status_level: self.status_level,
-                final_status_level: self.final_status_level,
-            },
+            display_config: DisplayConfig::with_overrides(
+                self.show_progress,
+                false, // Replay never uses no-capture.
+                self.status_level,
+                self.final_status_level,
+            ),
             test_count,
             success_output: self.success_output,
             failure_output: self.failure_output,
             should_colorize: self.should_colorize,
-            no_capture: false,
             verbose: self.verbose,
-            show_progress: self.show_progress,
             no_output_indent: self.no_output_indent,
             max_progress_running: self.max_progress_running,
             // For replay, we don't show terminal progress (OSC 9;4 codes) since

--- a/nextest-runner/src/reporter/displayer/config.rs
+++ b/nextest-runner/src/reporter/displayer/config.rs
@@ -1,0 +1,603 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Consolidated display configuration: resolves all display decisions (progress
+//! bar, counter, status levels) in a single place.
+
+use super::{ShowProgress, status_level::StatusLevels};
+use crate::reporter::displayer::{FinalStatusLevel, StatusLevel};
+
+/// Unresolved display configuration passed to the displayer.
+///
+/// The displayer resolves this into a [`ResolvedDisplay`] based on the
+/// progress display mode, terminal interactivity, and CI detection.
+pub(crate) struct DisplayConfig {
+    /// The progress display mode.
+    pub(crate) show_progress: ShowProgress,
+
+    /// Whether test output capture is disabled (`--no-capture`).
+    pub(crate) no_capture: bool,
+
+    /// Explicit override (from CLI `--status-level`), or `None` to use
+    /// context-dependent defaults.
+    pub(crate) status_level: Option<StatusLevel>,
+
+    /// Explicit override (from CLI `--final-status-level`).
+    pub(crate) final_status_level: Option<FinalStatusLevel>,
+
+    /// Status level from the nextest profile, used as the default when no
+    /// explicit override is set and no context-specific default applies.
+    pub(crate) profile_status_level: StatusLevel,
+
+    /// Final status level from the nextest profile, used as the default when
+    /// no explicit override is set and no context-specific default applies.
+    pub(crate) profile_final_status_level: FinalStatusLevel,
+}
+
+/// The fully resolved display decisions.
+///
+/// Produced by [`DisplayConfig::resolve()`].
+pub(crate) struct ResolvedDisplay {
+    /// What kind of progress indicator to show.
+    pub(crate) progress_display: ProgressDisplay,
+
+    /// The resolved status levels.
+    pub(crate) status_levels: StatusLevels,
+}
+
+/// The kind of progress indicator to display.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ProgressDisplay {
+    /// Show a progress bar with running tests.
+    Bar,
+
+    /// Show a counter (e.g. "(1/10)") on each status line.
+    Counter,
+
+    /// No progress indicator.
+    None,
+}
+
+impl DisplayConfig {
+    /// Creates a config with explicit status level overrides and no profile
+    /// defaults.
+    ///
+    /// Used by replay, where status levels are always explicitly set.
+    pub(crate) fn with_overrides(
+        show_progress: ShowProgress,
+        no_capture: bool,
+        status_level: StatusLevel,
+        final_status_level: FinalStatusLevel,
+    ) -> Self {
+        DisplayConfig {
+            show_progress,
+            no_capture,
+            status_level: Some(status_level),
+            final_status_level: Some(final_status_level),
+            // These are unused because the overrides above are always Some,
+            // but we set them to the same values for consistency.
+            profile_status_level: status_level,
+            profile_final_status_level: final_status_level,
+        }
+    }
+
+    /// Resolves this configuration into concrete display decisions.
+    ///
+    /// Resolution depends on `is_terminal` and `is_ci`, both of which are
+    /// passed in (rather than queried) for testability.
+    ///
+    /// The behavioral table:
+    ///
+    /// | `show_progress`                      | `bar_available` | bar | counter | status defaults |
+    /// |--------------------------------------|-----------------|-----|---------|-----------------|
+    /// | `Auto { suppress_success: false }`   | true            | yes | no      | profile         |
+    /// | `Auto { suppress_success: true }`    | true            | yes | no      | Slow / None     |
+    /// | `Auto { suppress_success: true }`    | false           | no  | yes     | profile         |
+    /// | `Auto { suppress_success: false }`   | false           | no  | yes     | profile         |
+    /// | `Running`                            | true            | yes | no      | profile         |
+    /// | `Running`                            | false           | no  | no      | profile         |
+    /// | `Counter`                            | *               | no  | yes     | profile         |
+    /// | `None`                               | *               | no  | no      | profile         |
+    ///
+    /// In no-capture mode, the status level is raised to at least
+    /// [`StatusLevel::Pass`].
+    pub(crate) fn resolve(&self, is_terminal: bool, is_ci: bool) -> ResolvedDisplay {
+        // The progress bar requires all three conditions:
+        // - Capture enabled: with --no-capture, stderr is passed directly to
+        //   child processes, making a progress bar incompatible. (A future
+        //   pty-based approach could lift this, but would require curses-like
+        //   handling for partial lines.)
+        // - Not CI: some CI environments pretend to be terminals but don't
+        //   render progress bars correctly.
+        // - Terminal output: indicatif requires a real terminal target.
+        let bar_available = !self.no_capture && !is_ci && is_terminal;
+        let (sl, fsl) = (self.profile_status_level, self.profile_final_status_level);
+
+        let mut resolved = match (self.show_progress, bar_available) {
+            // Auto + interactive: show bar, profile defaults.
+            (
+                ShowProgress::Auto {
+                    suppress_success: false,
+                },
+                true,
+            ) => ResolvedDisplay {
+                progress_display: ProgressDisplay::Bar,
+                status_levels: self.apply_overrides(sl, fsl),
+            },
+            // Auto + suppress_success + interactive: show bar, hide successful output.
+            (
+                ShowProgress::Auto {
+                    suppress_success: true,
+                },
+                true,
+            ) => ResolvedDisplay {
+                progress_display: ProgressDisplay::Bar,
+                status_levels: self.apply_overrides(StatusLevel::Slow, FinalStatusLevel::None),
+            },
+            // Auto + suppress_success + non-interactive: suppress_success
+            // is irrelevant without a progress bar; use profile defaults.
+            (
+                ShowProgress::Auto {
+                    suppress_success: true,
+                },
+                false,
+            ) => {
+                tracing::debug!(
+                    is_terminal,
+                    is_ci,
+                    no_capture = self.no_capture,
+                    "suppress_success requested but progress bar is unavailable; \
+                     using profile defaults",
+                );
+                ResolvedDisplay {
+                    progress_display: ProgressDisplay::Counter,
+                    status_levels: self.apply_overrides(sl, fsl),
+                }
+            }
+            // Auto + non-interactive: show counter, profile defaults.
+            (
+                ShowProgress::Auto {
+                    suppress_success: false,
+                },
+                false,
+            ) => ResolvedDisplay {
+                progress_display: ProgressDisplay::Counter,
+                status_levels: self.apply_overrides(sl, fsl),
+            },
+            // Running + interactive: show bar.
+            (ShowProgress::Running, true) => ResolvedDisplay {
+                progress_display: ProgressDisplay::Bar,
+                status_levels: self.apply_overrides(sl, fsl),
+            },
+            // Running + non-interactive: no visible progress.
+            (ShowProgress::Running, false) => ResolvedDisplay {
+                progress_display: ProgressDisplay::None,
+                status_levels: self.apply_overrides(sl, fsl),
+            },
+            // Counter: always counter, never bar.
+            (ShowProgress::Counter, _) => ResolvedDisplay {
+                progress_display: ProgressDisplay::Counter,
+                status_levels: self.apply_overrides(sl, fsl),
+            },
+            // None: no progress display of any kind.
+            (ShowProgress::None, _) => ResolvedDisplay {
+                progress_display: ProgressDisplay::None,
+                status_levels: self.apply_overrides(sl, fsl),
+            },
+        };
+
+        // In no-capture mode, raise status level to at least Pass.
+        if self.no_capture {
+            resolved.status_levels.status_level =
+                resolved.status_levels.status_level.max(StatusLevel::Pass);
+        }
+
+        resolved
+    }
+
+    fn apply_overrides(
+        &self,
+        default_sl: StatusLevel,
+        default_fsl: FinalStatusLevel,
+    ) -> StatusLevels {
+        StatusLevels {
+            status_level: self.status_level.unwrap_or(default_sl),
+            final_status_level: self.final_status_level.unwrap_or(default_fsl),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The profile defaults used in resolve tests.
+    const DEFAULT_SL: StatusLevel = StatusLevel::Pass;
+    const DEFAULT_FSL: FinalStatusLevel = FinalStatusLevel::Flaky;
+
+    fn make_config(
+        show_progress: ShowProgress,
+        no_capture: bool,
+        status_level: Option<StatusLevel>,
+        final_status_level: Option<FinalStatusLevel>,
+    ) -> DisplayConfig {
+        DisplayConfig {
+            show_progress,
+            no_capture,
+            status_level,
+            final_status_level,
+            profile_status_level: DEFAULT_SL,
+            profile_final_status_level: DEFAULT_FSL,
+        }
+    }
+
+    // -- Non-suppress modes use profile defaults --
+
+    /// For all ShowProgress variants *except* `Auto { suppress_success: true }` with
+    /// a progress bar, the resolved status levels should use profile defaults
+    /// (when no CLI overrides are set).
+    #[test]
+    fn resolve_uses_profile_defaults() {
+        let non_suppress_modes = [
+            ShowProgress::Auto {
+                suppress_success: false,
+            },
+            ShowProgress::None,
+            ShowProgress::Counter,
+            ShowProgress::Running,
+        ];
+
+        for show_progress in non_suppress_modes {
+            // Interactive terminal, not CI.
+            let config = make_config(show_progress, false, None, None);
+            let resolved = config.resolve(/* is_terminal */ true, /* is_ci */ false);
+            assert_eq!(
+                resolved.status_levels.status_level, DEFAULT_SL,
+                "show_progress={show_progress:?}, is_terminal=true, is_ci=false"
+            );
+            assert_eq!(
+                resolved.status_levels.final_status_level, DEFAULT_FSL,
+                "show_progress={show_progress:?}, is_terminal=true, is_ci=false"
+            );
+
+            // Non-interactive (piped).
+            let config = make_config(show_progress, false, None, None);
+            let resolved = config.resolve(/* is_terminal */ false, /* is_ci */ false);
+            assert_eq!(
+                resolved.status_levels.status_level, DEFAULT_SL,
+                "show_progress={show_progress:?}, is_terminal=false, is_ci=false"
+            );
+            assert_eq!(
+                resolved.status_levels.final_status_level, DEFAULT_FSL,
+                "show_progress={show_progress:?}, is_terminal=false, is_ci=false"
+            );
+
+            // CI environment.
+            let config = make_config(show_progress, false, None, None);
+            let resolved = config.resolve(/* is_terminal */ true, /* is_ci */ true);
+            assert_eq!(
+                resolved.status_levels.status_level, DEFAULT_SL,
+                "show_progress={show_progress:?}, is_terminal=true, is_ci=true"
+            );
+            assert_eq!(
+                resolved.status_levels.final_status_level, DEFAULT_FSL,
+                "show_progress={show_progress:?}, is_terminal=true, is_ci=true"
+            );
+        }
+
+        // Auto { suppress_success: true } without a progress bar also uses profile
+        // defaults (non-interactive).
+        let config = make_config(
+            ShowProgress::Auto {
+                suppress_success: true,
+            },
+            false,
+            None,
+            None,
+        );
+        let resolved = config.resolve(/* is_terminal */ false, /* is_ci */ false);
+        assert_eq!(resolved.status_levels.status_level, DEFAULT_SL);
+        assert_eq!(resolved.status_levels.final_status_level, DEFAULT_FSL);
+        assert_eq!(resolved.progress_display, ProgressDisplay::Counter);
+
+        // Auto { suppress_success: true } in CI also uses profile defaults.
+        let config = make_config(
+            ShowProgress::Auto {
+                suppress_success: true,
+            },
+            false,
+            None,
+            None,
+        );
+        let resolved = config.resolve(/* is_terminal */ true, /* is_ci */ true);
+        assert_eq!(resolved.status_levels.status_level, DEFAULT_SL);
+        assert_eq!(resolved.status_levels.final_status_level, DEFAULT_FSL);
+        assert_eq!(resolved.progress_display, ProgressDisplay::Counter);
+    }
+
+    /// `Auto { suppress_success: true }` with a progress bar hides successful output.
+    #[test]
+    fn resolve_suppress_success_with_progress_bar() {
+        let config = make_config(
+            ShowProgress::Auto {
+                suppress_success: true,
+            },
+            false,
+            None,
+            None,
+        );
+        let resolved = config.resolve(/* is_terminal */ true, /* is_ci */ false);
+        assert_eq!(
+            resolved.status_levels.status_level,
+            StatusLevel::Slow,
+            "suppress_success + progress bar should default to Slow"
+        );
+        assert_eq!(
+            resolved.status_levels.final_status_level,
+            FinalStatusLevel::None,
+            "suppress_success + progress bar should default to None"
+        );
+        assert_eq!(resolved.progress_display, ProgressDisplay::Bar);
+    }
+
+    // -- CLI overrides --
+
+    /// Explicit CLI overrides always win, even in suppress_success with a progress
+    /// bar.
+    #[test]
+    fn resolve_cli_overrides_win() {
+        let config = make_config(
+            ShowProgress::Auto {
+                suppress_success: true,
+            },
+            false,
+            Some(StatusLevel::Skip),
+            Some(FinalStatusLevel::Pass),
+        );
+
+        // suppress_success + progress bar: CLI override should still win.
+        let resolved = config.resolve(/* is_terminal */ true, /* is_ci */ false);
+        assert_eq!(
+            resolved.status_levels.status_level,
+            StatusLevel::Skip,
+            "CLI override wins over suppress_success defaults"
+        );
+        assert_eq!(
+            resolved.status_levels.final_status_level,
+            FinalStatusLevel::Pass,
+            "CLI override wins over suppress_success defaults"
+        );
+
+        // Normal auto mode: CLI override should also win.
+        let config = make_config(
+            ShowProgress::Auto {
+                suppress_success: false,
+            },
+            false,
+            Some(StatusLevel::Skip),
+            Some(FinalStatusLevel::Pass),
+        );
+        let resolved = config.resolve(/* is_terminal */ true, /* is_ci */ false);
+        assert_eq!(resolved.status_levels.status_level, StatusLevel::Skip);
+        assert_eq!(
+            resolved.status_levels.final_status_level,
+            FinalStatusLevel::Pass
+        );
+
+        // Non-auto mode: CLI override should also win.
+        let config = make_config(
+            ShowProgress::Running,
+            false,
+            Some(StatusLevel::Skip),
+            Some(FinalStatusLevel::Pass),
+        );
+        let resolved = config.resolve(/* is_terminal */ true, /* is_ci */ false);
+        assert_eq!(resolved.status_levels.status_level, StatusLevel::Skip);
+        assert_eq!(
+            resolved.status_levels.final_status_level,
+            FinalStatusLevel::Pass
+        );
+    }
+
+    /// Partial CLI overrides: only the overridden level uses the explicit
+    /// value, the other falls back to the contextual default.
+    #[test]
+    fn resolve_partial_cli_overrides() {
+        // Override only status_level.
+        let config = make_config(
+            ShowProgress::Auto {
+                suppress_success: true,
+            },
+            false,
+            Some(StatusLevel::All),
+            None,
+        );
+        let resolved = config.resolve(/* is_terminal */ true, /* is_ci */ false);
+        assert_eq!(
+            resolved.status_levels.status_level,
+            StatusLevel::All,
+            "CLI override for status_level"
+        );
+        assert_eq!(
+            resolved.status_levels.final_status_level,
+            FinalStatusLevel::None,
+            "suppress_success default for final_status_level"
+        );
+
+        // Override only final_status_level.
+        let config = make_config(
+            ShowProgress::Auto {
+                suppress_success: true,
+            },
+            false,
+            None,
+            Some(FinalStatusLevel::All),
+        );
+        let resolved = config.resolve(/* is_terminal */ true, /* is_ci */ false);
+        assert_eq!(
+            resolved.status_levels.status_level,
+            StatusLevel::Slow,
+            "suppress_success default for status_level"
+        );
+        assert_eq!(
+            resolved.status_levels.final_status_level,
+            FinalStatusLevel::All,
+            "CLI override for final_status_level"
+        );
+    }
+
+    // -- no_capture mode --
+
+    /// No-capture mode raises status_level to at least Pass.
+    #[test]
+    fn resolve_no_capture_raises_status_level() {
+        // Without CLI override, profile default Pass is unchanged.
+        let config = make_config(
+            ShowProgress::Auto {
+                suppress_success: false,
+            },
+            true,
+            None,
+            None,
+        );
+        let resolved = config.resolve(/* is_terminal */ false, /* is_ci */ false);
+        assert_eq!(
+            resolved.status_levels.status_level,
+            StatusLevel::Pass,
+            "no_capture raises to at least Pass (default was Pass)"
+        );
+
+        // With suppress_success + bar available: Slow is raised to Pass.
+        // Note: no_capture prevents the bar from being available, so
+        // bar_available=false and suppress_success is irrelevant. The profile default
+        // (Pass) is used.
+        let config = make_config(
+            ShowProgress::Auto {
+                suppress_success: true,
+            },
+            true,
+            None,
+            None,
+        );
+        let resolved = config.resolve(/* is_terminal */ true, /* is_ci */ false);
+        assert_eq!(
+            resolved.status_levels.status_level,
+            StatusLevel::Pass,
+            "no_capture prevents bar, so profile default Pass is used"
+        );
+        // With no_capture, bar is not available so suppress_success falls through to
+        // the Auto non-interactive branch which uses profile defaults.
+        assert_eq!(
+            resolved.status_levels.final_status_level, DEFAULT_FSL,
+            "no_capture prevents bar, so profile final default is used"
+        );
+        assert_eq!(
+            resolved.progress_display,
+            ProgressDisplay::Counter,
+            "no_capture prevents bar"
+        );
+
+        // With CLI override below Pass, no_capture raises it.
+        let config = make_config(ShowProgress::Running, true, Some(StatusLevel::Fail), None);
+        let resolved = config.resolve(/* is_terminal */ true, /* is_ci */ false);
+        assert_eq!(
+            resolved.status_levels.status_level,
+            StatusLevel::Pass,
+            "no_capture raises CLI override Fail to Pass"
+        );
+
+        // With CLI override above Pass, no_capture preserves it.
+        let config = make_config(ShowProgress::Running, true, Some(StatusLevel::All), None);
+        let resolved = config.resolve(/* is_terminal */ true, /* is_ci */ false);
+        assert_eq!(
+            resolved.status_levels.status_level,
+            StatusLevel::All,
+            "no_capture preserves CLI override All"
+        );
+    }
+
+    // -- Progress bar and counter decisions --
+
+    /// Auto mode: bar in interactive terminal, counter otherwise.
+    #[test]
+    fn resolve_auto_progress_decisions() {
+        // Interactive terminal.
+        let config = make_config(
+            ShowProgress::Auto {
+                suppress_success: false,
+            },
+            false,
+            None,
+            None,
+        );
+        let resolved = config.resolve(true, false);
+        assert_eq!(resolved.progress_display, ProgressDisplay::Bar);
+
+        // Non-interactive.
+        let config = make_config(
+            ShowProgress::Auto {
+                suppress_success: false,
+            },
+            false,
+            None,
+            None,
+        );
+        let resolved = config.resolve(false, false);
+        assert_eq!(resolved.progress_display, ProgressDisplay::Counter);
+
+        // CI pretending to be a terminal.
+        let config = make_config(
+            ShowProgress::Auto {
+                suppress_success: false,
+            },
+            false,
+            None,
+            None,
+        );
+        let resolved = config.resolve(true, true);
+        assert_eq!(resolved.progress_display, ProgressDisplay::Counter);
+    }
+
+    /// Running mode: bar in interactive terminal, nothing otherwise.
+    #[test]
+    fn resolve_running_progress_decisions() {
+        // Interactive terminal.
+        let config = make_config(ShowProgress::Running, false, None, None);
+        let resolved = config.resolve(true, false);
+        assert_eq!(resolved.progress_display, ProgressDisplay::Bar);
+
+        // Non-interactive.
+        let config = make_config(ShowProgress::Running, false, None, None);
+        let resolved = config.resolve(false, false);
+        assert_eq!(resolved.progress_display, ProgressDisplay::None);
+
+        // CI pretending to be a terminal: no bar, no counter.
+        let config = make_config(ShowProgress::Running, false, None, None);
+        let resolved = config.resolve(true, true);
+        assert_eq!(resolved.progress_display, ProgressDisplay::None);
+    }
+
+    /// Counter mode: always counter, never bar.
+    #[test]
+    fn resolve_counter_progress_decisions() {
+        let config = make_config(ShowProgress::Counter, false, None, None);
+        let resolved = config.resolve(true, false);
+        assert_eq!(resolved.progress_display, ProgressDisplay::Counter);
+
+        let config = make_config(ShowProgress::Counter, false, None, None);
+        let resolved = config.resolve(false, false);
+        assert_eq!(resolved.progress_display, ProgressDisplay::Counter);
+    }
+
+    /// None mode: no progress display.
+    #[test]
+    fn resolve_none_progress_decisions() {
+        let config = make_config(ShowProgress::None, false, None, None);
+        let resolved = config.resolve(true, false);
+        assert_eq!(resolved.progress_display, ProgressDisplay::None);
+
+        let config = make_config(ShowProgress::None, false, None, None);
+        let resolved = config.resolve(false, false);
+        assert_eq!(resolved.progress_display, ProgressDisplay::None);
+    }
+}

--- a/nextest-runner/src/reporter/displayer/mod.rs
+++ b/nextest-runner/src/reporter/displayer/mod.rs
@@ -3,12 +3,14 @@
 
 //! The displayer for human-friendly output.
 
+mod config;
 mod formatters;
 mod imp;
 mod progress;
 mod status_level;
 mod unit_output;
 
+pub(crate) use config::*;
 pub(crate) use formatters::DisplayUnitKind;
 pub(crate) use imp::*;
 pub use progress::{MaxProgressRunning, ShowProgress, ShowTerminalProgress};

--- a/nextest-runner/src/reporter/displayer/progress.rs
+++ b/nextest-runner/src/reporter/displayer/progress.rs
@@ -85,11 +85,23 @@ impl fmt::Display for MaxProgressRunning {
 }
 
 /// How to show progress.
-#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+///
+/// In the `Auto` variant, the progress display is chosen based on the
+/// environment: a progress bar in interactive terminals, a counter otherwise.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ShowProgress {
     /// Automatically decide based on environment.
-    #[default]
-    Auto,
+    ///
+    /// When `suppress_success` is true and a progress bar is shown,
+    /// successful test output is suppressed (status level defaults to
+    /// `Slow`, final status level defaults to `None`). In non-interactive
+    /// contexts, output behaves identically to `suppress_success: false`:
+    /// all test results are displayed normally.
+    Auto {
+        /// Whether to hide successful test output when a progress bar is
+        /// shown.
+        suppress_success: bool,
+    },
 
     /// No progress display.
     None,
@@ -97,8 +109,16 @@ pub enum ShowProgress {
     /// Show a counter on each line.
     Counter,
 
-    /// Show a progress bar and the running tests
+    /// Show a progress bar and the running tests.
     Running,
+}
+
+impl Default for ShowProgress {
+    fn default() -> Self {
+        ShowProgress::Auto {
+            suppress_success: false,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -514,10 +534,6 @@ impl ProgressBarState {
 
     fn should_hide(&self) -> bool {
         self.hidden_no_capture || self.hidden_run_paused || self.hidden_info_response
-    }
-
-    pub(super) fn is_hidden(&self) -> bool {
-        self.bar.is_hidden()
     }
 }
 

--- a/nextest-runner/src/reporter/imp.rs
+++ b/nextest-runner/src/reporter/imp.rs
@@ -6,8 +6,9 @@
 //! The main structure in this module is [`TestReporter`].
 
 use super::{
-    DisplayerKind, FinalStatusLevel, MaxProgressRunning, StatusLevel, TestOutputDisplay,
-    displayer::{DisplayReporter, DisplayReporterBuilder, ShowTerminalProgress, StatusLevels},
+    DisplayConfig, DisplayerKind, FinalStatusLevel, MaxProgressRunning, StatusLevel,
+    TestOutputDisplay,
+    displayer::{DisplayReporter, DisplayReporterBuilder, ShowTerminalProgress},
 };
 use crate::{
     config::core::EvaluatableProfile,
@@ -173,25 +174,22 @@ impl ReporterBuilder {
     ) -> Reporter<'a> {
         let aggregator = EventAggregator::new(test_list.mode(), profile);
 
-        let status_level = self.status_level.unwrap_or_else(|| profile.status_level());
-        let final_status_level = self
-            .final_status_level
-            .unwrap_or_else(|| profile.final_status_level());
-
         let display_reporter = DisplayReporterBuilder {
             mode: test_list.mode(),
             default_filter: profile.default_filter().clone(),
-            status_levels: StatusLevels {
-                status_level,
-                final_status_level,
+            display_config: DisplayConfig {
+                show_progress: self.show_progress,
+                no_capture: self.no_capture,
+                status_level: self.status_level,
+                final_status_level: self.final_status_level,
+                profile_status_level: profile.status_level(),
+                profile_final_status_level: profile.final_status_level(),
             },
             test_count: test_list.test_count(),
             success_output: self.success_output,
             failure_output: self.failure_output,
             should_colorize: self.should_colorize,
-            no_capture: self.no_capture,
             verbose: self.verbose,
-            show_progress: self.show_progress,
             no_output_indent: self.no_output_indent,
             max_progress_running: self.max_progress_running,
             show_term_progress,

--- a/nextest-runner/src/reporter/mod.rs
+++ b/nextest-runner/src/reporter/mod.rs
@@ -15,7 +15,7 @@ pub mod structured;
 #[cfg(test)]
 pub(crate) mod test_helpers;
 
-pub(crate) use displayer::{DisplayReporter, DisplayReporterBuilder, DisplayerKind, StatusLevels};
+pub(crate) use displayer::{DisplayConfig, DisplayReporter, DisplayReporterBuilder, DisplayerKind};
 pub use displayer::{
     FinalStatusLevel, MaxProgressRunning, ShowProgress, ShowTerminalProgress, StatusLevel,
     TestOutputDisplay,

--- a/site/src/changelog.md
+++ b/site/src/changelog.md
@@ -9,6 +9,12 @@ toc_depth: 1
 This page documents new features and bugfixes for cargo-nextest. Please see the [stability
 policy](https://nexte.st/docs/stability/) for how versioning works with cargo-nextest.
 
+## Unreleased
+
+### Changed
+
+- `--show-progress=only` now behaves like the default `auto` in non-interactive mode, showing successful tests with a counter. `only` is primarily intended for interactive scenarios.
+
 ## [0.9.128] - 2026-02-19
 
 ### Fixed


### PR DESCRIPTION
In non-interactive scenarios, `--show-progress=only` hides successful tests, which is generally not what this is intended for.