### PR TITLE
[nextest-runner] add OutputSpec for output types

### DIFF
--- a/cargo-nextest/src/dispatch/core/replay.rs
+++ b/cargo-nextest/src/dispatch/core/replay.rs
@@ -17,11 +17,12 @@ use nextest_metadata::NextestExitCode;
 use nextest_runner::{
     errors::{DisplayErrorChain, RecordReadError},
     list::{OwnedTestInstanceId, TestList},
+    output_spec::RecordingSpec,
     pager::PagedOutput,
     record::{
         PortableRecording, RecordReader, RecordedRunInfo, ReplayContext, ReplayHeader,
         ReplayReporterBuilder, RunIdIndex, RunIdOrRecordingSelector, RunStore,
-        STORE_FORMAT_VERSION, StoreReader, TestEventSummary, ZipStoreOutput, records_state_dir,
+        STORE_FORMAT_VERSION, StoreReader, TestEventSummary, records_state_dir,
     },
     reporter::ReporterOutput,
     user_config::{UserConfig, UserConfigExperimental},
@@ -237,7 +238,7 @@ fn exec_replay_from_archive(
 }
 
 type EventIter<'a> =
-    &'a mut dyn Iterator<Item = Result<TestEventSummary<ZipStoreOutput>, RecordReadError>>;
+    &'a mut dyn Iterator<Item = Result<TestEventSummary<RecordingSpec>, RecordReadError>>;
 
 /// Common replay logic shared between store-based and archive-based replay.
 #[expect(clippy::too_many_arguments)]

--- a/nextest-runner/src/lib.rs
+++ b/nextest-runner/src/lib.rs
@@ -19,6 +19,7 @@ pub mod helpers;
 pub mod indenter;
 pub mod input;
 pub mod list;
+pub mod output_spec;
 pub mod pager;
 pub mod partition;
 pub mod platform;

--- a/nextest-runner/src/output_spec.rs
+++ b/nextest-runner/src/output_spec.rs
@@ -1,0 +1,48 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Specifies how test output is represented.
+//!
+//! The [`OutputSpec`] trait abstracts over two modes of output storage:
+//!
+//! - [`LiveSpec`]: output stored in memory during live execution, using
+//!   [`ChildSingleOutput`].
+//! - [`RecordingSpec`]: output stored in recordings,
+//!   using [`ZipStoreOutput`].
+//!
+//! Types generic over `S: OutputSpec` use `S::ChildOutput` for their output
+//! fields. This enables adding additional associated types in the future
+//! without changing every generic type's parameter list.
+
+use crate::{record::ZipStoreOutput, test_output::ChildSingleOutput};
+
+/// Specifies how test output is represented.
+///
+/// Two implementations exist:
+///
+/// - [`LiveSpec`]: output stored in memory during live execution.
+/// - [`RecordingSpec`]: output stored in recordings.
+pub trait OutputSpec {
+    /// The type used to represent a single child output stream.
+    type ChildOutput;
+}
+
+/// Output spec for live test execution.
+///
+/// Uses [`ChildSingleOutput`] for in-memory byte buffers with lazy UTF-8 string
+/// conversion.
+pub struct LiveSpec;
+
+impl OutputSpec for LiveSpec {
+    type ChildOutput = ChildSingleOutput;
+}
+
+/// Output spec for recorded/replayed test runs.
+///
+/// Uses [`ZipStoreOutput`] for content-addressed file references in zip
+/// archives.
+pub struct RecordingSpec;
+
+impl OutputSpec for RecordingSpec {
+    type ChildOutput = ZipStoreOutput;
+}

--- a/nextest-runner/src/record/portable.rs
+++ b/nextest-runner/src/record/portable.rs
@@ -27,10 +27,11 @@ use super::{
     },
     reader::{StoreReader, decompress_with_dict},
     store::{RecordedRunInfo, RunFilesExist, StoreRunsDir},
-    summary::{RecordOpts, TestEventSummary, ZipStoreOutput},
+    summary::{RecordOpts, TestEventSummary},
 };
 use crate::{
     errors::{PortableRecordingError, PortableRecordingReadError, RecordReadError},
+    output_spec::RecordingSpec,
     user_config::elements::MAX_MAX_OUTPUT_SIZE,
 };
 use atomicwrites::{AtomicFile, OverwriteBehavior};
@@ -748,7 +749,7 @@ pub struct PortableRecordingEventIter<'a> {
 }
 
 impl Iterator for PortableRecordingEventIter<'_> {
-    type Item = Result<TestEventSummary<ZipStoreOutput>, RecordReadError>;
+    type Item = Result<TestEventSummary<RecordingSpec>, RecordReadError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {

--- a/nextest-runner/src/record/reader.rs
+++ b/nextest-runner/src/record/reader.rs
@@ -14,10 +14,11 @@ use super::{
         CARGO_METADATA_JSON_PATH, OutputDict, RECORD_OPTS_JSON_PATH, RUN_LOG_FILE_NAME,
         STDERR_DICT_PATH, STDOUT_DICT_PATH, STORE_ZIP_FILE_NAME, TEST_LIST_JSON_PATH,
     },
-    summary::{RecordOpts, TestEventSummary, ZipStoreOutput},
+    summary::{RecordOpts, TestEventSummary},
 };
 use crate::{
     errors::RecordReadError,
+    output_spec::RecordingSpec,
     record::format::{RERUN_INFO_JSON_PATH, RerunInfo},
     user_config::elements::MAX_MAX_OUTPUT_SIZE,
 };
@@ -413,7 +414,7 @@ pub struct RecordEventIter {
 }
 
 impl Iterator for RecordEventIter {
-    type Item = Result<TestEventSummary<ZipStoreOutput>, RecordReadError>;
+    type Item = Result<TestEventSummary<RecordingSpec>, RecordReadError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {

--- a/nextest-runner/src/record/replay.rs
+++ b/nextest-runner/src/record/replay.rs
@@ -10,6 +10,7 @@
 use crate::{
     errors::RecordReadError,
     list::{OwnedTestInstanceId, TestInstanceId, TestList},
+    output_spec::{LiveSpec, RecordingSpec},
     record::{
         CoreEventKind, OutputEventKind, OutputFileName, StoreReader, StressConditionSummary,
         StressIndexSummary, TestEventKindSummary, TestEventSummary, ZipStoreOutput,
@@ -87,7 +88,7 @@ impl<'a> ReplayContext<'a> {
     /// reference tests that weren't registered).
     pub fn convert_event<'cx>(
         &'cx self,
-        summary: &TestEventSummary<ZipStoreOutput>,
+        summary: &TestEventSummary<RecordingSpec>,
         reader: &mut dyn StoreReader,
     ) -> Result<TestEvent<'cx>, ReplayConversionError> {
         let kind = self.convert_event_kind(&summary.kind, reader)?;
@@ -100,7 +101,7 @@ impl<'a> ReplayContext<'a> {
 
     fn convert_event_kind<'cx>(
         &'cx self,
-        kind: &TestEventKindSummary<ZipStoreOutput>,
+        kind: &TestEventKindSummary<RecordingSpec>,
         reader: &mut dyn StoreReader,
     ) -> Result<TestEventKind<'cx>, ReplayConversionError> {
         match kind {
@@ -320,7 +321,7 @@ impl<'a> ReplayContext<'a> {
 
     fn convert_output_event<'cx>(
         &'cx self,
-        kind: &OutputEventKind<ZipStoreOutput>,
+        kind: &OutputEventKind<RecordingSpec>,
         reader: &mut dyn StoreReader,
     ) -> Result<TestEventKind<'cx>, ReplayConversionError> {
         match kind {
@@ -454,9 +455,9 @@ fn convert_stress_index(summary: &StressIndexSummary) -> StressIndex {
 }
 
 fn convert_execute_status(
-    status: &ExecuteStatus<ZipStoreOutput>,
+    status: &ExecuteStatus<RecordingSpec>,
     reader: &mut dyn StoreReader,
-) -> Result<ExecuteStatus<ChildSingleOutput>, ReplayConversionError> {
+) -> Result<ExecuteStatus<LiveSpec>, ReplayConversionError> {
     let output = convert_child_execution_output(&status.output, reader)?;
     Ok(ExecuteStatus {
         retry_data: status.retry_data,
@@ -472,10 +473,10 @@ fn convert_execute_status(
 }
 
 fn convert_execution_statuses(
-    statuses: &ExecutionStatuses<ZipStoreOutput>,
+    statuses: &ExecutionStatuses<RecordingSpec>,
     reader: &mut dyn StoreReader,
-) -> Result<ExecutionStatuses<ChildSingleOutput>, ReplayConversionError> {
-    let statuses: Vec<ExecuteStatus<ChildSingleOutput>> = statuses
+) -> Result<ExecutionStatuses<LiveSpec>, ReplayConversionError> {
+    let statuses: Vec<ExecuteStatus<LiveSpec>> = statuses
         .iter()
         .map(|s| convert_execute_status(s, reader))
         .collect::<Result<_, _>>()?;
@@ -484,9 +485,9 @@ fn convert_execution_statuses(
 }
 
 fn convert_setup_script_status(
-    status: &SetupScriptExecuteStatus<ZipStoreOutput>,
+    status: &SetupScriptExecuteStatus<RecordingSpec>,
     reader: &mut dyn StoreReader,
-) -> Result<SetupScriptExecuteStatus<ChildSingleOutput>, ReplayConversionError> {
+) -> Result<SetupScriptExecuteStatus<LiveSpec>, ReplayConversionError> {
     let output = convert_child_execution_output(&status.output, reader)?;
     Ok(SetupScriptExecuteStatus {
         output,
@@ -500,9 +501,9 @@ fn convert_setup_script_status(
 }
 
 fn convert_child_execution_output(
-    output: &ChildExecutionOutputDescription<ZipStoreOutput>,
+    output: &ChildExecutionOutputDescription<RecordingSpec>,
     reader: &mut dyn StoreReader,
-) -> Result<ChildExecutionOutputDescription<ChildSingleOutput>, ReplayConversionError> {
+) -> Result<ChildExecutionOutputDescription<LiveSpec>, ReplayConversionError> {
     match output {
         ChildExecutionOutputDescription::Output {
             result,
@@ -523,9 +524,9 @@ fn convert_child_execution_output(
 }
 
 fn convert_child_output(
-    output: &ChildOutputDescription<ZipStoreOutput>,
+    output: &ChildOutputDescription<RecordingSpec>,
     reader: &mut dyn StoreReader,
-) -> Result<ChildOutputDescription<ChildSingleOutput>, ReplayConversionError> {
+) -> Result<ChildOutputDescription<LiveSpec>, ReplayConversionError> {
     match output {
         ChildOutputDescription::Split { stdout, stderr } => {
             let stdout = stdout

--- a/nextest-runner/src/record/rerun.rs
+++ b/nextest-runner/src/record/rerun.rs
@@ -420,11 +420,11 @@ impl TestEventOutcomes {
 /// This helper exists to make the event processing logic testable without
 /// requiring a full `RecordReader`. It accepts a fallible iterator to enable
 /// streaming without in-memory buffering.
-fn collect_from_events<K, O, E>(
+fn collect_from_events<K, S: crate::output_spec::OutputSpec, E>(
     events: impl Iterator<Item = Result<K, E>>,
 ) -> Result<HashMap<OwnedTestInstanceId, TestOutcome>, E>
 where
-    K: Borrow<TestEventKindSummary<O>>,
+    K: Borrow<TestEventKindSummary<S>>,
 {
     let mut outcomes = HashMap::new();
 
@@ -477,6 +477,7 @@ where
 mod tests {
     use super::*;
     use crate::{
+        output_spec::RecordingSpec,
         record::{OutputEventKind, StressIndexSummary, TestEventKindSummary},
         reporter::{
             TestOutputDisplay,
@@ -1444,13 +1445,13 @@ mod tests {
 
     /// Creates a `TestFinished` event for testing.
     ///
-    /// Uses `()` as the output type since we don't need actual output data for
-    /// these tests.
+    /// Uses `RecordingSpec` as the output spec since we don't need actual output
+    /// data for these tests (all outputs are `None`).
     fn make_test_finished(
         test_instance: OwnedTestInstanceId,
         stress_index: Option<(u32, Option<u32>)>,
         passed: bool,
-    ) -> TestEventKindSummary<()> {
+    ) -> TestEventKindSummary<RecordingSpec> {
         let result = if passed {
             ExecutionResultDescription::Pass
         } else {

--- a/nextest-runner/src/reporter/aggregator/junit.rs
+++ b/nextest-runner/src/reporter/aggregator/junit.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     errors::{DisplayErrorChain, WriteEventError},
     list::TestInstanceId,
+    output_spec::LiveSpec,
     reporter::{
         UnitErrorDescription,
         displayer::DisplayUnitKind,
@@ -20,7 +21,6 @@ use crate::{
         },
     },
     run_mode::NextestRunMode,
-    test_output::ChildSingleOutput,
 };
 use debug_ignore::DebugIgnore;
 use indexmap::IndexMap;
@@ -455,7 +455,7 @@ impl TestcaseOrRerun<'_> {
 }
 
 fn set_execute_status_props(
-    exec_output: &ChildExecutionOutputDescription<ChildSingleOutput>,
+    exec_output: &ChildExecutionOutputDescription<LiveSpec>,
     store_stdout_stderr: bool,
     mut out: TestcaseOrRerun<'_>,
 ) {
@@ -772,7 +772,7 @@ mod tests {
     struct ExecuteStatusPropsCase<'a> {
         comment: &'a str,
         status: TestCaseStatus,
-        output: ChildExecutionOutputDescription<ChildSingleOutput>,
+        output: ChildExecutionOutputDescription<LiveSpec>,
         store_stdout_stderr: bool,
         message: Option<&'a str>,
         description: Option<&'a str>,

--- a/nextest-runner/src/reporter/displayer/imp.rs
+++ b/nextest-runner/src/reporter/displayer/imp.rs
@@ -31,6 +31,7 @@ use crate::{
     },
     indenter::indented,
     list::TestInstanceId,
+    output_spec::LiveSpec,
     record::{ReplayHeader, ShortestRunIdPrefix},
     reporter::{
         displayer::{
@@ -43,7 +44,6 @@ use crate::{
     },
     run_mode::NextestRunMode,
     runner::StressCount,
-    test_output::ChildSingleOutput,
     write_str::WriteStr,
 };
 use debug_ignore::DebugIgnore;
@@ -383,7 +383,7 @@ impl ReporterOutputImpl<'_> {
 enum FinalOutput {
     Skipped(#[expect(dead_code)] MismatchReason),
     Executed {
-        run_statuses: ExecutionStatuses<ChildSingleOutput>,
+        run_statuses: ExecutionStatuses<LiveSpec>,
         display_output: bool,
     },
 }
@@ -1452,7 +1452,7 @@ impl<'a> DisplayReporterImpl<'a> {
         script_id: &ScriptId,
         command: &str,
         args: &[String],
-        status: &SetupScriptExecuteStatus<ChildSingleOutput>,
+        status: &SetupScriptExecuteStatus<LiveSpec>,
         writer: &mut dyn WriteStr,
     ) -> io::Result<()> {
         match status.result {
@@ -1492,7 +1492,7 @@ impl<'a> DisplayReporterImpl<'a> {
         stress_index: Option<StressIndex>,
         counter: TestInstanceCounter,
         test_instance: TestInstanceId<'a>,
-        describe: ExecutionDescription<'_, ChildSingleOutput>,
+        describe: ExecutionDescription<'_, LiveSpec>,
         writer: &mut dyn WriteStr,
     ) -> io::Result<()> {
         self.write_status_line_impl(
@@ -1510,7 +1510,7 @@ impl<'a> DisplayReporterImpl<'a> {
         stress_index: Option<StressIndex>,
         counter: TestInstanceCounter,
         test_instance: TestInstanceId<'a>,
-        describe: ExecutionDescription<'_, ChildSingleOutput>,
+        describe: ExecutionDescription<'_, LiveSpec>,
         writer: &mut dyn WriteStr,
     ) -> io::Result<()> {
         self.write_status_line_impl(
@@ -1528,7 +1528,7 @@ impl<'a> DisplayReporterImpl<'a> {
         stress_index: Option<StressIndex>,
         counter: TestInstanceCounter,
         test_instance: TestInstanceId<'a>,
-        describe: ExecutionDescription<'_, ChildSingleOutput>,
+        describe: ExecutionDescription<'_, LiveSpec>,
         kind: StatusLineKind,
         writer: &mut dyn WriteStr,
     ) -> io::Result<()> {
@@ -1559,7 +1559,7 @@ impl<'a> DisplayReporterImpl<'a> {
 
     fn write_status_line_prefix(
         &self,
-        describe: ExecutionDescription<'_, ChildSingleOutput>,
+        describe: ExecutionDescription<'_, LiveSpec>,
         kind: StatusLineKind,
         writer: &mut dyn WriteStr,
     ) -> io::Result<()> {
@@ -2181,7 +2181,7 @@ impl<'a> DisplayReporterImpl<'a> {
 
     fn write_setup_script_execute_status(
         &self,
-        run_status: &SetupScriptExecuteStatus<ChildSingleOutput>,
+        run_status: &SetupScriptExecuteStatus<LiveSpec>,
         writer: &mut dyn WriteStr,
     ) -> io::Result<()> {
         let spec = self.output_spec_for_finished(&run_status.result, false);
@@ -2207,7 +2207,7 @@ impl<'a> DisplayReporterImpl<'a> {
 
     fn write_test_execute_status(
         &self,
-        run_status: &ExecuteStatus<ChildSingleOutput>,
+        run_status: &ExecuteStatus<LiveSpec>,
         is_retry: bool,
         writer: &mut dyn WriteStr,
     ) -> io::Result<()> {
@@ -2578,7 +2578,7 @@ mod tests {
                 UnitTerminateReason,
             },
         },
-        test_output::{ChildExecutionOutput, ChildOutput, ChildSingleOutput, ChildSplitOutput},
+        test_output::{ChildExecutionOutput, ChildOutput, ChildSplitOutput},
     };
     use bytes::Bytes;
     use chrono::Local;
@@ -3188,7 +3188,7 @@ mod tests {
 
         // Collect all test cases: (label, description).
         // The label helps identify each case in the snapshot.
-        let test_cases: Vec<(&str, ExecutionDescription<'_, ChildSingleOutput>)> = vec![
+        let test_cases: Vec<(&str, ExecutionDescription<'_, LiveSpec>)> = vec![
             // Success variants (is_slow = false).
             ("pass", pass_describe),
             ("leak pass", leak_pass_describe),
@@ -3854,7 +3854,7 @@ mod tests {
         result: Option<ExecutionResult>,
         stdout: &str,
         stderr: &str,
-    ) -> ChildExecutionOutputDescription<ChildSingleOutput> {
+    ) -> ChildExecutionOutputDescription<LiveSpec> {
         ChildExecutionOutput::Output {
             result,
             output: ChildOutput::Split(ChildSplitOutput {
@@ -3871,7 +3871,7 @@ mod tests {
         stdout: &str,
         stderr: &str,
         errors: Vec<ChildError>,
-    ) -> ChildExecutionOutputDescription<ChildSingleOutput> {
+    ) -> ChildExecutionOutputDescription<LiveSpec> {
         ChildExecutionOutput::Output {
             result,
             output: ChildOutput::Split(ChildSplitOutput {
@@ -3887,7 +3887,7 @@ mod tests {
         result: Option<ExecutionResult>,
         output: &str,
         errors: Vec<ChildError>,
-    ) -> ChildExecutionOutputDescription<ChildSingleOutput> {
+    ) -> ChildExecutionOutputDescription<LiveSpec> {
         ChildExecutionOutput::Output {
             result,
             output: ChildOutput::Combined {

--- a/nextest-runner/src/reporter/displayer/progress.rs
+++ b/nextest-runner/src/reporter/displayer/progress.rs
@@ -918,8 +918,9 @@ pub(super) fn progress_bar_msg(
 mod tests {
     use super::*;
     use crate::{
+        output_spec::LiveSpec,
         reporter::TestOutputDisplay,
-        test_output::{ChildExecutionOutput, ChildOutput, ChildSingleOutput, ChildSplitOutput},
+        test_output::{ChildExecutionOutput, ChildOutput, ChildSplitOutput},
     };
     use bytes::Bytes;
     use chrono::Local;
@@ -1345,7 +1346,7 @@ mod tests {
     }
 
     // Helper to create minimal output for ExecuteStatus.
-    fn make_test_output() -> ChildExecutionOutputDescription<ChildSingleOutput> {
+    fn make_test_output() -> ChildExecutionOutputDescription<LiveSpec> {
         ChildExecutionOutput::Output {
             result: Some(ExecutionResult::Pass),
             output: ChildOutput::Split(ChildSplitOutput {

--- a/nextest-runner/src/reporter/displayer/unit_output.rs
+++ b/nextest-runner/src/reporter/displayer/unit_output.rs
@@ -7,6 +7,7 @@ use super::DisplayerKind;
 use crate::{
     errors::DisplayErrorChain,
     indenter::indented,
+    output_spec::LiveSpec,
     reporter::{
         ByteSubslice, TestOutputErrorSlice, UnitErrorDescription,
         events::*,
@@ -129,7 +130,7 @@ impl UnitOutputReporter {
         &self,
         styles: &Styles,
         spec: &ChildOutputSpec,
-        exec_output: &ChildExecutionOutputDescription<ChildSingleOutput>,
+        exec_output: &ChildExecutionOutputDescription<LiveSpec>,
         mut writer: &mut dyn WriteStr,
     ) -> io::Result<()> {
         match exec_output {
@@ -181,7 +182,7 @@ impl UnitOutputReporter {
         &self,
         styles: &Styles,
         spec: &ChildOutputSpec,
-        output: &ChildOutputDescription<ChildSingleOutput>,
+        output: &ChildOutputDescription<LiveSpec>,
         highlight_slice: Option<TestOutputErrorSlice<'_>>,
         mut writer: &mut dyn WriteStr,
     ) -> io::Result<()> {

--- a/nextest-runner/src/reporter/error_description.rs
+++ b/nextest-runner/src/reporter/error_description.rs
@@ -6,7 +6,7 @@ use super::events::{
     ChildOutputDescription, ChildStartErrorDescription, ExecutionResultDescription,
     FailureDescription, UnitKind,
 };
-use crate::{errors::ErrorList, test_output::ChildSingleOutput};
+use crate::{errors::ErrorList, output_spec::LiveSpec};
 use bstr::ByteSlice;
 use regex::bytes::{Regex, RegexBuilder};
 use std::{fmt, sync::LazyLock};
@@ -25,10 +25,7 @@ pub struct UnitErrorDescription<'a> {
 
 impl<'a> UnitErrorDescription<'a> {
     /// Adds the execution output of a child process to the description.
-    pub fn new(
-        kind: UnitKind,
-        output: &'a ChildExecutionOutputDescription<ChildSingleOutput>,
-    ) -> Self {
+    pub fn new(kind: UnitKind, output: &'a ChildExecutionOutputDescription<LiveSpec>) -> Self {
         let mut start_error = None;
         let mut output_errors = None;
         let mut abort = None;

--- a/nextest-runner/src/reporter/structured/libtest.rs
+++ b/nextest-runner/src/reporter/structured/libtest.rs
@@ -26,6 +26,7 @@ use crate::{
     config::elements::{LeakTimeoutResult, SlowTimeoutResult},
     errors::{DisplayErrorChain, FormatVersionError, FormatVersionErrorInner, WriteEventError},
     list::{RustTestSuite, TestList},
+    output_spec::LiveSpec,
     reporter::events::{
         ChildExecutionOutputDescription, ChildOutputDescription, ExecutionResultDescription,
         StressIndex, TestEvent, TestEventKind,
@@ -586,7 +587,7 @@ impl<'cfg> LibtestReporter<'cfg> {
 /// This function relies on the fact that nextest runs every individual test in
 /// isolation.
 fn strip_human_output_from_failed_test(
-    output: &ChildExecutionOutputDescription<ChildSingleOutput>,
+    output: &ChildExecutionOutputDescription<LiveSpec>,
     out: &mut bytes::BytesMut,
     test_name: &TestCaseName,
 ) -> Result<(), WriteEventError> {

--- a/nextest-runner/src/reporter/structured/recorder.rs
+++ b/nextest-runner/src/reporter/structured/recorder.rs
@@ -5,9 +5,9 @@
 
 use crate::{
     errors::RecordReporterError,
+    output_spec::LiveSpec,
     record::{RecordOpts, RunRecorder, StoreSizes, TestEventSummary},
     reporter::events::TestEvent,
-    test_output::ChildSingleOutput,
 };
 use nextest_metadata::TestListSummary;
 use std::{
@@ -165,5 +165,5 @@ enum RecordEvent {
         opts: RecordOpts,
     },
     /// A test event.
-    TestEvent(TestEventSummary<ChildSingleOutput>),
+    TestEvent(TestEventSummary<LiveSpec>),
 }

--- a/nextest-runner/src/runner/internal_events.rs
+++ b/nextest-runner/src/runner/internal_events.rs
@@ -12,6 +12,7 @@ use crate::{
     config::scripts::{ScriptId, SetupScriptConfig},
     errors::DisplayErrorChain,
     list::TestInstance,
+    output_spec::LiveSpec,
     reporter::{
         TestOutputDisplay, UnitErrorDescription,
         events::{
@@ -21,7 +22,7 @@ use crate::{
         },
     },
     signal::ShutdownEvent,
-    test_output::{ChildExecutionOutput, ChildSingleOutput},
+    test_output::ChildExecutionOutput,
     time::StopwatchSnapshot,
 };
 use nextest_metadata::MismatchReason;
@@ -66,7 +67,7 @@ pub(super) enum ExecutorEvent<'a> {
         program: String,
         index: usize,
         total: usize,
-        status: SetupScriptExecuteStatus<ChildSingleOutput>,
+        status: SetupScriptExecuteStatus<LiveSpec>,
     },
     Started {
         stress_index: Option<StressIndex>,
@@ -95,7 +96,7 @@ pub(super) enum ExecutorEvent<'a> {
         stress_index: Option<StressIndex>,
         test_instance: TestInstance<'a>,
         failure_output: TestOutputDisplay,
-        run_status: ExecuteStatus<ChildSingleOutput>,
+        run_status: ExecuteStatus<LiveSpec>,
         delay_before_next_attempt: Duration,
     },
     RetryStarted {
@@ -113,7 +114,7 @@ pub(super) enum ExecutorEvent<'a> {
         failure_output: TestOutputDisplay,
         junit_store_success_output: bool,
         junit_store_failure_output: bool,
-        last_run_status: ExecuteStatus<ChildSingleOutput>,
+        last_run_status: ExecuteStatus<LiveSpec>,
     },
     Skipped {
         stress_index: Option<StressIndex>,
@@ -160,8 +161,8 @@ pub(super) struct InternalExecuteStatus<'a> {
 }
 
 impl InternalExecuteStatus<'_> {
-    pub(super) fn into_external(self) -> ExecuteStatus<ChildSingleOutput> {
-        let output: ChildExecutionOutputDescription<ChildSingleOutput> = self.output.into();
+    pub(super) fn into_external(self) -> ExecuteStatus<LiveSpec> {
+        let output: ChildExecutionOutputDescription<LiveSpec> = self.output.into();
 
         // Compute the error summary and output error slice using
         // UnitErrorDescription.
@@ -199,8 +200,8 @@ pub(super) struct InternalSetupScriptExecuteStatus<'a> {
 }
 
 impl InternalSetupScriptExecuteStatus<'_> {
-    pub(super) fn into_external(self) -> SetupScriptExecuteStatus<ChildSingleOutput> {
-        let output: ChildExecutionOutputDescription<ChildSingleOutput> = self.output.into();
+    pub(super) fn into_external(self) -> SetupScriptExecuteStatus<LiveSpec> {
+        let output: ChildExecutionOutputDescription<LiveSpec> = self.output.into();
 
         // Compute the error summary using UnitErrorDescription.
         // Setup scripts don't have output_error_slice since that's only for


### PR DESCRIPTION
For upcoming log file support we're going to need a different way to represent live outputs. Prepare for that -- this is good code hygiene anyway.