### PR TITLE
[nextest-runner] skip loading output for replays unless necessary

### DIFF
--- a/nextest-runner/src/output_spec.rs
+++ b/nextest-runner/src/output_spec.rs
@@ -6,15 +6,15 @@
 //! The [`OutputSpec`] trait abstracts over two modes of output storage:
 //!
 //! - [`LiveSpec`]: output stored in memory during live execution, using
-//!   [`ChildSingleOutput`].
+//!   [`ChildOutputDescription`].
 //! - [`RecordingSpec`]: output stored in recordings,
-//!   using [`ZipStoreOutput`].
+//!   using [`ZipStoreOutputDescription`].
 //!
-//! Types generic over `S: OutputSpec` use `S::ChildOutput` for their output
-//! fields. This enables adding additional associated types in the future
-//! without changing every generic type's parameter list.
+//! Types generic over `S: OutputSpec` use `S::ChildOutputDesc` for their output
+//! description fields. This enables adding additional associated types in the
+//! future without changing every generic type's parameter list.
 
-use crate::{record::ZipStoreOutput, test_output::ChildSingleOutput};
+use crate::{record::ZipStoreOutputDescription, reporter::events::ChildOutputDescription};
 
 /// Specifies how test output is represented.
 ///
@@ -23,26 +23,26 @@ use crate::{record::ZipStoreOutput, test_output::ChildSingleOutput};
 /// - [`LiveSpec`]: output stored in memory during live execution.
 /// - [`RecordingSpec`]: output stored in recordings.
 pub trait OutputSpec {
-    /// The type used to represent a single child output stream.
-    type ChildOutput;
+    /// The type used to describe child output.
+    type ChildOutputDesc;
 }
 
 /// Output spec for live test execution.
 ///
-/// Uses [`ChildSingleOutput`] for in-memory byte buffers with lazy UTF-8 string
-/// conversion.
+/// Uses [`ChildOutputDescription`] for in-memory byte buffers with lazy UTF-8
+/// string conversion.
 pub struct LiveSpec;
 
 impl OutputSpec for LiveSpec {
-    type ChildOutput = ChildSingleOutput;
+    type ChildOutputDesc = ChildOutputDescription;
 }
 
 /// Output spec for recorded/replayed test runs.
 ///
-/// Uses [`ZipStoreOutput`] for content-addressed file references in zip
-/// archives.
+/// Uses [`ZipStoreOutputDescription`] for content-addressed file references in
+/// zip archives.
 pub struct RecordingSpec;
 
 impl OutputSpec for RecordingSpec {
-    type ChildOutput = ZipStoreOutput;
+    type ChildOutputDesc = ZipStoreOutputDescription;
 }

--- a/nextest-runner/src/record/mod.rs
+++ b/nextest-runner/src/record/mod.rs
@@ -61,7 +61,8 @@ pub use portable::{
 pub use reader::{RecordEventIter, RecordReader, StoreReader};
 pub use recorder::{RunRecorder, StoreSizes};
 pub use replay::{
-    ReplayContext, ReplayConversionError, ReplayHeader, ReplayReporter, ReplayReporterBuilder,
+    LoadOutput, ReplayContext, ReplayConversionError, ReplayHeader, ReplayReporter,
+    ReplayReporterBuilder,
 };
 pub use rerun::ComputedRerunInfo;
 pub use retention::{PruneKind, PrunePlan, PruneResult, RecordRetentionPolicy};
@@ -80,4 +81,5 @@ pub use store::{
 pub use summary::{
     CoreEventKind, OutputEventKind, OutputFileName, RecordOpts, StressConditionSummary,
     StressIndexSummary, TestEventKindSummary, TestEventSummary, ZipStoreOutput,
+    ZipStoreOutputDescription,
 };

--- a/nextest-runner/src/record/rerun.rs
+++ b/nextest-runner/src/record/rerun.rs
@@ -478,13 +478,14 @@ mod tests {
     use super::*;
     use crate::{
         output_spec::RecordingSpec,
-        record::{OutputEventKind, StressIndexSummary, TestEventKindSummary},
+        record::{
+            OutputEventKind, StressIndexSummary, TestEventKindSummary, ZipStoreOutputDescription,
+        },
         reporter::{
             TestOutputDisplay,
             events::{
-                ChildExecutionOutputDescription, ChildOutputDescription, ExecuteStatus,
-                ExecutionResultDescription, ExecutionStatuses, FailureDescription, RetryData,
-                RunStats,
+                ChildExecutionOutputDescription, ExecuteStatus, ExecutionResultDescription,
+                ExecutionStatuses, FailureDescription, RetryData, RunStats,
             },
         },
     };
@@ -1468,7 +1469,7 @@ mod tests {
             },
             output: ChildExecutionOutputDescription::Output {
                 result: Some(result.clone()),
-                output: ChildOutputDescription::Split {
+                output: ZipStoreOutputDescription::Split {
                     stdout: None,
                     stderr: None,
                 },

--- a/nextest-runner/src/record/summary.rs
+++ b/nextest-runner/src/record/summary.rs
@@ -66,19 +66,19 @@ impl RecordOpts {
 ///
 /// The `S` parameter specifies how test outputs are stored (see
 /// [`OutputSpec`]).
-#[derive_where::derive_where(Debug, PartialEq; S::ChildOutput)]
+#[derive_where::derive_where(Debug, PartialEq; S::ChildOutputDesc)]
 #[derive(Deserialize, Serialize)]
 #[serde(
     rename_all = "kebab-case",
     bound(
-        serialize = "S::ChildOutput: Serialize",
-        deserialize = "S::ChildOutput: serde::de::DeserializeOwned"
+        serialize = "S::ChildOutputDesc: Serialize",
+        deserialize = "S::ChildOutputDesc: serde::de::DeserializeOwned"
     )
 )]
 #[cfg_attr(
     test,
     derive(test_strategy::Arbitrary),
-    arbitrary(bound(S: 'static, S::ChildOutput: proptest::arbitrary::Arbitrary + PartialEq + 'static))
+    arbitrary(bound(S: 'static, S::ChildOutputDesc: proptest::arbitrary::Arbitrary + PartialEq + 'static))
 )]
 pub struct TestEventSummary<S: OutputSpec> {
     /// The timestamp of the event.
@@ -120,20 +120,20 @@ impl TestEventSummary<LiveSpec> {
 ///
 /// The type parameter `S` specifies how test output is stored (see
 /// [`OutputSpec`]).
-#[derive_where::derive_where(Debug, PartialEq; S::ChildOutput)]
+#[derive_where::derive_where(Debug, PartialEq; S::ChildOutputDesc)]
 #[derive(Deserialize, Serialize)]
 #[serde(
     tag = "type",
     rename_all = "kebab-case",
     bound(
-        serialize = "S::ChildOutput: Serialize",
-        deserialize = "S::ChildOutput: serde::de::DeserializeOwned"
+        serialize = "S::ChildOutputDesc: Serialize",
+        deserialize = "S::ChildOutputDesc: serde::de::DeserializeOwned"
     )
 )]
 #[cfg_attr(
     test,
     derive(test_strategy::Arbitrary),
-    arbitrary(bound(S: 'static, S::ChildOutput: proptest::arbitrary::Arbitrary + PartialEq + 'static))
+    arbitrary(bound(S: 'static, S::ChildOutputDesc: proptest::arbitrary::Arbitrary + PartialEq + 'static))
 )]
 pub enum TestEventKindSummary<S: OutputSpec> {
     /// An event that doesn't carry output.
@@ -346,20 +346,20 @@ pub struct TestsNotSeenSummary {
 ///
 /// The type parameter `S` specifies how test output is stored (see
 /// [`OutputSpec`]).
-#[derive_where::derive_where(Debug, PartialEq; S::ChildOutput)]
+#[derive_where::derive_where(Debug, PartialEq; S::ChildOutputDesc)]
 #[derive(Deserialize, Serialize)]
 #[serde(
     tag = "kind",
     rename_all = "kebab-case",
     bound(
-        serialize = "S::ChildOutput: Serialize",
-        deserialize = "S::ChildOutput: serde::de::DeserializeOwned"
+        serialize = "S::ChildOutputDesc: Serialize",
+        deserialize = "S::ChildOutputDesc: serde::de::DeserializeOwned"
     )
 )]
 #[cfg_attr(
     test,
     derive(test_strategy::Arbitrary),
-    arbitrary(bound(S: 'static, S::ChildOutput: proptest::arbitrary::Arbitrary + PartialEq + 'static))
+    arbitrary(bound(S: 'static, S::ChildOutputDesc: proptest::arbitrary::Arbitrary + PartialEq + 'static))
 )]
 pub enum OutputEventKind<S: OutputSpec> {
     /// A setup script finished.
@@ -842,6 +842,32 @@ impl ZipStoreOutput {
             }
         }
     }
+}
+
+/// A description of child process output stored in a recording.
+///
+/// This is the recording-side counterpart to [`ChildOutputDescription`]. Unlike
+/// `ChildOutputDescription`, this type does not have a `NotLoaded` variant,
+/// because recorded output is always present in the archive.
+///
+/// [`ChildOutputDescription`]: crate::reporter::events::ChildOutputDescription
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+#[cfg_attr(test, derive(test_strategy::Arbitrary))]
+pub enum ZipStoreOutputDescription {
+    /// The output was split into stdout and stderr.
+    Split {
+        /// Standard output, or `None` if not captured.
+        stdout: Option<ZipStoreOutput>,
+        /// Standard error, or `None` if not captured.
+        stderr: Option<ZipStoreOutput>,
+    },
+
+    /// The output was combined into a single stream.
+    Combined {
+        /// The combined output.
+        output: ZipStoreOutput,
+    },
 }
 
 #[cfg(test)]

--- a/nextest-runner/src/reporter/aggregator/junit.rs
+++ b/nextest-runner/src/reporter/aggregator/junit.rs
@@ -490,6 +490,16 @@ fn set_execute_status_props(
                 out.set_system_out(output.as_str_lossy())
                     .set_system_err(STDOUT_STDERR_COMBINED);
             }
+            ChildExecutionOutputDescription::Output {
+                output: ChildOutputDescription::NotLoaded,
+                ..
+            } => {
+                unreachable!(
+                    "attempted to store stdout/stderr from output that was not loaded \
+                     (the JUnit reporter is not used during replay, where NotLoaded \
+                     is produced)"
+                );
+            }
             ChildExecutionOutputDescription::StartError(_) => {
                 out.set_system_out(PROCESS_FAILED_TO_START)
                     .set_system_err(PROCESS_FAILED_TO_START);

--- a/nextest-runner/src/reporter/displayer/mod.rs
+++ b/nextest-runner/src/reporter/displayer/mod.rs
@@ -12,6 +12,7 @@ mod unit_output;
 
 pub(crate) use config::*;
 pub(crate) use formatters::DisplayUnitKind;
+pub use imp::OutputLoadDecider;
 pub(crate) use imp::*;
 pub use progress::{MaxProgressRunning, ShowProgress, ShowTerminalProgress};
 pub use status_level::*;

--- a/nextest-runner/src/reporter/error_description.rs
+++ b/nextest-runner/src/reporter/error_description.rs
@@ -58,6 +58,13 @@ impl<'a> UnitErrorDescription<'a> {
                                     Some(output.buf.as_ref()),
                                 );
                             }
+                            ChildOutputDescription::NotLoaded => {
+                                unreachable!(
+                                    "attempted to extract errors from output that was not loaded \
+                                     (the OutputLoadDecider should have returned Load for this \
+                                     event)"
+                                );
+                            }
                         }
                     }
 

--- a/nextest-runner/src/reporter/mod.rs
+++ b/nextest-runner/src/reporter/mod.rs
@@ -17,8 +17,8 @@ pub(crate) mod test_helpers;
 
 pub(crate) use displayer::{DisplayConfig, DisplayReporter, DisplayReporterBuilder, DisplayerKind};
 pub use displayer::{
-    FinalStatusLevel, MaxProgressRunning, ShowProgress, ShowTerminalProgress, StatusLevel,
-    TestOutputDisplay,
+    FinalStatusLevel, MaxProgressRunning, OutputLoadDecider, ShowProgress, ShowTerminalProgress,
+    StatusLevel, TestOutputDisplay,
 };
 pub use error_description::*;
 pub use helpers::highlight_end;

--- a/nextest-runner/src/reporter/structured/libtest.rs
+++ b/nextest-runner/src/reporter/structured/libtest.rs
@@ -628,6 +628,13 @@ fn strip_human_output_from_failed_test(
                         writeln!(out, "\\n(stderr not captured)").map_err(fmt_err)?;
                     }
                 }
+                ChildOutputDescription::NotLoaded => {
+                    unreachable!(
+                        "attempted to strip output from output that was not loaded \
+                         (the libtest reporter is not used during replay, where NotLoaded \
+                         is produced)"
+                    );
+                }
             }
 
             if let Some(errors) = errors {


### PR DESCRIPTION
Measured this against a 727 test run locally -- `time cargo nextest replay > /dev/null` dropped from 0.15s to 0.135s.

We use a pure function with a conservative approximation to avoid having to track the cancel reason and other less relevant facts.

The property-based tests ensure the invariants.