### PR TITLE
[nextest-runner] use subtraits for Serialize/Arbitrary bounds

### DIFF
--- a/nextest-runner/src/output_spec.rs
+++ b/nextest-runner/src/output_spec.rs
@@ -15,6 +15,7 @@
 //! future without changing every generic type's parameter list.
 
 use crate::{record::ZipStoreOutputDescription, reporter::events::ChildOutputDescription};
+use serde::{Serialize, de::DeserializeOwned};
 
 /// Specifies how test output is represented.
 ///
@@ -45,4 +46,33 @@ pub struct RecordingSpec;
 
 impl OutputSpec for RecordingSpec {
     type ChildOutputDesc = ZipStoreOutputDescription;
+}
+
+/// An [`OutputSpec`] that supports serialization and deserialization.
+pub trait SerializableOutputSpec:
+    OutputSpec<ChildOutputDesc: Serialize + DeserializeOwned>
+{
+}
+
+impl<S> SerializableOutputSpec for S
+where
+    S: OutputSpec,
+    S::ChildOutputDesc: Serialize + DeserializeOwned,
+{
+}
+
+/// An [`OutputSpec`] that supports generation via
+/// [`proptest::arbitrary::Arbitrary`].
+#[cfg(test)]
+pub(crate) trait ArbitraryOutputSpec:
+    OutputSpec<ChildOutputDesc: proptest::arbitrary::Arbitrary + PartialEq + 'static> + 'static
+{
+}
+
+#[cfg(test)]
+impl<S> ArbitraryOutputSpec for S
+where
+    S: OutputSpec + 'static,
+    S::ChildOutputDesc: proptest::arbitrary::Arbitrary + PartialEq + 'static,
+{
 }

--- a/nextest-runner/src/record/summary.rs
+++ b/nextest-runner/src/record/summary.rs
@@ -14,10 +14,12 @@
 //! - [`RecordingSpec`](crate::output_spec::RecordingSpec): reference to a file stored
 //!   in the zip archive.
 
+#[cfg(test)]
+use crate::output_spec::ArbitraryOutputSpec;
 use crate::{
     config::scripts::ScriptId,
     list::OwnedTestInstanceId,
-    output_spec::{LiveSpec, OutputSpec},
+    output_spec::{LiveSpec, OutputSpec, SerializableOutputSpec},
     reporter::{
         TestOutputDisplay,
         events::{
@@ -71,14 +73,14 @@ impl RecordOpts {
 #[serde(
     rename_all = "kebab-case",
     bound(
-        serialize = "S::ChildOutputDesc: Serialize",
-        deserialize = "S::ChildOutputDesc: serde::de::DeserializeOwned"
+        serialize = "S: SerializableOutputSpec",
+        deserialize = "S: SerializableOutputSpec"
     )
 )]
 #[cfg_attr(
     test,
     derive(test_strategy::Arbitrary),
-    arbitrary(bound(S: 'static, S::ChildOutputDesc: proptest::arbitrary::Arbitrary + PartialEq + 'static))
+    arbitrary(bound(S: ArbitraryOutputSpec))
 )]
 pub struct TestEventSummary<S: OutputSpec> {
     /// The timestamp of the event.
@@ -126,14 +128,14 @@ impl TestEventSummary<LiveSpec> {
     tag = "type",
     rename_all = "kebab-case",
     bound(
-        serialize = "S::ChildOutputDesc: Serialize",
-        deserialize = "S::ChildOutputDesc: serde::de::DeserializeOwned"
+        serialize = "S: SerializableOutputSpec",
+        deserialize = "S: SerializableOutputSpec"
     )
 )]
 #[cfg_attr(
     test,
     derive(test_strategy::Arbitrary),
-    arbitrary(bound(S: 'static, S::ChildOutputDesc: proptest::arbitrary::Arbitrary + PartialEq + 'static))
+    arbitrary(bound(S: ArbitraryOutputSpec))
 )]
 pub enum TestEventKindSummary<S: OutputSpec> {
     /// An event that doesn't carry output.
@@ -352,14 +354,14 @@ pub struct TestsNotSeenSummary {
     tag = "kind",
     rename_all = "kebab-case",
     bound(
-        serialize = "S::ChildOutputDesc: Serialize",
-        deserialize = "S::ChildOutputDesc: serde::de::DeserializeOwned"
+        serialize = "S: SerializableOutputSpec",
+        deserialize = "S: SerializableOutputSpec"
     )
 )]
 #[cfg_attr(
     test,
     derive(test_strategy::Arbitrary),
-    arbitrary(bound(S: 'static, S::ChildOutputDesc: proptest::arbitrary::Arbitrary + PartialEq + 'static))
+    arbitrary(bound(S: ArbitraryOutputSpec))
 )]
 pub enum OutputEventKind<S: OutputSpec> {
     /// A setup script finished.


### PR DESCRIPTION
We're going to add a second `LogFile` associated type -- avoid having to add bounds everywhere.