### PR TITLE
[nextest-runner] remove record migration from cache dir to state dir

### DIFF
--- a/nextest-runner/src/record/state_dir.rs
+++ b/nextest-runner/src/record/state_dir.rs
@@ -9,11 +9,9 @@
 //! the application must be able to regenerate," but recordings capture a
 //! specific execution at a specific point in time and cannot be regenerated.
 
-use crate::errors::{DisplayErrorChain, StateDirError};
+use crate::errors::StateDirError;
 use camino::{Utf8Path, Utf8PathBuf};
 use etcetera::{BaseStrategy, choose_base_strategy};
-use std::fs;
-use tracing::{info, warn};
 use xxhash_rust::xxh3::xxh3_64;
 
 /// Maximum length of the encoded workspace path in bytes.
@@ -46,20 +44,13 @@ pub const NEXTEST_STATE_DIR_ENV: &str = "NEXTEST_STATE_DIR";
 /// representation. This ensures that accessing a workspace via a symlink
 /// produces the same state directory as accessing it via the real path.
 ///
-/// ## Migration from cache to state directory
-///
-/// On first access after upgrading, this function automatically migrates the
-/// entire `~/.cache/nextest/` directory (nextest <= 0.9.125) to
-/// `~/.local/state/nextest/` if the old location exists and the new one does
-/// not. This is a one-time migration.
-///
 /// Returns an error if:
 ///
 /// - The platform state directory cannot be determined.
 /// - The workspace path cannot be canonicalized (e.g., doesn't exist).
 /// - Any path is not valid UTF-8.
 pub fn records_state_dir(workspace_root: &Utf8Path) -> Result<Utf8PathBuf, StateDirError> {
-    // If NEXTEST_STATE_DIR is set, use it directly (no migration).
+    // If NEXTEST_STATE_DIR is set, use it directly.
     if let Ok(state_dir) = std::env::var(NEXTEST_STATE_DIR_ENV) {
         let base_dir = Utf8PathBuf::from(state_dir);
         let canonical_workspace =
@@ -92,20 +83,8 @@ pub fn records_state_dir(workspace_root: &Utf8Path) -> Result<Utf8PathBuf, State
     // Compute the state directory path. Use state_dir() if available, otherwise
     // fall back to cache_dir() (Windows has no state directory concept).
     let nextest_dir = if let Some(base_state_dir) = strategy.state_dir() {
-        // The state directory is available (Unix with XDG). Attempt a one-time
-        // migration from the old cache location.
-        let nextest_state = base_state_dir.join("nextest");
-        let nextest_cache = strategy.cache_dir().join("nextest");
-        if let (Ok(nextest_state_utf8), Ok(nextest_cache_utf8)) = (
-            Utf8PathBuf::from_path_buf(nextest_state.clone()),
-            Utf8PathBuf::from_path_buf(nextest_cache),
-        ) && nextest_state_utf8 != nextest_cache_utf8
-        {
-            migrate_nextest_dir(&nextest_cache_utf8, &nextest_state_utf8);
-        };
-        nextest_state
+        base_state_dir.join("nextest")
     } else {
-        // No state directory (Windows). Use cache directory directly.
         strategy.cache_dir().join("nextest")
     };
 
@@ -116,40 +95,6 @@ pub fn records_state_dir(workspace_root: &Utf8Path) -> Result<Utf8PathBuf, State
         .join("projects")
         .join(&encoded_workspace)
         .join("records"))
-}
-
-/// Attempts to migrate the entire nextest directory from cache to state location.
-///
-/// This is a one-time migration.
-fn migrate_nextest_dir(old_dir: &Utf8Path, new_dir: &Utf8Path) {
-    if !old_dir.exists() || new_dir.exists() {
-        return;
-    }
-
-    if let Some(parent) = new_dir.parent()
-        && let Err(error) = fs::create_dir_all(parent)
-    {
-        warn!(
-            "failed to create parent directory for new state location \
-             at `{new_dir}`: {}",
-            DisplayErrorChain::new(&error),
-        );
-        return;
-    }
-
-    // Attempt an atomic rename.
-    match fs::rename(old_dir, new_dir) {
-        Ok(()) => {
-            info!("migrated nextest recordings from `{old_dir}` to `{new_dir}`");
-        }
-        Err(error) => {
-            warn!(
-                "failed to migrate nextest recordings from `{old_dir}` to `{new_dir}` \
-                 (cross-filesystem move or permission issue): {}",
-                DisplayErrorChain::new(&error),
-            );
-        }
-    }
 }
 
 /// Encodes a workspace path into a directory-safe string.
@@ -269,6 +214,7 @@ pub fn decode_workspace_path(encoded: &str) -> Option<Utf8PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     #[test]
     fn test_records_state_dir() {
@@ -325,117 +271,6 @@ mod tests {
             state_via_real, state_via_symlink,
             "state dir should be the same whether accessed via real path or symlink"
         );
-    }
-
-    #[test]
-    fn test_migration_from_cache_to_state() {
-        // This test verifies that the entire nextest directory is migrated at once.
-        let temp_dir = camino_tempfile::tempdir().expect("tempdir should be created");
-        let base = temp_dir.path();
-
-        // Create the old cache nextest directory with multiple workspaces.
-        let old_nextest = base.join("cache").join("nextest");
-        let workspace1_records = old_nextest
-            .join("projects")
-            .join("workspace1")
-            .join("records");
-        let workspace2_records = old_nextest
-            .join("projects")
-            .join("workspace2")
-            .join("records");
-        fs::create_dir_all(&workspace1_records).expect("workspace1 dir should be created");
-        fs::create_dir_all(&workspace2_records).expect("workspace2 dir should be created");
-
-        // Create marker files in both workspaces.
-        fs::write(workspace1_records.join("runs.json.zst"), b"workspace1 data")
-            .expect("workspace1 marker should be created");
-        fs::write(workspace2_records.join("runs.json.zst"), b"workspace2 data")
-            .expect("workspace2 marker should be created");
-
-        // Verify the old location exists.
-        assert!(
-            old_nextest.exists(),
-            "old nextest dir should exist before migration"
-        );
-
-        // Simulate migration by calling migrate_nextest_dir directly.
-        let new_nextest = base.join("state").join("nextest");
-        migrate_nextest_dir(&old_nextest, &new_nextest);
-
-        // Verify migration succeeded: old is gone, new has all the content.
-        assert!(
-            !old_nextest.exists(),
-            "old nextest dir should not exist after migration"
-        );
-        assert!(
-            new_nextest.exists(),
-            "new nextest dir should exist after migration"
-        );
-        assert!(
-            new_nextest
-                .join("projects")
-                .join("workspace1")
-                .join("records")
-                .join("runs.json.zst")
-                .exists(),
-            "workspace1 marker should exist in new location"
-        );
-        assert!(
-            new_nextest
-                .join("projects")
-                .join("workspace2")
-                .join("records")
-                .join("runs.json.zst")
-                .exists(),
-            "workspace2 marker should exist in new location"
-        );
-    }
-
-    #[test]
-    fn test_migration_skipped_if_new_exists() {
-        let temp_dir = camino_tempfile::tempdir().expect("tempdir should be created");
-        let base = temp_dir.path();
-
-        let old_nextest = base.join("cache").join("nextest");
-        let new_nextest = base.join("state").join("nextest");
-        fs::create_dir_all(old_nextest.join("projects")).expect("old dir should be created");
-        fs::create_dir_all(new_nextest.join("projects")).expect("new dir should be created");
-
-        // Put different content in each to verify no migration occurs.
-        fs::write(old_nextest.join("old_marker"), b"old").expect("old marker should be created");
-        fs::write(new_nextest.join("new_marker"), b"new").expect("new marker should be created");
-
-        migrate_nextest_dir(&old_nextest, &new_nextest);
-
-        // Both should still exist with their original content.
-        assert!(old_nextest.exists(), "old dir should still exist");
-        assert!(new_nextest.exists(), "new dir should still exist");
-        assert!(
-            old_nextest.join("old_marker").exists(),
-            "old marker should still exist"
-        );
-        assert!(
-            new_nextest.join("new_marker").exists(),
-            "new marker should still exist"
-        );
-    }
-
-    #[test]
-    fn test_migration_skipped_if_old_does_not_exist() {
-        // Migration should not occur if the old directory doesn't exist.
-        let temp_dir = camino_tempfile::tempdir().expect("tempdir should be created");
-        let base = temp_dir.path();
-
-        let old_nextest = base.join("cache").join("nextest");
-        let new_nextest = base.join("state").join("nextest");
-
-        assert!(!old_nextest.exists());
-        assert!(!new_nextest.exists());
-
-        migrate_nextest_dir(&old_nextest, &new_nextest);
-
-        assert!(!old_nextest.exists());
-        assert!(!new_nextest.exists());
     }
 
     // Basic encoding tests.


### PR DESCRIPTION
This migration was meant to be short-lived.