### PR TITLE
docs: replace metaphor with precise test workload wording

### DIFF
--- a/site/src/index.md
+++ b/site/src/index.md
@@ -42,7 +42,7 @@ Welcome to the home page for **cargo-nextest**, a next-generation test runner fo
 
     ---
 
-    Treat tests as cattle, not pets. Detect and terminate [slow tests](docs/features/slow-tests.md). Loop over tests many times with [stress testing](docs/features/stress-tests.md).
+    Treat tests as replaceable workloads. Detect and terminate [slow tests](docs/features/slow-tests.md). Loop over tests many times with [stress testing](docs/features/stress-tests.md).
 
     [:octicons-arrow-right-24: Slow tests and timeouts](docs/features/slow-tests.md)
 


### PR DESCRIPTION
## Summary\n- replace the phrase 'Treat tests as cattle, not pets' on the website landing page\n- use direct wording: 'Treat tests as replaceable workloads'\n\n## Why\n- preserves the same operational guidance while using precise technical language\n- keeps onboarding copy clear for readers unfamiliar with the metaphor\n\n## Scope\n- docs-only, one-line copy change