### PR TITLE
optimize reused binaries-only list path

### DIFF
--- a/cargo-nextest/src/dispatch/app.rs
+++ b/cargo-nextest/src/dispatch/app.rs
@@ -114,6 +114,16 @@ impl AppOpts {
     ) -> Result<i32> {
         match self.command {
             Command::List(list_opts) => {
+                if list_opts.try_exec_binaries_only_fast(
+                    &early_args,
+                    self.common.manifest_path.as_deref(),
+                    &self.common.config_opts,
+                    output,
+                    output_writer,
+                )? {
+                    return Ok(0);
+                }
+
                 let base = BaseApp::new(
                     output,
                     early_args,

--- a/cargo-nextest/src/dispatch/core/base.rs
+++ b/cargo-nextest/src/dispatch/core/base.rs
@@ -9,7 +9,11 @@ use crate::{
     dispatch::{
         EarlyArgs,
         common::ConfigOpts,
-        helpers::{acquire_graph_data, detect_build_platforms, runner_for_target},
+        helpers::{
+            acquire_graph_data, check_version_config_final as check_version_config_final_impl,
+            detect_build_platforms, load_version_only_config as load_version_only_config_impl,
+            runner_for_target,
+        },
     },
     output::{OutputContext, OutputWriter},
 };
@@ -19,8 +23,7 @@ use nextest_filtering::ParseContext;
 use nextest_runner::{
     cargo_config::CargoConfigs,
     config::core::{
-        ConfigExperimental, EarlyProfile, ExperimentalConfig, NextestConfig, NextestVersionConfig,
-        NextestVersionEval, VersionOnlyConfig,
+        ConfigExperimental, EarlyProfile, NextestConfig, NextestVersionConfig, VersionOnlyConfig,
     },
     double_spawn::DoubleSpawnInfo,
     list::BinaryList,
@@ -28,14 +31,13 @@ use nextest_runner::{
     reuse_build::ReuseBuildInfo,
     target_runner::TargetRunner,
 };
-use owo_colors::OwoColorize;
 use semver::Version;
 use std::{
     collections::BTreeSet,
     env::VarError,
     sync::{Arc, OnceLock},
 };
-use tracing::{Level, info, warn};
+use tracing::{info, warn};
 
 /// Base application state shared by core commands (run, list, bench, archive).
 pub(crate) struct BaseApp {
@@ -150,49 +152,7 @@ impl BaseApp {
         pcx: &ParseContext<'_>,
         required_experimental: &BTreeSet<ConfigExperimental>,
     ) -> Result<(VersionOnlyConfig, NextestConfig)> {
-        // Load the version-only config first to avoid incompatibilities with parsing the rest of
-        // the config.
-        let version_only_config = self
-            .config_opts
-            .make_version_only_config(&self.workspace_root)?;
-        self.check_version_config_initial(version_only_config.nextest_version())?;
-
-        // Check for unknown experimental features after the version check. This ensures that if
-        // the required nextest version is higher than the current version, the version error takes
-        // precedence (a future version may have new experimental features).
-        self.check_experimental_config_initial(version_only_config.experimental())?;
-
-        let mut experimental = ConfigExperimental::from_env();
-        experimental.extend(version_only_config.experimental().known());
-
-        // Check that all required experimental features are enabled.
-        let missing = required_experimental
-            .difference(&experimental)
-            .copied()
-            .collect::<Vec<_>>();
-
-        if !missing.is_empty() {
-            let config_file = self
-                .config_opts
-                .config_file
-                .clone()
-                .unwrap_or_else(|| Utf8PathBuf::from(".config/nextest.toml"));
-            return Err(ExpectedError::ConfigExperimentalFeaturesNotEnabled {
-                config_file,
-                missing,
-            });
-        }
-
-        if !experimental.is_empty() {
-            info!(
-                "experimental features enabled: {}",
-                experimental
-                    .iter()
-                    .map(|x| x.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            );
-        }
+        let version_only_config = self.load_version_only_config(required_experimental)?;
 
         let config = self.config_opts.make_config(
             &self.workspace_root,
@@ -203,153 +163,29 @@ impl BaseApp {
         Ok((version_only_config, config))
     }
 
-    fn check_version_config_initial(&self, version_cfg: &NextestVersionConfig) -> Result<()> {
-        let styles = self.output.stderr_styles();
-
-        match version_cfg.eval(
-            &self.current_version,
-            self.config_opts.override_version_check,
-        ) {
-            NextestVersionEval::Satisfied => Ok(()),
-            NextestVersionEval::Error {
-                required,
-                current,
-                tool,
-            } => Err(ExpectedError::RequiredVersionNotMet {
-                required,
-                current,
-                tool,
-            }),
-            NextestVersionEval::Warn {
-                recommended: required,
-                current,
-                tool,
-            } => {
-                warn!(
-                    "this repository recommends nextest version {}, but the current version is {}",
-                    required.style(styles.bold),
-                    current.style(styles.bold),
-                );
-                if let Some(tool) = tool {
-                    info!(
-                        target: "cargo_nextest::no_heading",
-                        "(recommended version specified by tool `{}`)",
-                        tool,
-                    );
-                }
-
-                Ok(())
-            }
-            NextestVersionEval::ErrorOverride {
-                required,
-                current,
-                tool,
-            } => {
-                info!(
-                    "overriding version check (required: {}, current: {})",
-                    required, current
-                );
-                if let Some(tool) = tool {
-                    info!(
-                        target: "cargo_nextest::no_heading",
-                        "(required version specified by tool `{}`)",
-                        tool,
-                    );
-                }
-
-                Ok(())
-            }
-            NextestVersionEval::WarnOverride {
-                recommended,
-                current,
-                tool,
-            } => {
-                info!(
-                    "overriding version check (recommended: {}, current: {})",
-                    recommended, current,
-                );
-                if let Some(tool) = tool {
-                    info!(
-                        target: "cargo_nextest::no_heading",
-                        "(recommended version specified by tool `{}`)",
-                        tool,
-                    );
-                }
-
-                Ok(())
-            }
-        }
-    }
-
-    fn check_experimental_config_initial(
+    pub(crate) fn load_version_only_config(
         &self,
-        experimental_cfg: &ExperimentalConfig,
-    ) -> Result<()> {
-        let config_file = self
-            .config_opts
-            .config_file
-            .clone()
-            .unwrap_or_else(|| self.workspace_root.join(NextestConfig::CONFIG_PATH));
-        if let Some(err) = experimental_cfg.eval().into_error(config_file) {
-            Err(err.into())
-        } else {
-            Ok(())
-        }
+        required_experimental: &BTreeSet<ConfigExperimental>,
+    ) -> Result<VersionOnlyConfig> {
+        load_version_only_config_impl(
+            self.output,
+            &self.config_opts,
+            &self.workspace_root,
+            &self.current_version,
+            required_experimental,
+        )
     }
 
     pub(crate) fn check_version_config_final(
         &self,
         version_cfg: &NextestVersionConfig,
     ) -> Result<()> {
-        let styles = self.output.stderr_styles();
-
-        match version_cfg.eval(
+        check_version_config_final_impl(
+            self.output,
+            &self.config_opts,
             &self.current_version,
-            self.config_opts.override_version_check,
-        ) {
-            NextestVersionEval::Satisfied => Ok(()),
-            NextestVersionEval::Error {
-                required,
-                current,
-                tool,
-            } => Err(ExpectedError::RequiredVersionNotMet {
-                required,
-                current,
-                tool,
-            }),
-            NextestVersionEval::Warn {
-                recommended: required,
-                current,
-                tool,
-            } => {
-                warn!(
-                    "this repository recommends nextest version {}, but the current version is {}",
-                    required.style(styles.bold),
-                    current.style(styles.bold),
-                );
-                if let Some(tool) = tool {
-                    info!(
-                        target: "cargo_nextest::no_heading",
-                        "(recommended version specified by tool `{}`)",
-                        tool,
-                    );
-                }
-
-                // Don't need to print extra text here -- this is a warning, not an error.
-                crate::helpers::log_needs_update(
-                    Level::INFO,
-                    crate::helpers::BYPASS_VERSION_TEXT,
-                    &styles,
-                );
-
-                Ok(())
-            }
-            NextestVersionEval::ErrorOverride { .. } | NextestVersionEval::WarnOverride { .. } => {
-                // Don't print overrides at the end since users have already opted into overrides --
-                // just be ok with the one at the beginning.
-                Ok(())
-            }
-        }
+            version_cfg,
+        )
     }
 
     pub(crate) fn load_double_spawn(&self) -> &DoubleSpawnInfo {

--- a/cargo-nextest/src/dispatch/core/list.rs
+++ b/cargo-nextest/src/dispatch/core/list.rs
@@ -4,6 +4,7 @@
 //! List command options and execution.
 
 use super::{
+    current_version,
     filter::TestBuildFilter,
     run::App,
     value_enums::{ListType, MessageFormatOpts},
@@ -11,15 +12,25 @@ use super::{
 use crate::{
     Result,
     cargo_cli::CargoOptions,
-    dispatch::helpers::{build_filtersets, resolve_user_config},
+    dispatch::{
+        EarlyArgs,
+        common::ConfigOpts,
+        helpers::{
+            build_filtersets, check_experimental_filtering, check_version_config_final,
+            load_version_only_config, locate_workspace_root, resolve_user_config,
+        },
+    },
+    output::{OutputContext, OutputWriter},
     reuse_build::ReuseBuildOpts,
 };
+use camino::Utf8Path;
 use clap::Args;
 use nextest_filtering::{FiltersetKind, ParseContext};
 use nextest_runner::{
     errors::WriteTestListError,
     list::TestExecuteContext,
     pager::PagedOutput,
+    platform::Platform,
     run_mode::NextestRunMode,
     show_config::{ShowTestGroupSettings, ShowTestGroups, ShowTestGroupsMode},
     user_config::elements::PaginateSetting,
@@ -61,6 +72,111 @@ pub(crate) struct ListOpts {
     pub(crate) reuse_build: ReuseBuildOpts,
 }
 
+impl ListOpts {
+    pub(crate) fn try_exec_binaries_only_fast(
+        &self,
+        early_args: &EarlyArgs,
+        manifest_path: Option<&Utf8Path>,
+        config_opts: &ConfigOpts,
+        output: OutputContext,
+        output_writer: &mut OutputWriter,
+    ) -> Result<bool> {
+        if !self.supports_binaries_only_fast_path(config_opts) {
+            return Ok(false);
+        }
+
+        check_experimental_filtering(output);
+        self.reuse_build.check_experimental(output);
+
+        let reuse_build = self.reuse_build.process(output, output_writer)?;
+        let binary_list = reuse_build
+            .binaries_metadata()
+            .expect("binaries metadata must be present on the fast path")
+            .binary_list
+            .clone();
+        let workspace_root = locate_workspace_root(manifest_path, output)?;
+        let version_only_config = load_version_only_config(
+            output,
+            config_opts,
+            &workspace_root,
+            &current_version(),
+            &BTreeSet::new(),
+        )?;
+
+        // Even though binaries-only doesn't enumerate tests, keep validating test-binary args
+        // to preserve the current CLI diagnostics for those flags.
+        let _test_filter = self
+            .build_filter
+            .make_test_filter(NextestRunMode::Test, Vec::new())?;
+
+        let mut paged_output = create_paged_output(
+            early_args,
+            &binary_list.rust_build_meta.build_platforms.host.platform,
+            self.message_format,
+        )?;
+        let is_interactive = paged_output.is_interactive();
+        let should_colorize = output.color.should_colorize(supports_color::Stream::Stdout);
+
+        binary_list.write(
+            self.message_format
+                .to_output_format(output.verbose, is_interactive),
+            &mut paged_output,
+            should_colorize,
+        )?;
+
+        paged_output
+            .write_str_flush()
+            .map_err(WriteTestListError::Io)?;
+        paged_output.finalize();
+
+        check_version_config_final(
+            output,
+            config_opts,
+            &current_version(),
+            version_only_config.nextest_version(),
+        )?;
+
+        Ok(true)
+    }
+
+    fn supports_binaries_only_fast_path(&self, config_opts: &ConfigOpts) -> bool {
+        matches!(self.list_type, ListType::BinariesOnly)
+            && self.reuse_build.binaries_metadata.is_some()
+            && self.reuse_build.cargo_metadata.is_none()
+            && self.reuse_build.archive_file.is_none()
+            && self.build_filter.filterset.is_empty()
+            && config_opts.profile.is_none()
+            && config_opts.config_file.is_none()
+            && config_opts.tool_config_files.is_empty()
+    }
+}
+
+fn create_paged_output(
+    early_args: &EarlyArgs,
+    host_platform: &Platform,
+    message_format: MessageFormatOpts,
+) -> Result<PagedOutput> {
+    if !message_format.is_human_readable() {
+        return Ok(PagedOutput::terminal());
+    }
+
+    let resolved_user_config =
+        resolve_user_config(host_platform, early_args.user_config_location())?;
+    let (pager_setting, paginate) = early_args.resolve_pager(&resolved_user_config.ui);
+
+    let should_page = !matches!(paginate, PaginateSetting::Never);
+
+    Ok(if should_page {
+        PagedOutput::request_pager(
+            &pager_setting,
+            paginate,
+            &resolved_user_config.ui.streampager,
+        )
+    } else {
+        PagedOutput::terminal()
+    })
+}
+
 impl App {
     pub(crate) fn exec_list(
         &self,
@@ -79,25 +195,11 @@ impl App {
 
         let binary_list = self.base.build_binary_list("test")?;
 
-        let resolved_user_config = resolve_user_config(
+        let mut paged_output = create_paged_output(
+            &self.base.early_args,
             &self.base.build_platforms.host.platform,
-            self.base.early_args.user_config_location(),
+            message_format,
         )?;
-        let (pager_setting, paginate) =
-            self.base.early_args.resolve_pager(&resolved_user_config.ui);
-
-        let should_page =
-            !matches!(paginate, PaginateSetting::Never) && message_format.is_human_readable();
-
-        let mut paged_output = if should_page {
-            PagedOutput::request_pager(
-                &pager_setting,
-                paginate,
-                &resolved_user_config.ui.streampager,
-            )
-        } else {
-            PagedOutput::terminal()
-        };
 
         let is_interactive = paged_output.is_interactive();
         let should_colorize = self

--- a/cargo-nextest/src/dispatch/core/run.rs
+++ b/cargo-nextest/src/dispatch/core/run.rs
@@ -13,7 +13,9 @@ use super::{
 };
 use crate::{
     ExpectedError, Result,
-    dispatch::helpers::{build_filtersets, final_stats_to_error, resolve_user_config},
+    dispatch::helpers::{
+        build_filtersets, check_experimental_filtering, final_stats_to_error, resolve_user_config,
+    },
     output::OutputWriter,
     reuse_build::ReuseBuildOpts,
 };
@@ -775,17 +777,6 @@ impl BenchReporterOpts {
             .unwrap_or(resolved_ui.show_progress.into());
         builder.set_show_progress(show_progress);
         builder
-    }
-}
-
-// (_output is not used, but must be passed in to ensure that the output is properly initialized
-// before calling this method)
-fn check_experimental_filtering(_output: crate::output::OutputContext) {
-    const EXPERIMENTAL_ENV: &str = "NEXTEST_EXPERIMENTAL_FILTER_EXPR";
-    if std::env::var(EXPERIMENTAL_ENV).is_ok() {
-        warn!(
-            "filtersets are no longer experimental: NEXTEST_EXPERIMENTAL_FILTER_EXPR does not need to be set"
-        );
     }
 }
 

--- a/cargo-nextest/src/dispatch/helpers.rs
+++ b/cargo-nextest/src/dispatch/helpers.rs
@@ -6,14 +6,19 @@
 use crate::{
     ExpectedError, ExtractOutputFormat, Result,
     cargo_cli::{CargoCli, CargoOptions},
+    dispatch::common::ConfigOpts,
     output::{OutputContext, StderrStyles},
 };
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 use itertools::Itertools;
 use nextest_filtering::{Filterset, FiltersetKind, ParseContext};
 use nextest_runner::{
     RustcCli,
     cargo_config::{CargoConfigs, TargetTriple},
+    config::core::{
+        ConfigExperimental, ExperimentalConfig, NextestConfig, NextestVersionConfig,
+        NextestVersionEval, VersionOnlyConfig,
+    },
     errors::TargetTripleError,
     platform::{BuildPlatforms, HostPlatform, Platform, PlatformLibdir, TargetPlatform},
     reporter::{
@@ -25,9 +30,10 @@ use nextest_runner::{
     user_config::{UserConfig, UserConfigLocation},
 };
 use owo_colors::OwoColorize;
-use std::io::Write;
+use semver::Version;
+use std::{collections::BTreeSet, io::Write};
 use swrite::{SWrite, swrite};
-use tracing::{debug, warn};
+use tracing::{Level, debug, info, warn};
 
 pub(super) fn acquire_graph_data(
     manifest_path: Option<&Utf8Path>,
@@ -96,6 +102,154 @@ pub(super) fn resolve_user_config(
 ) -> Result<UserConfig, ExpectedError> {
     UserConfig::for_host_platform(host_platform, location)
         .map_err(|e| ExpectedError::UserConfigError { err: Box::new(e) })
+}
+
+pub(super) fn locate_workspace_root(
+    manifest_path: Option<&Utf8Path>,
+    output: OutputContext,
+) -> Result<Utf8PathBuf> {
+    let mut cargo_cli = CargoCli::new("locate-project", manifest_path, output);
+    cargo_cli.add_args(["--workspace", "--message-format=plain"]);
+    let locate_project_output = cargo_cli
+        .to_expression()
+        .stdout_capture()
+        .unchecked()
+        .run()
+        .map_err(|error| {
+            ExpectedError::cargo_locate_project_exec_failed(cargo_cli.all_args(), error)
+        })?;
+    if !locate_project_output.status.success() {
+        return Err(ExpectedError::cargo_locate_project_failed(
+            cargo_cli.all_args(),
+            locate_project_output.status,
+        ));
+    }
+
+    let workspace_root = String::from_utf8(locate_project_output.stdout)
+        .map_err(|err| ExpectedError::WorkspaceRootInvalidUtf8 { err })?;
+    let workspace_root = Utf8Path::new(workspace_root.trim_end());
+    let workspace_root =
+        workspace_root
+            .parent()
+            .ok_or_else(|| ExpectedError::WorkspaceRootInvalid {
+                workspace_root: workspace_root.to_owned(),
+            })?;
+
+    Ok(workspace_root.to_owned())
+}
+
+pub(super) fn load_version_only_config(
+    output: OutputContext,
+    config_opts: &ConfigOpts,
+    workspace_root: &Utf8Path,
+    current_version: &Version,
+    required_experimental: &BTreeSet<ConfigExperimental>,
+) -> Result<VersionOnlyConfig> {
+    // Load the version-only config first to avoid incompatibilities with parsing the rest of
+    // the config.
+    let version_only_config = config_opts.make_version_only_config(workspace_root)?;
+    check_version_config_initial(
+        output,
+        config_opts,
+        current_version,
+        version_only_config.nextest_version(),
+    )?;
+
+    // Check for unknown experimental features after the version check. This ensures that if
+    // the required nextest version is higher than the current version, the version error takes
+    // precedence (a future version may have new experimental features).
+    check_experimental_config_initial(
+        config_opts,
+        workspace_root,
+        version_only_config.experimental(),
+    )?;
+
+    let mut experimental = ConfigExperimental::from_env();
+    experimental.extend(version_only_config.experimental().known());
+
+    // Check that all required experimental features are enabled.
+    let missing = required_experimental
+        .difference(&experimental)
+        .copied()
+        .collect::<Vec<_>>();
+
+    if !missing.is_empty() {
+        let config_file = config_opts
+            .config_file
+            .clone()
+            .unwrap_or_else(|| Utf8PathBuf::from(".config/nextest.toml"));
+        return Err(ExpectedError::ConfigExperimentalFeaturesNotEnabled {
+            config_file,
+            missing,
+        });
+    }
+
+    if !experimental.is_empty() {
+        info!(
+            "experimental features enabled: {}",
+            experimental
+                .iter()
+                .map(|x| x.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+
+    Ok(version_only_config)
+}
+
+pub(super) fn check_version_config_final(
+    output: OutputContext,
+    config_opts: &ConfigOpts,
+    current_version: &Version,
+    version_cfg: &NextestVersionConfig,
+) -> Result<()> {
+    let styles = output.stderr_styles();
+
+    match version_cfg.eval(current_version, config_opts.override_version_check) {
+        NextestVersionEval::Satisfied => Ok(()),
+        NextestVersionEval::Error {
+            required,
+            current,
+            tool,
+        } => Err(ExpectedError::RequiredVersionNotMet {
+            required,
+            current,
+            tool,
+        }),
+        NextestVersionEval::Warn {
+            recommended: required,
+            current,
+            tool,
+        } => {
+            warn!(
+                "this repository recommends nextest version {}, but the current version is {}",
+                required.style(styles.bold),
+                current.style(styles.bold),
+            );
+            if let Some(tool) = tool {
+                info!(
+                    target: "cargo_nextest::no_heading",
+                    "(recommended version specified by tool `{}`)",
+                    tool,
+                );
+            }
+
+            // Don't need to print extra text here -- this is a warning, not an error.
+            crate::helpers::log_needs_update(
+                Level::INFO,
+                crate::helpers::BYPASS_VERSION_TEXT,
+                &styles,
+            );
+
+            Ok(())
+        }
+        NextestVersionEval::ErrorOverride { .. } | NextestVersionEval::WarnOverride { .. } => {
+            // Don't print overrides at the end since users have already opted into overrides --
+            // just be ok with the one at the beginning.
+            Ok(())
+        }
+    }
 }
 
 pub(super) fn discover_target_triple(
@@ -182,6 +336,113 @@ pub(super) fn build_filtersets(
         Err(ExpectedError::filter_expression_parse_error(all_errors))
     } else {
         Ok(exprs)
+    }
+}
+
+// (_output is not used, but must be passed in to ensure that the output is properly initialized
+// before calling this method)
+pub(super) fn check_experimental_filtering(_output: OutputContext) {
+    const EXPERIMENTAL_ENV: &str = "NEXTEST_EXPERIMENTAL_FILTER_EXPR";
+    if std::env::var(EXPERIMENTAL_ENV).is_ok() {
+        warn!(
+            "filtersets are no longer experimental: NEXTEST_EXPERIMENTAL_FILTER_EXPR does not need to be set"
+        );
+    }
+}
+
+fn check_version_config_initial(
+    output: OutputContext,
+    config_opts: &ConfigOpts,
+    current_version: &Version,
+    version_cfg: &NextestVersionConfig,
+) -> Result<()> {
+    let styles = output.stderr_styles();
+
+    match version_cfg.eval(current_version, config_opts.override_version_check) {
+        NextestVersionEval::Satisfied => Ok(()),
+        NextestVersionEval::Error {
+            required,
+            current,
+            tool,
+        } => Err(ExpectedError::RequiredVersionNotMet {
+            required,
+            current,
+            tool,
+        }),
+        NextestVersionEval::Warn {
+            recommended: required,
+            current,
+            tool,
+        } => {
+            warn!(
+                "this repository recommends nextest version {}, but the current version is {}",
+                required.style(styles.bold),
+                current.style(styles.bold),
+            );
+            if let Some(tool) = tool {
+                info!(
+                    target: "cargo_nextest::no_heading",
+                    "(recommended version specified by tool `{}`)",
+                    tool,
+                );
+            }
+
+            Ok(())
+        }
+        NextestVersionEval::ErrorOverride {
+            required,
+            current,
+            tool,
+        } => {
+            info!(
+                "overriding version check (required: {}, current: {})",
+                required, current
+            );
+            if let Some(tool) = tool {
+                info!(
+                    target: "cargo_nextest::no_heading",
+                    "(required version specified by tool `{}`)",
+                    tool,
+                );
+            }
+
+            Ok(())
+        }
+        NextestVersionEval::WarnOverride {
+            recommended,
+            current,
+            tool,
+        } => {
+            info!(
+                "overriding version check (recommended: {}, current: {})",
+                recommended, current,
+            );
+            if let Some(tool) = tool {
+                info!(
+                    target: "cargo_nextest::no_heading",
+                    "(recommended version specified by tool `{}`)",
+                    tool,
+                );
+            }
+
+            Ok(())
+        }
+    }
+}
+
+fn check_experimental_config_initial(
+    config_opts: &ConfigOpts,
+    workspace_root: &Utf8Path,
+    experimental_cfg: &ExperimentalConfig,
+) -> Result<()> {
+    let config_file = config_opts
+        .config_file
+        .clone()
+        .unwrap_or_else(|| workspace_root.join(NextestConfig::CONFIG_PATH));
+    if let Some(err) = experimental_cfg.eval().into_error(config_file) {
+        Err(err.into())
+    } else {
+        Ok(())
     }
 }
 

--- a/integration-tests/tests/integration/main.rs
+++ b/integration-tests/tests/integration/main.rs
@@ -345,6 +345,30 @@ fn test_list_full_after_build() {
 }
 
 #[test]
+fn test_list_binaries_only_after_build() {
+    let env_info = set_env_vars_for_test();
+
+    let p = TempProject::new(&env_info).unwrap();
+    save_binaries_metadata(&env_info, &p);
+
+    let output = CargoNextestCli::for_test(&env_info)
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "list",
+            "--binaries-metadata",
+            p.binaries_metadata_path().as_str(),
+            "--message-format",
+            "json",
+            "--list-type",
+            "binaries-only",
+        ])
+        .output();
+
+    check_list_binaries_output(&output.stdout);
+}
+
+#[test]
 fn test_list_host_after_build() {
     let env_info = set_env_vars_for_test();
 


### PR DESCRIPTION
Refs #3128.

## summary

- add a dispatch-level fast path for `cargo nextest list --list-type binaries-only` when `--binaries-metadata` is reused
- skip `BaseApp::new`, `cargo metadata`, and `PackageGraph` setup for that narrow reused-binaries case
- keep the fast path conservative by falling back to the existing implementation if filtersets, explicit profiles, or explicit config files are in play
- factor the version-only config and workspace-root loading needed by both paths into shared dispatch helpers
- add integration coverage for `list --list-type binaries-only --binaries-metadata ...`

## testing

- `cargo xfmt`
- `cargo check -p cargo-nextest -p integration-tests`
- `cargo nextest run -p cargo-nextest`
- `cargo nextest run -p integration-tests -E 'test(test_list_binaries_only) or test(test_list_binaries_only_after_build) or test(test_list_full_after_build) or test(test_list_host_after_build) or test(test_list_target_after_build)'

## performance

- I did not find an existing benchmark-style test harness for nextest itself in this repo, so these numbers are from local `hyperfine` runs.
- On the locally built binary, the optimized path measured: `./target/debug/cargo-nextest nextest list --list-type binaries-only --binaries-metadata /tmp/nextest-binaries-metadata.json --message-format json >/dev/null` -> `56.8 ms ± 13.1 ms`.
- To isolate the savings on the same branch, I forced the fallback path by passing an explicit profile: `... --profile default ...` -> `357.2 ms ± 63.6 ms`.
- I also forced the fallback path with an explicit config file: `... --config-file /Users/gshikhman/nextest/.config/nextest.toml ...` -> `293.5 ms ± 40.5 ms`.
- Before this change, my earlier workspace measurement for `cargo nextest list --list-type binaries-only --binaries-metadata /tmp/nextest-binaries-metadata.json` was about `194 ms`.
