### PR TITLE
[nextest-runner] make ChildSingleOutput's buf private

### DIFF
--- a/nextest-runner/src/record/recorder.rs
+++ b/nextest-runner/src/record/recorder.rs
@@ -661,15 +661,15 @@ impl SerializeTestEventContext<'_> {
             return Ok(ZipStoreOutput::Empty);
         };
 
-        if output.buf.is_empty() {
+        if output.buf().is_empty() {
             return Ok(ZipStoreOutput::Empty);
         }
 
-        let original_len = output.buf.len();
+        let original_len = output.buf().len();
         let (data, truncated): (Cow<'_, [u8]>, bool) = if original_len <= self.max_output_size {
-            (Cow::Borrowed(&output.buf), false)
+            (Cow::Borrowed(output.buf()), false)
         } else {
-            (truncate_output(&output.buf, self.max_output_size), true)
+            (truncate_output(output.buf(), self.max_output_size), true)
         };
 
         let file_name = OutputFileName::from_content(&data, kind);

--- a/nextest-runner/src/reporter/error_description.rs
+++ b/nextest-runner/src/reporter/error_description.rs
@@ -48,14 +48,14 @@ impl<'a> UnitErrorDescription<'a> {
                             // only makes sense for completed tests.
                             ChildOutputDescription::Split { stdout, stderr } => {
                                 output_slice = TestOutputErrorSlice::heuristic_extract(
-                                    stdout.as_ref().map(|x| x.buf.as_ref()),
-                                    stderr.as_ref().map(|x| x.buf.as_ref()),
+                                    stdout.as_ref().map(|x| x.buf().as_ref()),
+                                    stderr.as_ref().map(|x| x.buf().as_ref()),
                                 );
                             }
                             ChildOutputDescription::Combined { output } => {
                                 output_slice = TestOutputErrorSlice::heuristic_extract(
-                                    Some(output.buf.as_ref()),
-                                    Some(output.buf.as_ref()),
+                                    Some(output.buf().as_ref()),
+                                    Some(output.buf().as_ref()),
                                 );
                             }
                             ChildOutputDescription::NotLoaded => {

--- a/nextest-runner/src/reporter/events.rs
+++ b/nextest-runner/src/reporter/events.rs
@@ -1345,10 +1345,10 @@ impl ChildOutputDescription {
     pub fn stdout_stderr_len(&self) -> (Option<u64>, Option<u64>) {
         match self {
             Self::Split { stdout, stderr } => (
-                stdout.as_ref().map(|s| s.buf.len() as u64),
-                stderr.as_ref().map(|s| s.buf.len() as u64),
+                stdout.as_ref().map(|s| s.buf().len() as u64),
+                stderr.as_ref().map(|s| s.buf().len() as u64),
             ),
-            Self::Combined { output } => (Some(output.buf.len() as u64), None),
+            Self::Combined { output } => (Some(output.buf().len() as u64), None),
             Self::NotLoaded => {
                 unreachable!(
                     "attempted to get output lengths from output that was not loaded \

--- a/nextest-runner/src/reporter/structured/libtest.rs
+++ b/nextest-runner/src/reporter/structured/libtest.rs
@@ -665,7 +665,7 @@ fn strip_human_stdout_or_combined(
     out: &mut bytes::BytesMut,
     test_name: &TestCaseName,
 ) -> Result<(), WriteEventError> {
-    if output.buf.contains_str("running 1 test\n") {
+    if output.buf().contains_str("running 1 test\n") {
         // This is most likely the default test harness.
         let lines = output
             .lines()

--- a/nextest-runner/src/test_output.rs
+++ b/nextest-runner/src/test_output.rs
@@ -35,8 +35,8 @@ pub enum CaptureStrategy {
 /// This is a wrapper around a [`Bytes`] that provides some convenience methods.
 #[derive(Clone, Debug)]
 pub struct ChildSingleOutput {
-    /// The raw output buffer
-    pub buf: Bytes,
+    /// The raw output buffer.
+    buf: Bytes,
 
     /// A string representation of the output, computed on first access.
     ///
@@ -55,6 +55,12 @@ impl From<Bytes> for ChildSingleOutput {
 }
 
 impl ChildSingleOutput {
+    /// Returns the raw output buffer.
+    #[inline]
+    pub fn buf(&self) -> &Bytes {
+        &self.buf
+    }
+
     /// Gets this output as a lossy UTF-8 string.
     #[inline]
     pub fn as_str_lossy(&self) -> &str {
@@ -134,10 +140,10 @@ impl ChildOutput {
     pub fn stdout_stderr_len(&self) -> (Option<u64>, Option<u64>) {
         match self {
             Self::Split(split) => (
-                split.stdout.as_ref().map(|s| s.buf.len() as u64),
-                split.stderr.as_ref().map(|s| s.buf.len() as u64),
+                split.stdout.as_ref().map(|s| s.buf().len() as u64),
+                split.stderr.as_ref().map(|s| s.buf().len() as u64),
             ),
-            Self::Combined { output } => (Some(output.buf.len() as u64), None),
+            Self::Combined { output } => (Some(output.buf().len() as u64), None),
         }
     }
 }


### PR DESCRIPTION
Fix the potential unsoundness identified in #3134.

Fixes #3134.