### PR TITLE
[nextest-runner] set CARGO_BIN_EXE_ at runtime

### DIFF
--- a/fixtures/nextest-tests/src/lib.rs
+++ b/fixtures/nextest-tests/src/lib.rs
@@ -28,20 +28,27 @@ fn generate_warning_for_tests() -> u32 {
     deprecated_function()
 }
 
-/// This method is called by integration tests and benchmarks to ensure that NEXTEST_BIN_EXE
-/// environment variables are properly set.
+/// This method is called by integration tests and benchmarks to ensure that CARGO_BIN_EXE and
+/// NEXTEST_BIN_EXE environment variables are properly set.
 pub fn test_execute_bin_helper() {
-    let binary_path = std::env::var("NEXTEST_BIN_EXE_nextest-tests")
+    let cargo_bin_exe = std::env::var("CARGO_BIN_EXE_nextest-tests")
+        .expect("CARGO_BIN_EXE_nextest-tests should be present");
+    let nextest_bin_exe = std::env::var("NEXTEST_BIN_EXE_nextest-tests")
         .expect("NEXTEST_BIN_EXE_nextest-tests should be present");
     let with_underscores = std::env::var("NEXTEST_BIN_EXE_nextest_tests")
         .expect("NEXTEST_BIN_EXE_nextest_tests (with underscores) should be present");
-    assert_eq!(binary_path, with_underscores);
+    assert_eq!(
+        cargo_bin_exe, nextest_bin_exe,
+        "CARGO_BIN_EXE and NEXTEST_BIN_EXE should match"
+    );
+    assert_eq!(nextest_bin_exe, with_underscores);
+    let binary_path = &nextest_bin_exe;
     assert!(
-        Path::new(&binary_path).is_absolute(),
+        Path::new(binary_path).is_absolute(),
         "binary path {} is absolute",
         binary_path
     );
-    let output = std::process::Command::new(&binary_path)
+    let output = std::process::Command::new(binary_path)
         .output()
         .unwrap_or_else(|err| panic!("failed to run binary at {}: {}", binary_path, err));
     assert_eq!(output.status.code(), Some(42), "exit code matches");
@@ -64,16 +71,23 @@ mod tests {
     #[test]
     fn unit_test_success() {
         assert_eq!(2 + 2, 4, "this test should succeed");
-        // Check that CARGO_BIN_EXE is not set.
+        // Check that CARGO_BIN_EXE is not set at compile time (unit tests don't get it).
         assert_eq!(
             option_env!("CARGO_BIN_EXE_nextest-tests"),
             None,
             "CARGO_BIN_EXE_nextest-tests not set at compile time"
         );
 
-        let runtime_bin_exe = std::env::var_os("NEXTEST_BIN_EXE_nextest-tests");
+        // Neither CARGO_BIN_EXE nor NEXTEST_BIN_EXE should be set at runtime
+        // for unit tests.
         assert_eq!(
-            runtime_bin_exe, None,
+            std::env::var_os("CARGO_BIN_EXE_nextest-tests"),
+            None,
+            "CARGO_BIN_EXE_nextest-tests is not set at runtime"
+        );
+        assert_eq!(
+            std::env::var_os("NEXTEST_BIN_EXE_nextest-tests"),
+            None,
             "NEXTEST_BIN_EXE_nextest-tests is not set at runtime"
         )
     }

--- a/fixtures/nextest-tests/tests/basic.rs
+++ b/fixtures/nextest-tests/tests/basic.rs
@@ -230,8 +230,13 @@ fn test_cargo_env_vars() {
     assert_env!("CARGO_PKG_LICENSE_FILE");
     assert_env!("CARGO_PKG_RUST_VERSION");
 
+    // CARGO_BIN_EXE_<name> is set at runtime by nextest, matching Rust 1.94+.
+    // We don't use assert_env! here because the compile-time and runtime paths
+    // may differ when running from archives with path remapping. The value is
+    // validated by test_execute_bin instead.
+    check_env("CARGO_BIN_EXE_nextest-tests");
+
     // CARGO_CRATE_NAME is missing at runtime
-    // CARGO_BIN_EXE_<name> is missing at runtime
     // CARGO_PRIMARY_PACKAGE is missing at runtime
     // CARGO_TARGET_TMPDIR is missing at runtime
     // Dynamic library paths are tested by actually executing the tests -- they depend on the dynamic library.

--- a/integration-tests/src/env.rs
+++ b/integration-tests/src/env.rs
@@ -21,8 +21,8 @@ pub struct TestEnvInfo {
 
 /// Sets up environment variables for a setup script.
 ///
-/// Setup scripts don't have access to `NEXTEST_BIN_EXE_*` variables, so this
-/// only performs sanitization without capturing binary paths.
+/// Setup scripts don't have access to `CARGO_BIN_EXE_*` or `NEXTEST_BIN_EXE_*`
+/// variables, so this only performs sanitization without capturing binary paths.
 pub fn set_env_vars_for_script() {
     // SAFETY:
     // https://nexte.st/docs/configuration/env-vars/#altering-the-environment-within-tests

--- a/integration-tests/src/nextest_cli.rs
+++ b/integration-tests/src/nextest_cli.rs
@@ -54,8 +54,8 @@ impl CargoNextestCli {
 
     /// Creates a new CargoNextestCli instance for use in a setup script.
     ///
-    /// Scripts don't have access to the `NEXTEST_BIN_EXE_cargo_nextest_dup` environment variable,
-    /// so we run `cargo run --bin cargo-nextest-dup nextest debug current-exe` instead.
+    /// Scripts don't have access to `CARGO_BIN_EXE_*` or `NEXTEST_BIN_EXE_*` environment
+    /// variables, so we run `cargo run --bin cargo-nextest-dup nextest debug current-exe` instead.
     pub fn for_script() -> Result<Self> {
         let cargo_bin = cargo_bin();
         let mut command = std::process::Command::new(&cargo_bin);

--- a/nextest-runner/src/test_command.rs
+++ b/nextest-runner/src/test_command.rs
@@ -115,17 +115,23 @@ impl TestCommand {
         apply_ld_dyld_env(&mut cmd, lctx.dylib_path);
 
         // Expose paths to non-test binaries at runtime so that relocated paths
-        // work. These paths aren't exposed by Cargo at runtime, so use a
-        // NEXTEST_BIN_EXE prefix.
+        // work.
+        //
+        // CARGO_BIN_EXE_<name> is set by Cargo at build time, and as of Rust
+        // 1.94, also at runtime. Set it here (with the hyphen version) to match
+        // Cargo's behavior.
+        //
+        // NEXTEST_BIN_EXE_<name> is additionally set for both the hyphen and
+        // underscore variants. Some shells and debuggers drop environment
+        // variables with hyphens in their names, so the underscore variant is
+        // provided as a workaround.
+        //
+        // See
+        // https://unix.stackexchange.com/questions/23659/can-shell-variable-name-include-a-hyphen-or-dash.
         for (name, path) in non_test_binaries {
-            // Some shells and debuggers have been known to drop environment
-            // variables with hyphens in their names. Provide an alternative
-            // name with underscores instead.
-            //
-            // See
-            // https://unix.stackexchange.com/questions/23659/can-shell-variable-name-include-a-hyphen-or-dash.
-            let with_underscores = name.replace('-', "_");
+            cmd.env(format!("CARGO_BIN_EXE_{name}"), path);
             cmd.env(format!("NEXTEST_BIN_EXE_{name}"), path);
+            let with_underscores = name.replace('-', "_");
             if &with_underscores != name {
                 cmd.env(format!("NEXTEST_BIN_EXE_{with_underscores}"), path);
             }

--- a/site/src/docs/ci-features/archiving.md
+++ b/site/src/docs/ci-features/archiving.md
@@ -201,11 +201,13 @@ Some tests may need to be modified to handle changes in the workspace and target
 
   If the workspace is remapped, nextest automatically sets `CARGO_MANIFEST_DIR` to the new location.
 
-- To obtain the path to a crate's executables, Cargo provides the [`CARGO_BIN_EXE_<name>`] option to integration tests at build time. To handle target directory remapping, use the value of `NEXTEST_BIN_EXE_<name>` at runtime.
+- To obtain the path to a crate's executables, Cargo provides the [`CARGO_BIN_EXE_<name>`] option to integration tests and benchmarks at build time. To make tests relocatable, use one of the below environment variables _at runtime_:
 
-  <!-- md:version 0.9.113 --> Because some shells and [debuggers](../integrations/debuggers-tracers.md) drop [environment variables with hyphens in their names](https://unix.stackexchange.com/a/23714), nextest also sets `NEXTEST_BIN_EXE_<name>`, where hyphens in the name are replaced with underscores. This form is now recommended.
-
-  To retain compatibility with `cargo test`, you can fall back to the value of `CARGO_BIN_EXE_<name>` at build time.
+  - <!-- md:version 0.9.113 --> `NEXTEST_BIN_EXE_<name>`, with hyphens in the name replaced with underscores. (For example, to get the path to a binary named `my-program`, use `NEXTEST_BIN_EXE_my_program`.)
+  
+    Because some shells and [debuggers](../integrations/debuggers-tracers.md) drop [environment variables with hyphens in their names](https://unix.stackexchange.com/a/23714), the underscore form is recommended when possible.
+  - `NEXTEST_BIN_EXE_<name>`, where hyphens in the name are preserved as-is.
+  - <!-- md:version 0.9.130 --> `CARGO_BIN_EXE_<name>`, where hyphens in the name are preserved as-is. This matches `cargo test` in Rust 1.94 and above (though nextest sets this variable on all Rust versions).
 
 [`CARGO_BIN_EXE_<name>`]: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
 

--- a/site/src/docs/configuration/env-vars.md
+++ b/site/src/docs/configuration/env-vars.md
@@ -93,10 +93,10 @@ Nextest exposes these environment variables to your tests _at runtime only_. The
 : The current nextest version as a semver string (e.g. `"0.9.120"`). Set for both tests and [setup scripts](setup-scripts.md).
 
 `NEXTEST_REQUIRED_VERSION` <!-- md:version 0.9.130 -->
-: The minimum required nextest version from the repository's [`nextest-version`](index.md#minimum-nextest-version) configuration, as a semver string. If no required version is configured, this is `"none"`. Set for both tests and [setup scripts](setup-scripts.md).
+: The minimum required nextest version from the repository's [`nextest-version` configuration](minimum-versions.md), as a semver string. If no required version is configured, this is `"none"`. Set for both tests and [setup scripts](setup-scripts.md).
 
 `NEXTEST_RECOMMENDED_VERSION` <!-- md:version 0.9.130 -->
-: The minimum recommended nextest version from the repository's [`nextest-version`](index.md#minimum-nextest-version) configuration, as a semver string. If no recommended version is configured, this is `"none"`. Set for both tests and [setup scripts](setup-scripts.md).
+: The minimum recommended nextest version from the repository's [`nextest-version` configuration](minimum-versions.md), as a semver string. If no recommended version is configured, this is `"none"`. Set for both tests and [setup scripts](setup-scripts.md).
 
 `NEXTEST_EXECUTION_MODE`
 : Currently, always `process-per-test`. More options may be added in the future if nextest gains the ability to run multiple tests within the same process ([#27]).
@@ -138,7 +138,7 @@ Nextest exposes these environment variables to your tests _at runtime only_. The
     If the test is not in any groups, this is `"none"`.
 
 `NEXTEST_TEST_THREADS` <!-- md:version 0.9.130 -->
-: The number of [test threads](../features/test-threads.md) configured for this run. This is the computed value after considering the profile, command-line overrides, and capture strategy. Set for both tests and [setup scripts](setup-scripts.md).
+: The number of test threads configured for this run. This is the computed value after considering the profile, command-line overrides, and capture strategy. Set for both tests and [setup scripts](setup-scripts.md).
 
 `NEXTEST_WORKSPACE_ROOT` <!-- md:version 0.9.130 -->
 : The absolute path to the workspace root. Set for both tests and [setup scripts](setup-scripts.md).
@@ -146,7 +146,7 @@ Nextest exposes these environment variables to your tests _at runtime only_. The
     When [`--workspace-remap`](../ci-features/archiving.md#specifying-a-new-location-for-the-source-code) is passed in, this is set to the remapped workspace root.
 
 `NEXTEST_BIN_EXE_<name>`
-: The absolute path to a binary target's executable. This is only set when running an [integration test] or benchmark. The `<name>` is the name of the binary target, exactly as-is. For example, `NEXTEST_BIN_EXE_my-program` for a binary named `my-program`.
+: The absolute path to a binary target's executable. (See also, `CARGO_BIN_EXE_<name>` below.) This is only set when running an [integration test] or benchmark. The `<name>` is the name of the binary target, exactly as-is. For example, `NEXTEST_BIN_EXE_my-program` for a binary named `my-program`.
 
     Binaries are automatically built when the test is built, unless the binary has required features that are not enabled.
 
@@ -215,6 +215,13 @@ Nextest also sets these environment variables at runtime, matching the behavior 
 
 `CARGO_PKG_LICENSE_FILE`
 : The license file from the manifest of the test's package.
+
+`CARGO_BIN_EXE_<name>` <!-- md:version 0.9.130 -->
+: The absolute path to a binary target's executable, matching `cargo test` in Rust 1.94 and above (though nextest sets this variable on all Rust versions). This is only set when running an [integration test] or benchmark. The `<name>` is the name of the binary target, exactly as-is. For example, `CARGO_BIN_EXE_my-program` for a binary named `my-program`.
+
+    When [reusing builds](../ci-features/archiving.md) from an archive, this is set to the remapped path within the target directory.
+    
+    See also, `NEXTEST_BIN_EXE_<name>` above.
 
 `OUT_DIR`
 : The path to the test's build script output directory.


### PR DESCRIPTION
Matches Rust 1.94.