### PR TITLE
[meta] update self_update to 0.43.1, use ureq, excise ring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -539,6 +561,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "color-eyre"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,19 +615,6 @@ dependencies = [
  "serde_json",
  "toml",
  "winnow",
-]
-
-[[package]]
-name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width 0.2.2",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -665,6 +683,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -857,7 +904,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -910,7 +967,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
 dependencies = [
- "console 0.16.2",
+ "console",
  "shell-words",
  "tempfile",
  "zeroize",
@@ -1061,6 +1118,15 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "enum_dispatch"
@@ -1271,6 +1337,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "future-queue"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,10 +1459,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1400,11 +1470,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1635,23 +1703,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-rustls"
-version = "0.27.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tower-service",
- "webpki-roots",
-]
-
-[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1665,28 +1716,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
 dependencies = [
- "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -1694,9 +1728,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "ipnet",
  "libc",
- "percent-encoding",
  "pin-project-lite",
  "socket2 0.5.10",
  "tokio",
@@ -1814,24 +1846,11 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
-dependencies = [
- "console 0.15.11",
- "number_prefix",
- "portable-atomic",
- "unicode-width 0.2.2",
- "web-time",
-]
-
-[[package]]
-name = "indicatif"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
- "console 0.16.2",
+ "console",
  "portable-atomic",
  "unicode-width 0.2.2",
  "unit-prefix",
@@ -1904,22 +1923,6 @@ dependencies = [
 [[package]]
 name = "internal-test"
 version = "0.1.2-b.12"
-
-[[package]]
-name = "ipnet"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_ci"
@@ -2054,12 +2057,6 @@ name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac_address"
@@ -2286,7 +2283,7 @@ dependencies = [
  "chrono",
  "color-eyre",
  "config",
- "console 0.16.2",
+ "console",
  "console-subscriber",
  "countio",
  "crossterm",
@@ -2306,7 +2303,7 @@ dependencies = [
  "humantime-serde",
  "iddqd",
  "indexmap",
- "indicatif 0.18.4",
+ "indicatif",
  "indoc",
  "insta",
  "is_ci",
@@ -2329,6 +2326,7 @@ dependencies = [
  "quick-junit",
  "rand 0.9.2",
  "regex",
+ "rustls",
  "sapling-streampager",
  "self_update",
  "semver",
@@ -2358,6 +2356,7 @@ dependencies = [
  "unicode-ident",
  "unicode-normalization",
  "unicode-width 0.2.2",
+ "ureq",
  "usdt",
  "win32job",
  "windows-sys 0.61.2",
@@ -2378,12 +2377,8 @@ dependencies = [
  "clap_builder",
  "dof",
  "either",
- "futures-channel",
- "futures-core",
- "futures-sink",
  "getrandom 0.3.3",
  "hashbrown 0.16.1",
- "idna_adapter",
  "indexmap",
  "libc",
  "log",
@@ -2407,8 +2402,6 @@ dependencies = [
  "serde",
  "serde_core",
  "serde_json",
- "slab",
- "smallvec",
  "syn 2.0.114",
  "target-spec",
  "target-spec-miette",
@@ -2460,6 +2453,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2487,12 +2486,6 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "objc2-core-foundation"
@@ -2638,6 +2631,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 dependencies = [
  "camino",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -2808,6 +2810,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2918,19 +2926,10 @@ dependencies = [
  "chrono",
  "indexmap",
  "newtype-uuid",
- "quick-xml 0.38.3",
+ "quick-xml",
  "strip-ansi-escapes",
  "thiserror 2.0.18",
  "uuid",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.37.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -2940,61 +2939,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a232e7487fc2ef313d96dde7948e7a3c05101870d8985e4fd8d26aedd27b89"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "quinn"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2 0.5.10",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
-dependencies = [
- "bytes",
- "getrandom 0.3.3",
- "lru-slab",
- "rand 0.9.2",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2 0.5.10",
- "tracing",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3133,53 +3077,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "reqwest"
-version = "0.12.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f8e5513d63f2e5b386eb5106dc67eaf3f84e95258e210489136b8b92ad6119"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-tls",
- "hyper-util",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3257,12 +3154,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.27"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3275,16 +3173,16 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3307,12 +3205,6 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -3416,23 +3308,24 @@ dependencies = [
 
 [[package]]
 name = "self_update"
-version = "0.42.0"
+version = "0.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d832c086ece0dacc29fb2947bb4219b8f6e12fe9e40b7108f9e57c4224e47b5c"
+checksum = "6644febaa58f323b28f7321d04e24d0020d117c27619ab869d6abdf76be9aac6"
 dependencies = [
  "either",
  "flate2",
- "hyper",
- "indicatif 0.17.11",
+ "http",
+ "indicatif",
  "log",
- "quick-xml 0.37.5",
+ "quick-xml",
  "regex",
- "reqwest",
  "self-replace",
  "semver",
+ "serde",
  "serde_json",
  "tar",
  "tempfile",
+ "ureq",
  "urlencoding",
  "zipsign-api",
 ]
@@ -3531,18 +3424,6 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -3700,6 +3581,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3813,9 +3705,6 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
 
 [[package]]
 name = "tar"
@@ -4062,6 +3951,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4102,26 +4022,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
-dependencies = [
- "rustls",
- "tokio",
 ]
 
 [[package]]
@@ -4268,24 +4168,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
-dependencies = [
- "bitflags 2.11.0",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "iri-string",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -4457,6 +4339,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
+dependencies = [
+ "base64 0.22.1",
+ "cookie_store",
+ "der",
+ "encoding_rs",
+ "flate2",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "socks",
+ "ureq-proto",
+ "utf-8",
+ "webpki-root-certs",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4535,6 +4454,12 @@ dependencies = [
  "syn 2.0.114",
  "usdt-impl",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -4669,20 +4594,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
-dependencies = [
- "cfg-if",
- "futures-util",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4732,6 +4643,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,9 +111,15 @@ recursion = "0.5.4"
 regex = "1.12.3"
 regex-syntax = "0.8.10"
 sapling-streampager = "0.12.0"
-self_update = { version = "0.42.0", default-features = false, features = [
+rustls = { version = "0.23.37", default-features = false }
+self_update = { version = "0.43.1", default-features = false, features = [
     "archive-tar",
     "compression-flate2",
+    # nextest only uses self_update for archive extraction (ArchiveKind,
+    # Compression, Extract), not its HTTP client. But self_update's Download
+    # struct unconditionally calls http_client::get, so at least one HTTP
+    # backend must be enabled for it to compile.
+    "ureq",
 ] }
 semver = "1.0.27"
 serde = { version = "1.0.228", features = ["derive"] }
@@ -142,6 +148,7 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", default-features = false, features = ["std", "tracing-log", "fmt"] }
 unicode-ident = "1.0.24"
 unicode-normalization = "0.1.25"
+ureq = { version = "3.2.0", default-features = false }
 usdt = "0.6.0"
 walkdir = "2.5.0"
 whoami = "2.1.1"

--- a/Cross.toml
+++ b/Cross.toml
@@ -6,10 +6,11 @@ passthrough = ["CARGO_PROFILE_RELEASE_LTO"]
 # https://github.com/cross-rs/cross/pull/1166
 image = "ghcr.io/cross-rs/x86_64-unknown-freebsd:edge"
 
-# This doesn't work because the cross 0.2.4 Docker container is based on Ubuntu 18.04, which doesn't
-# have binary packages available for riscv64.
-# [target.riscv64gc-unknown-linux-gnu]
-# pre-build = [
-#     "dpkg --add-architecture aarch64",
-#     "apt-get update && apt-get install --assume-yes libssl-dev:aarch64"
-# ]
+[target.riscv64gc-unknown-linux-gnu]
+# The default cross image is based on Ubuntu 18.04, which doesn't have riscv64
+# packages. The edge image is newer and does.
+image = "ghcr.io/cross-rs/riscv64gc-unknown-linux-gnu:edge"
+pre-build = [
+    "dpkg --add-architecture riscv64",
+    "apt-get update && apt-get install --assume-yes libssl-dev:riscv64",
+]

--- a/cargo-nextest/src/update.rs
+++ b/cargo-nextest/src/update.rs
@@ -4,7 +4,10 @@
 use crate::{ExpectedError, Result, output::OutputContext};
 use camino::Utf8PathBuf;
 use nextest_metadata::NextestExitCode;
-use nextest_runner::update::{CheckStatus, MuktiBackend, UpdateVersionReq};
+use nextest_runner::{
+    helpers::ThemeCharacters,
+    update::{CheckStatus, MuktiBackend, UpdateDisplayStyles, UpdateVersionReq},
+};
 use owo_colors::OwoColorize;
 use semver::Version;
 use std::cmp::Ordering;
@@ -111,8 +114,16 @@ pub(crate) fn perform_update(
             };
 
             if should_apply {
+                let mut update_styles = UpdateDisplayStyles {
+                    theme_characters: ThemeCharacters::detect(supports_unicode::Stream::Stderr),
+                    ..Default::default()
+                };
+                if output.color.should_colorize(supports_color::Stream::Stderr) {
+                    update_styles.colorize();
+                }
+
                 debug!(url = ctx.location.url, "updating cargo nextest");
-                ctx.do_update()
+                ctx.do_update(&update_styles)
                     .map_err(|err| ExpectedError::UpdateError { err })?;
                 info!(
                     "cargo-nextest updated to {}",

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -142,16 +142,20 @@ windows-sys = { workspace = true, features = [
 ] }
 win32job.workspace = true
 
-# Use rustls by default, OpenSSL on platforms where rustls isn't available:
+# Use rustls with aws-lc-rs by default, OpenSSL on platforms where rustls
+# isn't available:
 # RISC-V: https://github.com/nextest-rs/nextest/issues/820
-# (default features for self_update turns on openssl)
 [target.'cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))'.dependencies]
-self_update = { workspace = true, optional = true, default-features = false, features = [
-    "rustls",
-] }
+self_update = { workspace = true, optional = true, default-features = false }
+# self_update's "rustls" feature hardcodes ureq's ring crypto provider. To use
+# aws-lc-rs instead, activate ureq's TLS and rustls's provider separately.
+ureq = { workspace = true, optional = true, features = ["rustls-no-provider", "rustls-webpki-roots"] }
+rustls = { workspace = true, optional = true, features = ["aws-lc-rs"] }
 
 [target.'cfg(any(target_arch = "riscv32", target_arch = "riscv64"))'.dependencies]
-self_update = { workspace = true, optional = true, default-features = true }
+self_update = { workspace = true, optional = true, default-features = false }
+# On RISC-V, rustls/aws-lc-rs aren't available, so use native-tls instead.
+ureq = { workspace = true, optional = true, features = ["native-tls"] }
 
 
 [dev-dependencies]
@@ -176,7 +180,9 @@ self-update = [
     "dep:self_update",
     "dep:http",
     "dep:mukti-metadata",
+    "dep:rustls",
     "dep:sha2",
+    "dep:ureq",
 ]
 usdt = ["dep:usdt"]
 experimental-tokio-console = [

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -2890,6 +2890,32 @@ mod self_update_errors {
         #[error("self-update failed")]
         SelfUpdate(#[source] self_update::errors::Error),
 
+        /// An HTTP error occurred while performing a request.
+        #[error("error performing HTTP request")]
+        Http(#[source] ureq::Error),
+
+        /// An error occurred while reading an HTTP response body.
+        #[error("error reading HTTP response body")]
+        HttpBody(#[source] std::io::Error),
+
+        /// The server's Content-Length header was present but could not be
+        /// parsed.
+        #[error("Content-Length header present but could not be parsed as an integer: {value:?}")]
+        ContentLengthInvalid {
+            /// The raw header value.
+            value: String,
+        },
+
+        /// The server's Content-Length header didn't match the number of bytes
+        /// received.
+        #[error("content length mismatch: expected {expected} bytes, received {actual} bytes")]
+        ContentLengthMismatch {
+            /// The expected number of bytes (from the Content-Length header).
+            expected: u64,
+            /// The actual number of bytes received.
+            actual: u64,
+        },
+
         /// Deserializing release metadata failed.
         #[error("deserializing release metadata failed")]
         ReleaseMetadataDe(#[source] serde_json::Error),

--- a/nextest-runner/src/helpers.rs
+++ b/nextest-runner/src/helpers.rs
@@ -735,6 +735,16 @@ impl Default for ThemeCharacters {
 }
 
 impl ThemeCharacters {
+    /// Creates a `ThemeCharacters` with Unicode auto-detected for the given
+    /// stream.
+    pub fn detect(stream: supports_unicode::Stream) -> Self {
+        let mut this = Self::default();
+        if supports_unicode::on(stream) {
+            this.use_unicode();
+        }
+        this
+    }
+
     /// Switches to Unicode characters for richer terminal output.
     pub fn use_unicode(&mut self) {
         self.hbar = '─';

--- a/nextest-runner/src/reporter/displayer/imp.rs
+++ b/nextest-runner/src/reporter/displayer/imp.rs
@@ -91,19 +91,16 @@ impl DisplayReporterBuilder {
             styles.colorize();
         }
 
-        let mut theme_characters = ThemeCharacters::default();
-        match &output {
-            ReporterOutput::Terminal => {
-                if supports_unicode::on(supports_unicode::Stream::Stderr) {
-                    theme_characters.use_unicode();
-                }
-            }
+        let theme_characters = match &output {
+            ReporterOutput::Terminal => ThemeCharacters::detect(supports_unicode::Stream::Stderr),
             ReporterOutput::Writer { use_unicode, .. } => {
+                let mut tc = ThemeCharacters::default();
                 if *use_unicode {
-                    theme_characters.use_unicode();
+                    tc.use_unicode();
                 }
+                tc
             }
-        }
+        };
 
         let is_terminal = matches!(&output, ReporterOutput::Terminal) && io::stderr().is_terminal();
         let is_ci = is_ci::uncached();

--- a/nextest-runner/src/update.rs
+++ b/nextest-runner/src/update.rs
@@ -3,19 +3,27 @@
 
 //! Self-updates for nextest.
 
-use crate::errors::{UpdateError, UpdateVersionParseError};
+use crate::{
+    errors::{UpdateError, UpdateVersionParseError},
+    helpers::ThemeCharacters,
+};
 use camino::{Utf8Path, Utf8PathBuf};
+use indicatif::{ProgressBar, ProgressStyle};
 use mukti_metadata::{
     DigestAlgorithm, MuktiProject, MuktiReleasesJson, ReleaseLocation, ReleaseStatus,
 };
-use self_update::{ArchiveKind, Compression, Download, Extract};
+use owo_colors::{OwoColorize, Style};
+use self_update::{ArchiveKind, Compression, Extract};
 use semver::{Version, VersionReq};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
+#[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+use std::sync::OnceLock;
 use std::{
     fs,
-    io::{self, BufWriter},
+    io::{self, BufRead, BufReader, BufWriter, Write as _},
     str::FromStr,
+    time::Duration,
 };
 use target_spec::Platform;
 use tracing::{debug, info, warn};
@@ -42,11 +50,19 @@ impl MuktiBackend {
                 error,
             })?
         } else {
-            let mut releases_buf: Vec<u8> = Vec::new();
-            Download::from_url(&self.url)
-                .download_to(&mut releases_buf)
-                .map_err(UpdateError::SelfUpdate)?;
-            releases_buf
+            let agent = ureq_agent();
+            agent
+                .get(&self.url)
+                .call()
+                .map_err(UpdateError::Http)?
+                .into_body()
+                // The default read_to_vec() limit is 10 MiB, which the
+                // releases JSON could plausibly exceed as releases
+                // accumulate. Use a 64 MiB limit instead.
+                .into_with_config()
+                .limit(64 * 1024 * 1024)
+                .read_to_vec()
+                .map_err(UpdateError::Http)?
         };
 
         let mut releases_json: MuktiReleasesJson =
@@ -316,6 +332,24 @@ pub enum CheckStatus<'a> {
     /// All checks were performed successfully and we are ready to update.
     Success(MuktiUpdateContext<'a>),
 }
+
+/// Display styles for update progress output.
+#[derive(Clone, Debug, Default)]
+pub struct UpdateDisplayStyles {
+    /// Style for the progress bar prefix (e.g. "Downloading").
+    pub progress_prefix: Style,
+
+    /// Theme characters for the progress bar (ASCII or Unicode).
+    pub theme_characters: ThemeCharacters,
+}
+
+impl UpdateDisplayStyles {
+    /// Creates colorized styles.
+    pub fn colorize(&mut self) {
+        self.progress_prefix = Style::new().green().bold();
+    }
+}
+
 /// Context for an update.
 ///
 /// Returned as part of the `Success` variant of [`CheckStatus`].
@@ -340,7 +374,7 @@ pub struct MuktiUpdateContext<'a> {
 
 impl MuktiUpdateContext<'_> {
     /// Performs the update.
-    pub fn do_update(&self) -> Result<(), UpdateError> {
+    pub fn do_update(&self, styles: &UpdateDisplayStyles) -> Result<(), UpdateError> {
         // This method is adapted from self_update's update_extended.
 
         let tmp_dir_parent = self.context.bin_install_path.parent().ok_or_else(|| {
@@ -386,19 +420,93 @@ impl MuktiUpdateContext<'_> {
         })?;
         let mut tmp_archive_buf = BufWriter::new(tmp_archive);
 
-        let mut download = Download::from_url(&self.location.url);
-        let mut headers = http::header::HeaderMap::new();
-        headers.insert(
-            http::header::ACCEPT,
-            "application/octet-stream".parse().unwrap(),
-        );
-        download.set_headers(headers);
-        download.show_progress(true);
-        // TODO: set progress style
+        let agent = ureq_agent();
+        let resp = agent
+            .get(&self.location.url)
+            .header(http::header::ACCEPT.as_str(), "application/octet-stream")
+            .call()
+            .map_err(UpdateError::Http)?;
 
-        download
-            .download_to(&mut tmp_archive_buf)
-            .map_err(UpdateError::SelfUpdate)?;
+        let content_length: Option<u64> =
+            match resp.headers().get(http::header::CONTENT_LENGTH.as_str()) {
+                Some(v) => {
+                    let s = v.to_str().map_err(|_| UpdateError::ContentLengthInvalid {
+                        value: format!("{v:?}"),
+                    })?;
+                    let len = s
+                        .parse::<u64>()
+                        .map_err(|_| UpdateError::ContentLengthInvalid {
+                            value: s.to_owned(),
+                        })?;
+                    Some(len)
+                }
+                None => None,
+            };
+
+        // Stream the response body to the archive file with a progress bar.
+        // into_reader() has no size limit, unlike read_to_vec(). This is
+        // intentional: release archives are ~10 MiB as of March 2026 and
+        // are streamed to a temporary file via tmp_archive_buf above,
+        // not buffered entirely in memory. The SHA-256 checksum verified
+        // later guards against corruption or truncation.
+        let mut src = BufReader::new(resp.into_body().into_reader());
+        let prefix = format!("{}", "Downloading".style(styles.progress_prefix));
+        let progress_bar = match content_length {
+            Some(size) => {
+                let pb = ProgressBar::new(size);
+                pb.set_style(
+                    ProgressStyle::default_bar()
+                        .template(
+                            "  {prefix:>10} [{elapsed_precise:>9}] {wide_bar} \
+                             {bytes:>9}/{total_bytes:>9}",
+                        )
+                        .expect("valid progress bar template")
+                        .progress_chars(styles.theme_characters.progress_chars()),
+                );
+                pb
+            }
+            None => {
+                let pb = ProgressBar::new_spinner();
+                pb.set_style(
+                    ProgressStyle::default_spinner()
+                        .template("  {prefix:>10} [{elapsed_precise:>9}] {bytes}")
+                        .expect("valid progress spinner template"),
+                );
+                pb
+            }
+        };
+        progress_bar.set_prefix(prefix);
+
+        let mut downloaded: u64 = 0;
+        loop {
+            let n = {
+                let buf = src.fill_buf().map_err(UpdateError::HttpBody)?;
+                tmp_archive_buf
+                    .write_all(buf)
+                    .map_err(|error| UpdateError::TempArchiveWrite {
+                        archive_path: tmp_archive_path.clone(),
+                        error,
+                    })?;
+                buf.len()
+            };
+            if n == 0 {
+                break;
+            }
+            src.consume(n);
+            downloaded += n as u64;
+            progress_bar.set_position(downloaded);
+        }
+        progress_bar.finish();
+
+        // Verify that we received the expected number of bytes.
+        if let Some(expected) = content_length
+            && downloaded != expected
+        {
+            return Err(UpdateError::ContentLengthMismatch {
+                expected,
+                actual: downloaded,
+            });
+        }
 
         debug!(target: "nextest-runner::update", "downloaded to {tmp_archive_path}");
 
@@ -603,6 +711,69 @@ fn cleanup_backup_temp_directories(
     }
     Ok(())
 }
+
+/// Returns a ureq agent configured with rustls and the aws-lc-rs crypto
+/// provider.
+///
+/// On RISC-V, rustls/aws-lc-rs aren't available; see the RISC-V variant
+/// below.
+#[cfg(not(any(target_arch = "riscv32", target_arch = "riscv64")))]
+fn ureq_agent() -> ureq::Agent {
+    // Install aws-lc-rs as the default rustls crypto provider. The OnceLock
+    // ensures we only attempt this once; if it's already set (by us or someone
+    // else), we log and move on.
+    static PROVIDER_INSTALLED: OnceLock<()> = OnceLock::new();
+    PROVIDER_INSTALLED.get_or_init(|| {
+        if rustls::crypto::CryptoProvider::install_default(
+            rustls::crypto::aws_lc_rs::default_provider(),
+        )
+        .is_err()
+        {
+            warn!(
+                target: "nextest-runner::update",
+                "a rustls crypto provider was already installed; \
+                 using the existing provider",
+            );
+        }
+    });
+
+    ureq::Agent::new_with_config(
+        ureq::Agent::config_builder()
+            // Set a connect timeout to avoid hanging on unreachable hosts.
+            // No global timeout: binary downloads can be large on slow
+            // connections, and the progress bar keeps the user informed.
+            .timeout_connect(Some(CONNECT_TIMEOUT))
+            .tls_config(
+                ureq::tls::TlsConfig::builder()
+                    .provider(ureq::tls::TlsProvider::Rustls)
+                    .build(),
+            )
+            .build(),
+    )
+}
+
+/// Returns a ureq agent configured with native-tls.
+///
+/// On RISC-V, rustls/aws-lc-rs aren't available (see
+/// <https://github.com/nextest-rs/nextest/issues/820>), so native-tls is used
+/// instead.
+#[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
+fn ureq_agent() -> ureq::Agent {
+    ureq::Agent::new_with_config(
+        ureq::Agent::config_builder()
+            .timeout_connect(Some(CONNECT_TIMEOUT))
+            .tls_config(
+                ureq::tls::TlsConfig::builder()
+                    .provider(ureq::tls::TlsProvider::NativeTls)
+                    .build(),
+            )
+            .build(),
+    )
+}
+
+/// Connect timeout for HTTP requests. Matches reqwest's old default of 30
+/// seconds, which self_update 0.42.0 relied on implicitly.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
 const TAR_GZ_SUFFIX: &str = "tar.gz";
 

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -25,7 +25,6 @@ clap_builder = { version = "4.5.60", default-features = false, features = ["colo
 either = { version = "1.15.0", features = ["use_std"] }
 getrandom = { version = "0.3.3", default-features = false, features = ["std"] }
 hashbrown = { version = "0.16.1", default-features = false, features = ["allocator-api2", "inline-more"] }
-idna_adapter = { version = "1.0.0", default-features = false, features = ["compiled_data"] }
 indexmap = { version = "2.13.0", features = ["serde"] }
 log = { version = "0.4.29", default-features = false, features = ["std"] }
 memchr = { version = "2.7.6" }
@@ -43,7 +42,6 @@ regex-automata = { version = "0.4.12", default-features = false, features = ["df
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde_core = { version = "1.0.228", features = ["alloc", "rc"] }
 serde_json = { version = "1.0.149", features = ["unbounded_depth"] }
-smallvec = { version = "1.15.1", default-features = false, features = ["const_generics"] }
 target-spec = { version = "3.5.7", default-features = false, features = ["custom", "summaries"] }
 target-spec-miette = { version = "0.4.5", default-features = false, features = ["fixtures"] }
 tokio = { version = "1.50.0", features = ["fs", "io-std", "io-util", "macros", "process", "rt-multi-thread", "signal", "sync", "time", "tracing"] }
@@ -66,19 +64,13 @@ ucd-trie = { version = "0.1.7" }
 [target.x86_64-unknown-linux-gnu.dependencies]
 bitflags = { version = "2.11.0", default-features = false, features = ["std"] }
 dof = { version = "0.4.0", default-features = false, features = ["des"] }
-futures-channel = { version = "0.3.32", features = ["sink"] }
-futures-core = { version = "0.3.32" }
-futures-sink = { version = "0.3.32" }
 libc = { version = "0.2.183", features = ["extra_traits"] }
 miniz_oxide = { version = "0.8.9", default-features = false, features = ["with-alloc"] }
 mio = { version = "1.0.4", features = ["net", "os-ext"] }
 proc-macro2 = { version = "1.0.106" }
 quote = { version = "1.0.44" }
 rustix = { version = "1.0.7", features = ["fs", "stdio", "termios"] }
-slab = { version = "0.4.11" }
-smallvec = { version = "1.15.1", default-features = false, features = ["const_new"] }
 syn = { version = "2.0.114", features = ["extra-traits", "full", "visit", "visit-mut"] }
-tokio = { version = "1.50.0", default-features = false, features = ["net"] }
 usdt-impl = { version = "0.6.0", default-features = false, features = ["des"] }
 zerocopy = { version = "0.8.27", default-features = false, features = ["derive", "simd"] }
 
@@ -94,16 +86,10 @@ zerocopy = { version = "0.8.27", default-features = false, features = ["derive",
 
 [target.aarch64-unknown-linux-gnu.dependencies]
 bitflags = { version = "2.11.0", default-features = false, features = ["std"] }
-futures-channel = { version = "0.3.32", features = ["sink"] }
-futures-core = { version = "0.3.32" }
-futures-sink = { version = "0.3.32" }
 libc = { version = "0.2.183", features = ["extra_traits"] }
 miniz_oxide = { version = "0.8.9", default-features = false, features = ["with-alloc"] }
 mio = { version = "1.0.4", features = ["net", "os-ext"] }
 rustix = { version = "1.0.7", features = ["fs", "stdio", "termios"] }
-slab = { version = "0.4.11" }
-smallvec = { version = "1.15.1", default-features = false, features = ["const_new"] }
-tokio = { version = "1.50.0", default-features = false, features = ["net"] }
 
 [target.aarch64-unknown-linux-gnu.build-dependencies]
 bitflags = { version = "2.11.0", default-features = false, features = ["std"] }
@@ -112,19 +98,13 @@ libc = { version = "0.2.183", features = ["extra_traits"] }
 [target.x86_64-unknown-linux-musl.dependencies]
 bitflags = { version = "2.11.0", default-features = false, features = ["std"] }
 dof = { version = "0.4.0", default-features = false, features = ["des"] }
-futures-channel = { version = "0.3.32", features = ["sink"] }
-futures-core = { version = "0.3.32" }
-futures-sink = { version = "0.3.32" }
 libc = { version = "0.2.183", features = ["extra_traits"] }
 miniz_oxide = { version = "0.8.9", default-features = false, features = ["with-alloc"] }
 mio = { version = "1.0.4", features = ["net", "os-ext"] }
 proc-macro2 = { version = "1.0.106" }
 quote = { version = "1.0.44" }
 rustix = { version = "1.0.7", features = ["fs", "stdio", "termios"] }
-slab = { version = "0.4.11" }
-smallvec = { version = "1.15.1", default-features = false, features = ["const_new"] }
 syn = { version = "2.0.114", features = ["extra-traits", "full", "visit", "visit-mut"] }
-tokio = { version = "1.50.0", default-features = false, features = ["net"] }
 usdt-impl = { version = "0.6.0", default-features = false, features = ["des"] }
 zerocopy = { version = "0.8.27", default-features = false, features = ["derive", "simd"] }
 
@@ -140,16 +120,10 @@ zerocopy = { version = "0.8.27", default-features = false, features = ["derive",
 
 [target.aarch64-unknown-linux-musl.dependencies]
 bitflags = { version = "2.11.0", default-features = false, features = ["std"] }
-futures-channel = { version = "0.3.32", features = ["sink"] }
-futures-core = { version = "0.3.32" }
-futures-sink = { version = "0.3.32" }
 libc = { version = "0.2.183", features = ["extra_traits"] }
 miniz_oxide = { version = "0.8.9", default-features = false, features = ["with-alloc"] }
 mio = { version = "1.0.4", features = ["net", "os-ext"] }
 rustix = { version = "1.0.7", features = ["fs", "stdio", "termios"] }
-slab = { version = "0.4.11" }
-smallvec = { version = "1.15.1", default-features = false, features = ["const_new"] }
-tokio = { version = "1.50.0", default-features = false, features = ["net"] }
 
 [target.aarch64-unknown-linux-musl.build-dependencies]
 bitflags = { version = "2.11.0", default-features = false, features = ["std"] }
@@ -158,19 +132,13 @@ libc = { version = "0.2.183", features = ["extra_traits"] }
 [target.x86_64-unknown-illumos.dependencies]
 bitflags = { version = "2.11.0", default-features = false, features = ["std"] }
 dof = { version = "0.4.0", default-features = false, features = ["des"] }
-futures-channel = { version = "0.3.32", features = ["sink"] }
-futures-core = { version = "0.3.32" }
-futures-sink = { version = "0.3.32" }
 libc = { version = "0.2.183", features = ["extra_traits"] }
 miniz_oxide = { version = "0.8.9", default-features = false, features = ["with-alloc"] }
 mio = { version = "1.0.4", features = ["net", "os-ext"] }
 proc-macro2 = { version = "1.0.106" }
 quote = { version = "1.0.44" }
 rustix = { version = "1.0.7", features = ["fs", "stdio", "termios"] }
-slab = { version = "0.4.11" }
-smallvec = { version = "1.15.1", default-features = false, features = ["const_new"] }
 syn = { version = "2.0.114", features = ["extra-traits", "full", "visit", "visit-mut"] }
-tokio = { version = "1.50.0", default-features = false, features = ["net"] }
 usdt-impl = { version = "0.6.0", default-features = false, features = ["des"] }
 zerocopy = { version = "0.8.27", default-features = false, features = ["derive", "simd"] }
 
@@ -187,19 +155,13 @@ zerocopy = { version = "0.8.27", default-features = false, features = ["derive",
 [target.x86_64-unknown-freebsd.dependencies]
 bitflags = { version = "2.11.0", default-features = false, features = ["std"] }
 dof = { version = "0.4.0", default-features = false, features = ["des"] }
-futures-channel = { version = "0.3.32", features = ["sink"] }
-futures-core = { version = "0.3.32" }
-futures-sink = { version = "0.3.32" }
 libc = { version = "0.2.183", features = ["extra_traits"] }
 miniz_oxide = { version = "0.8.9", default-features = false, features = ["with-alloc"] }
 mio = { version = "1.0.4", features = ["net", "os-ext"] }
 proc-macro2 = { version = "1.0.106" }
 quote = { version = "1.0.44" }
 rustix = { version = "1.0.7", features = ["fs", "stdio", "termios"] }
-slab = { version = "0.4.11" }
-smallvec = { version = "1.15.1", default-features = false, features = ["const_new"] }
 syn = { version = "2.0.114", features = ["extra-traits", "full", "visit", "visit-mut"] }
-tokio = { version = "1.50.0", default-features = false, features = ["net"] }
 usdt-impl = { version = "0.6.0", default-features = false, features = ["des"] }
 zerocopy = { version = "0.8.27", default-features = false, features = ["derive", "simd"] }
 
@@ -216,19 +178,13 @@ zerocopy = { version = "0.8.27", default-features = false, features = ["derive",
 [target.aarch64-unknown-freebsd.dependencies]
 bitflags = { version = "2.11.0", default-features = false, features = ["std"] }
 dof = { version = "0.4.0", default-features = false, features = ["des"] }
-futures-channel = { version = "0.3.32", features = ["sink"] }
-futures-core = { version = "0.3.32" }
-futures-sink = { version = "0.3.32" }
 libc = { version = "0.2.183", features = ["extra_traits"] }
 miniz_oxide = { version = "0.8.9", default-features = false, features = ["with-alloc"] }
 mio = { version = "1.0.4", features = ["net", "os-ext"] }
 proc-macro2 = { version = "1.0.106" }
 quote = { version = "1.0.44" }
 rustix = { version = "1.0.7", features = ["fs", "stdio", "termios"] }
-slab = { version = "0.4.11" }
-smallvec = { version = "1.15.1", default-features = false, features = ["const_new"] }
 syn = { version = "2.0.114", features = ["extra-traits", "full", "visit", "visit-mut"] }
-tokio = { version = "1.50.0", default-features = false, features = ["net"] }
 usdt-impl = { version = "0.6.0", default-features = false, features = ["des"] }
 zerocopy = { version = "0.8.27", default-features = false, features = ["derive", "simd"] }
 
@@ -244,19 +200,13 @@ zerocopy = { version = "0.8.27", default-features = false, features = ["derive",
 
 [target.aarch64-apple-darwin.dependencies]
 bitflags = { version = "2.11.0", default-features = false, features = ["std"] }
-futures-channel = { version = "0.3.32", features = ["sink"] }
-futures-core = { version = "0.3.32" }
-futures-sink = { version = "0.3.32" }
 libc = { version = "0.2.183", features = ["extra_traits"] }
 miniz_oxide = { version = "0.8.9", default-features = false, features = ["with-alloc"] }
 mio = { version = "1.0.4", features = ["net", "os-ext"] }
 proc-macro2 = { version = "1.0.106" }
 quote = { version = "1.0.44" }
 rustix = { version = "1.0.7", features = ["fs", "stdio", "termios"] }
-slab = { version = "0.4.11" }
-smallvec = { version = "1.15.1", default-features = false, features = ["const_new"] }
 syn = { version = "2.0.114", features = ["extra-traits", "full", "visit", "visit-mut"] }
-tokio = { version = "1.50.0", default-features = false, features = ["net"] }
 usdt-impl = { version = "0.6.0", default-features = false, features = ["des"] }
 zerocopy = { version = "0.8.27", default-features = false, features = ["derive", "simd"] }
 
@@ -270,29 +220,17 @@ usdt-impl = { version = "0.6.0", default-features = false, features = ["des"] }
 zerocopy = { version = "0.8.27", default-features = false, features = ["derive", "simd"] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-futures-channel = { version = "0.3.32", features = ["sink"] }
-futures-core = { version = "0.3.32" }
-futures-sink = { version = "0.3.32" }
-slab = { version = "0.4.11" }
-smallvec = { version = "1.15.1", default-features = false, features = ["const_new"] }
-tokio = { version = "1.50.0", default-features = false, features = ["net"] }
-windows-sys-73dcd821b1037cfd = { package = "windows-sys", version = "0.59.0", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
-windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52.0", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Environment", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Shell"] }
-windows-sys-d4189bed749088b6 = { package = "windows-sys", version = "0.61.2", features = ["Win32_Globalization", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_JobObjects", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell"] }
+windows-sys-73dcd821b1037cfd = { package = "windows-sys", version = "0.59.0", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_WindowsProgramming"] }
+windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52.0", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Environment", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Threading", "Win32_UI_Shell"] }
+windows-sys-d4189bed749088b6 = { package = "windows-sys", version = "0.61.2", features = ["Win32_Globalization", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_JobObjects", "Win32_System_Pipes", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell"] }
 
 [target.x86_64-pc-windows-msvc.build-dependencies]
 getrandom = { version = "0.3.3", default-features = false, features = ["std"] }
 
 [target.aarch64-pc-windows-msvc.dependencies]
-futures-channel = { version = "0.3.32", features = ["sink"] }
-futures-core = { version = "0.3.32" }
-futures-sink = { version = "0.3.32" }
-slab = { version = "0.4.11" }
-smallvec = { version = "1.15.1", default-features = false, features = ["const_new"] }
-tokio = { version = "1.50.0", default-features = false, features = ["net"] }
-windows-sys-73dcd821b1037cfd = { package = "windows-sys", version = "0.59.0", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse"] }
-windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52.0", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Environment", "Win32_System_IO", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Shell"] }
-windows-sys-d4189bed749088b6 = { package = "windows-sys", version = "0.61.2", features = ["Win32_Globalization", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_JobObjects", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell"] }
+windows-sys-73dcd821b1037cfd = { package = "windows-sys", version = "0.59.0", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_WindowsProgramming"] }
+windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52.0", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Environment", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Threading", "Win32_UI_Shell"] }
+windows-sys-d4189bed749088b6 = { package = "windows-sys", version = "0.61.2", features = ["Win32_Globalization", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_IO", "Win32_System_JobObjects", "Win32_System_Pipes", "Win32_System_Threading", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell"] }
 
 [target.aarch64-pc-windows-msvc.build-dependencies]
 getrandom = { version = "0.3.3", default-features = false, features = ["std"] }


### PR DESCRIPTION
The ring crate has caused no end of issues with spurious recompiles.

* Update self_update to 0.43.1.
* Switch to ureq -- we don't need reqwest for a single serial HTTP download.
* Remove ring by manually enabling aws-lc-rs and doing the download with ureq ourselves. (As a bonus, we can use nextest's progress bar style.)

The ring crate is still present in Cargo.lock, but that's only due to https://github.com/rust-lang/cargo/issues/10801.