### PR TITLE
[fixtures] verify number of reruns in integration tests

### DIFF
--- a/fixture-data/src/models.rs
+++ b/fixture-data/src/models.rs
@@ -6,7 +6,17 @@
 use iddqd::{IdOrdItem, IdOrdMap, id_upcast};
 use nextest_metadata::{BuildPlatform, FilterMatch, RustBinaryId, TestCaseName};
 
-/// The expected result for a test execution.
+/// The expected result for a test execution, including both the outcome and the
+/// expected rerun behavior.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ExpectedTestResult {
+    /// The expected outcome.
+    pub result: CheckResult,
+    /// The expected rerun behavior.
+    pub expected_reruns: ExpectedReruns,
+}
+
+/// The expected outcome of a test execution.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CheckResult {
     Pass,
@@ -16,6 +26,37 @@ pub enum CheckResult {
     FailLeak,
     Abort,
     Timeout,
+}
+
+impl CheckResult {
+    /// Returns true if this result represents a test failure of any kind.
+    ///
+    /// `Leak` is not a failure: the test passed but leaked subprocess handles.
+    /// `LeakFail` is a failure: the test was marked as failed due to leaked
+    /// handles.
+    pub fn is_failure(self) -> bool {
+        match self {
+            CheckResult::Pass | CheckResult::Leak => false,
+            CheckResult::LeakFail
+            | CheckResult::Fail
+            | CheckResult::FailLeak
+            | CheckResult::Abort
+            | CheckResult::Timeout => true,
+        }
+    }
+}
+
+/// What rerun behavior to expect for a test case.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExpectedReruns {
+    /// No reruns expected (no retries configured, or test doesn't retry).
+    None,
+    /// Exactly N flaky runs expected (test passed on attempt N+1).
+    FlakyRunCount(usize),
+    /// Some reruns expected but the exact count is unknown (failing test with
+    /// retries, where the count depends on per-test profile overrides that the
+    /// fixture data model doesn't track).
+    SomeReruns,
 }
 
 bitflags::bitflags! {
@@ -284,8 +325,20 @@ impl TestCaseFixture {
         false
     }
 
-    /// Determines the expected test result based on test status and run properties.
-    pub fn expected_result(&self, properties: RunProperties) -> CheckResult {
+    /// Determines the expected test result based on test status and run
+    /// properties.
+    ///
+    /// Returns both the expected outcome and the expected rerun behavior.
+    pub fn expected_result(&self, properties: RunProperties) -> ExpectedTestResult {
+        let result = self.expected_check_result(properties);
+        let expected_reruns = self.expected_reruns(result, properties);
+        ExpectedTestResult {
+            result,
+            expected_reruns,
+        }
+    }
+
+    fn expected_check_result(&self, properties: RunProperties) -> CheckResult {
         // BenchOverrideTimeout - the benchmark times out due to override.
         if self.has_property(TestCaseFixtureProperties::BENCH_OVERRIDE_TIMEOUT)
             && properties.contains(RunProperties::BENCH_OVERRIDE_TIMEOUT)
@@ -312,14 +365,6 @@ impl TestCaseFixture {
         // The output shows PASS, not TIMEOUT.
         if self.has_property(TestCaseFixtureProperties::SLOW_TIMEOUT_SUBSTRING)
             && properties.contains(RunProperties::TIMEOUT_RETRIES_PASS)
-        {
-            return CheckResult::Pass;
-        }
-
-        // TIMEOUT_RETRIES_FLAKY - test is flaky (fails twice, then times out and passes).
-        // The output shows PASS, not TIMEOUT.
-        if self.has_property(TestCaseFixtureProperties::FLAKY_SLOW_TIMEOUT_SUBSTRING)
-            && properties.contains(RunProperties::TIMEOUT_RETRIES_FLAKY)
         {
             return CheckResult::Pass;
         }
@@ -392,7 +437,42 @@ impl TestCaseFixture {
                     unreachable!("ignored tests should be filtered out")
                 }
             }
+            TestCaseFixtureStatus::IgnoredFlaky { .. } => {
+                // TIMEOUT_RETRIES_FLAKY: the test fails several times, then
+                // times out and passes due to on-timeout=pass.
+                if properties.contains(RunProperties::TIMEOUT_RETRIES_FLAKY) {
+                    CheckResult::Pass
+                } else if properties.contains(RunProperties::RUN_IGNORED_ONLY) {
+                    CheckResult::Fail
+                } else {
+                    unreachable!("ignored tests should be filtered out")
+                }
+            }
         }
+    }
+
+    /// Computes the expected rerun behavior for a test case based on its
+    /// fixture status, the check result, and the run properties.
+    fn expected_reruns(&self, result: CheckResult, properties: RunProperties) -> ExpectedReruns {
+        if let TestCaseFixtureStatus::Flaky { pass_attempt }
+        | TestCaseFixtureStatus::IgnoredFlaky { pass_attempt } = self.status
+            && result == CheckResult::Pass
+        {
+            debug_assert!(
+                pass_attempt >= 2,
+                "pass_attempt must be >= 2 for a flaky test"
+            );
+            return ExpectedReruns::FlakyRunCount((pass_attempt - 1) as usize);
+        }
+
+        // Failing tests with retries configured will have reruns, but the exact
+        // count depends on per-test profile overrides which the fixture data
+        // model doesn't track.
+        if properties.contains(RunProperties::WITH_RETRIES) && result.is_failure() {
+            return ExpectedReruns::SomeReruns;
+        }
+
+        ExpectedReruns::None
     }
 }
 
@@ -425,21 +505,36 @@ impl PartialEq<TestNameAndFilterMatch<'_>> for TestCaseFixture {
 pub enum TestCaseFixtureStatus {
     Pass,
     Fail,
-    Flaky { pass_attempt: u32 },
+    Flaky {
+        pass_attempt: u32,
+    },
     Leak,
     LeakFail,
     FailLeak,
     Segfault,
     IgnoredPass,
     IgnoredFail,
+    /// An ignored test that is flaky: it fails `pass_attempt - 1` times, then
+    /// passes on attempt `pass_attempt`.
+    IgnoredFlaky {
+        pass_attempt: u32,
+    },
 }
 
 impl TestCaseFixtureStatus {
     pub fn is_ignored(self) -> bool {
-        matches!(
-            self,
-            TestCaseFixtureStatus::IgnoredPass | TestCaseFixtureStatus::IgnoredFail
-        )
+        match self {
+            TestCaseFixtureStatus::IgnoredPass
+            | TestCaseFixtureStatus::IgnoredFail
+            | TestCaseFixtureStatus::IgnoredFlaky { .. } => true,
+            TestCaseFixtureStatus::Pass
+            | TestCaseFixtureStatus::Fail
+            | TestCaseFixtureStatus::Flaky { .. }
+            | TestCaseFixtureStatus::Leak
+            | TestCaseFixtureStatus::LeakFail
+            | TestCaseFixtureStatus::FailLeak
+            | TestCaseFixtureStatus::Segfault => false,
+        }
     }
 }
 

--- a/fixture-data/src/nextest_tests.rs
+++ b/fixture-data/src/nextest_tests.rs
@@ -56,7 +56,7 @@ pub static EXPECTED_TEST_SUITES: LazyLock<IdOrdMap<TestSuiteFixture>> = LazyLock
                     .with_property(TestCaseFixtureProperties::TEST_SLOW_TIMEOUT_SUBSTRING),
                 TestCaseFixture::new(
                     "test_flaky_slow_timeout_mod_3",
-                    TestCaseFixtureStatus::IgnoredFail,
+                    TestCaseFixtureStatus::IgnoredFlaky { pass_attempt: 3 },
                 )
                     .with_property(TestCaseFixtureProperties::SLOW_TIMEOUT_SUBSTRING)
                     .with_property(TestCaseFixtureProperties::FLAKY_SLOW_TIMEOUT_SUBSTRING),

--- a/integration-tests/tests/integration/fixtures.rs
+++ b/integration-tests/tests/integration/fixtures.rs
@@ -4,7 +4,10 @@
 use super::temp_project::TempProject;
 use camino::Utf8Path;
 use fixture_data::{
-    models::{CheckResult, RunProperties, TestCaseFixtureProperties, TestSuiteFixtureProperties},
+    models::{
+        CheckResult, ExpectedReruns, ExpectedTestResult, RunProperties, TestCaseFixtureProperties,
+        TestSuiteFixtureProperties,
+    },
     nextest_tests::EXPECTED_TEST_SUITES,
 };
 use iddqd::{IdOrdItem, IdOrdMap, id_upcast};
@@ -306,11 +309,11 @@ impl ExpectedTestResults {
                 }
 
                 // Determine the expected result for this test.
-                let result = test.expected_result(properties);
+                let expected = test.expected_result(properties);
 
-                summary.update(result);
+                summary.update(expected.result);
                 should_run
-                    .insert_unique(ExpectedOutcome { id, result })
+                    .insert_unique(ExpectedOutcome { id, expected })
                     .expect("duplicate ids should not be seen");
             }
         }
@@ -348,11 +351,11 @@ impl ExpectedTestResults {
                     continue;
                 }
 
-                let result = test.expected_result(properties);
+                let expected = test.expected_result(properties);
 
-                summary.update(result);
+                summary.update(expected.result);
                 should_run
-                    .insert_unique(ExpectedOutcome { id, result })
+                    .insert_unique(ExpectedOutcome { id, expected })
                     .expect("duplicate ids should not be seen");
             }
         }
@@ -369,7 +372,7 @@ impl ExpectedTestResults {
 #[derive(Clone, Debug)]
 struct ExpectedOutcome {
     id: TestInstanceId,
-    result: CheckResult,
+    expected: ExpectedTestResult,
 }
 
 impl IdOrdItem for ExpectedOutcome {
@@ -682,23 +685,64 @@ fn verify_expected_in_actual(
                 // With retries, a test may have multiple attempts - we check the last one.
                 let actual_result = actual.final_result();
                 assert_eq!(
-                    expected_outcome.result,
+                    expected_outcome.expected.result,
                     actual_result,
                     "{}: expected result {:?} but got {:?} (attempts: {:?})\n\n\
                      --- output ---\n{}\n--- end output ---",
                     expected_outcome.id.full_name(),
-                    expected_outcome.result,
+                    expected_outcome.expected.result,
                     actual_result,
                     actual.attempts,
                     output
                 );
+
+                // Verify the number of retry attempts matches expectations.
+                // The number of non-final attempts (retries) is attempts.len() - 1.
+                let actual_rerun_count = actual.attempts.len() - 1;
+                match expected_outcome.expected.expected_reruns {
+                    ExpectedReruns::None => {
+                        assert_eq!(
+                            actual_rerun_count,
+                            0,
+                            "{}: expected no reruns but found {} (properties: {})\n\n\
+                             --- output ---\n{}\n--- end output ---",
+                            expected_outcome.id.full_name(),
+                            actual_rerun_count,
+                            debug_run_properties(properties),
+                            output
+                        );
+                    }
+                    ExpectedReruns::FlakyRunCount(expected_count) => {
+                        assert_eq!(
+                            actual_rerun_count,
+                            expected_count,
+                            "{}: expected {} reruns but found {} (properties: {})\n\n\
+                             --- output ---\n{}\n--- end output ---",
+                            expected_outcome.id.full_name(),
+                            expected_count,
+                            actual_rerun_count,
+                            debug_run_properties(properties),
+                            output
+                        );
+                    }
+                    ExpectedReruns::SomeReruns => {
+                        assert!(
+                            actual_rerun_count > 0,
+                            "{}: expected reruns but found none (properties: {})\n\n\
+                             --- output ---\n{}\n--- end output ---",
+                            expected_outcome.id.full_name(),
+                            debug_run_properties(properties),
+                            output
+                        );
+                    }
+                }
             }
             None => {
                 panic!(
                     "{}: expected to run with result {:?} but was not found in output\n\n\
                      --- output ---\n{}\n--- end output ---",
                     expected_outcome.id.full_name(),
-                    expected_outcome.result,
+                    expected_outcome.expected.result,
                     output
                 );
             }
@@ -946,7 +990,7 @@ pub fn check_rerun_expanded_output(
             .should_run
             .insert_unique(outcome.clone())
             .expect("expanded tests should not overlap with initial run tests");
-        rerun_expected.summary.update(outcome.result);
+        rerun_expected.summary.update(outcome.expected.result);
     }
 
     // The fixture model includes tests (like benchmarks) that the actual run
@@ -984,7 +1028,7 @@ fn filter_for_rerun(expected: &ExpectedTestResults) -> ExpectedTestResults {
     };
 
     for outcome in &expected.should_run {
-        match outcome.result {
+        match outcome.expected.result {
             // Failed tests are still outstanding and should run.
             CheckResult::Fail
             | CheckResult::Abort
@@ -994,10 +1038,10 @@ fn filter_for_rerun(expected: &ExpectedTestResults) -> ExpectedTestResults {
                 rerun_should_run
                     .insert_unique(ExpectedOutcome {
                         id: outcome.id.clone(),
-                        result: outcome.result,
+                        expected: outcome.expected,
                     })
                     .expect("no duplicates");
-                rerun_summary.update(outcome.result);
+                rerun_summary.update(outcome.expected.result);
             }
             // Passed tests become skipped in the rerun.
             CheckResult::Pass | CheckResult::Leak => {
@@ -1053,6 +1097,9 @@ struct JunitOutcome {
     id: TestInstanceId,
     /// The NonSuccessKind and type string, or None for success.
     non_success: Option<(quick_junit::NonSuccessKind, String)>,
+    /// The number of rerun elements (flaky_runs for Success, reruns for
+    /// NonSuccess).
+    rerun_count: usize,
 }
 
 impl IdOrdItem for JunitOutcome {
@@ -1086,12 +1133,17 @@ impl ActualJunitResults {
                 let test_name = TestCaseName::new(test_case.name.as_str());
                 let id = TestInstanceId::new(binary_id, &test_name);
 
-                let non_success = match &test_case.status {
-                    quick_junit::TestCaseStatus::Success { .. } => None,
-                    quick_junit::TestCaseStatus::NonSuccess { kind, ty, .. } => Some((
-                        *kind,
-                        ty.as_ref().map(|s| s.to_string()).unwrap_or_default(),
-                    )),
+                let (non_success, rerun_count) = match &test_case.status {
+                    quick_junit::TestCaseStatus::Success { flaky_runs } => (None, flaky_runs.len()),
+                    quick_junit::TestCaseStatus::NonSuccess {
+                        kind, ty, reruns, ..
+                    } => (
+                        Some((
+                            *kind,
+                            ty.as_ref().map(|s| s.to_string()).unwrap_or_default(),
+                        )),
+                        reruns.len(),
+                    ),
                     quick_junit::TestCaseStatus::Skipped { .. } => {
                         // Skipped tests are filtered out during test execution and don't appear
                         // in our fixture data's expected results, so we skip them here to
@@ -1103,6 +1155,7 @@ impl ActualJunitResults {
                 let outcome = JunitOutcome {
                     id: id.clone(),
                     non_success,
+                    rerun_count,
                 };
                 tests
                     .insert_unique(outcome)
@@ -1153,7 +1206,7 @@ fn verify_expected_in_junit(
                 // - LeakFail:                  "test exited with code 0, but leaked handles so was marked failed"
                 // - Timeout:                   "test timeout" or "benchmark timeout"
                 let expected_junit: Option<(quick_junit::NonSuccessKind, &str)> =
-                    match expected_outcome.result {
+                    match expected_outcome.expected.result {
                         CheckResult::Pass | CheckResult::Leak => None,
                         CheckResult::LeakFail => Some((
                             quick_junit::NonSuccessKind::Error,
@@ -1193,7 +1246,7 @@ fn verify_expected_in_junit(
                                 actual_kind,
                                 debug_run_properties(properties),
                                 junit_path,
-                                expected_outcome.result,
+                                expected_outcome.expected.result,
                                 actual_type,
                             );
                         }
@@ -1212,7 +1265,7 @@ fn verify_expected_in_junit(
                                 actual_type,
                                 debug_run_properties(properties),
                                 junit_path,
-                                expected_outcome.result,
+                                expected_outcome.expected.result,
                             );
                         }
                     }
@@ -1227,7 +1280,7 @@ fn verify_expected_in_junit(
                             ty,
                             debug_run_properties(properties),
                             junit_path,
-                            expected_outcome.result,
+                            expected_outcome.expected.result,
                         );
                     }
                     (Some((kind, _)), None) => {
@@ -1239,7 +1292,46 @@ fn verify_expected_in_junit(
                             kind,
                             debug_run_properties(properties),
                             junit_path,
-                            expected_outcome.result,
+                            expected_outcome.expected.result,
+                        );
+                    }
+                }
+
+                // Verify that the rerun count matches the expected value.
+                match expected_outcome.expected.expected_reruns {
+                    ExpectedReruns::None => {
+                        assert_eq!(
+                            actual.rerun_count,
+                            0,
+                            "{}: expected no reruns but found {} (properties: {})\n\
+                             JUnit path: {}",
+                            expected_outcome.id.full_name(),
+                            actual.rerun_count,
+                            debug_run_properties(properties),
+                            junit_path,
+                        );
+                    }
+                    ExpectedReruns::FlakyRunCount(expected_count) => {
+                        assert_eq!(
+                            actual.rerun_count,
+                            expected_count,
+                            "{}: expected {} flaky runs but found {} (properties: {})\n\
+                             JUnit path: {}",
+                            expected_outcome.id.full_name(),
+                            expected_count,
+                            actual.rerun_count,
+                            debug_run_properties(properties),
+                            junit_path,
+                        );
+                    }
+                    ExpectedReruns::SomeReruns => {
+                        assert!(
+                            actual.rerun_count > 0,
+                            "{}: expected reruns but found none (properties: {})\n\
+                             JUnit path: {}",
+                            expected_outcome.id.full_name(),
+                            debug_run_properties(properties),
+                            junit_path,
                         );
                     }
                 }
@@ -1250,7 +1342,7 @@ fn verify_expected_in_junit(
                      (properties: {})\n\
                      JUnit path: {}",
                     expected_outcome.id.full_name(),
-                    expected_outcome.result,
+                    expected_outcome.expected.result,
                     debug_run_properties(properties),
                     junit_path,
                 );


### PR DESCRIPTION
Verify reruns in regular and JUnit output.

This is preparation for upcoming work to let you mark tests as failing if they are flaky.