### PR TITLE
[nextest-runner] introduce FlakyResult type and thread through codebase

### DIFF
--- a/nextest-runner/src/config/core/imp.rs
+++ b/nextest-runner/src/config/core/imp.rs
@@ -7,10 +7,10 @@ use crate::{
         core::ConfigExperimental,
         elements::{
             ArchiveConfig, BenchConfig, CustomTestGroup, DefaultBenchConfig, DefaultJunitImpl,
-            GlobalTimeout, Inherits, JunitConfig, JunitImpl, JunitSettings, LeakTimeout, MaxFail,
-            RetryPolicy, SlowTimeout, TestGroup, TestGroupConfig, TestThreads, ThreadsRequired,
-            deserialize_fail_fast, deserialize_leak_timeout, deserialize_retry_policy,
-            deserialize_slow_timeout,
+            DeserializedRetryPolicy, FlakyResult, GlobalTimeout, Inherits, JunitConfig, JunitImpl,
+            JunitSettings, LeakTimeout, MaxFail, RetryPolicy, SlowTimeout, TestGroup,
+            TestGroupConfig, TestThreads, ThreadsRequired, deserialize_fail_fast,
+            deserialize_leak_timeout, deserialize_retry_policy, deserialize_slow_timeout,
         },
         overrides::{
             CompiledByProfile, CompiledData, CompiledDefaultFilter, DeserializedOverride,
@@ -1080,9 +1080,22 @@ impl<'cfg> EvaluatableProfile<'cfg> {
         self.scripts
     }
 
-    /// Returns the retry count for this profile.
+    /// Returns the retry policy for this profile.
     pub fn retries(&self) -> RetryPolicy {
-        profile_field!(self.retries)
+        self.custom_profile
+            .iter()
+            .chain(self.inheritance_chain.iter())
+            .find_map(|p| p.retries.as_ref().map(|drp| drp.policy))
+            .unwrap_or(self.default_profile.retries)
+    }
+
+    /// Returns the flaky result behavior for this profile.
+    pub fn flaky_result(&self) -> FlakyResult {
+        self.custom_profile
+            .iter()
+            .chain(self.inheritance_chain.iter())
+            .find_map(|p| p.retries.as_ref().and_then(|drp| drp.flaky_result))
+            .unwrap_or(self.default_profile.flaky_result)
     }
 
     /// Returns the number of threads to run against for this profile.
@@ -1501,6 +1514,7 @@ pub(in crate::config) struct DefaultProfileImpl {
     threads_required: ThreadsRequired,
     run_extra_args: Vec<String>,
     retries: RetryPolicy,
+    flaky_result: FlakyResult,
     status_level: StatusLevel,
     final_status_level: FinalStatusLevel,
     failure_output: TestOutputDisplay,
@@ -1519,6 +1533,7 @@ pub(in crate::config) struct DefaultProfileImpl {
 
 impl DefaultProfileImpl {
     fn new(p: CustomProfileImpl) -> Self {
+        let deserialized_retries = p.retries.expect("retries present in default profile");
         Self {
             default_filter: p
                 .default_filter
@@ -1532,7 +1547,8 @@ impl DefaultProfileImpl {
             run_extra_args: p
                 .run_extra_args
                 .expect("run-extra-args present in default profile"),
-            retries: p.retries.expect("retries present in default profile"),
+            retries: deserialized_retries.policy,
+            flaky_result: deserialized_retries.flaky_result.unwrap_or_default(),
             status_level: p
                 .status_level
                 .expect("status-level present in default profile"),
@@ -1604,7 +1620,7 @@ pub(in crate::config) struct CustomProfileImpl {
     #[serde(default)]
     default_filter: Option<String>,
     #[serde(default, deserialize_with = "deserialize_retry_policy")]
-    retries: Option<RetryPolicy>,
+    retries: Option<DeserializedRetryPolicy>,
     #[serde(default)]
     test_threads: Option<TestThreads>,
     #[serde(default)]

--- a/nextest-runner/src/config/elements/retry_policy.rs
+++ b/nextest-runner/src/config/elements/retry_policy.rs
@@ -1,44 +1,36 @@
 // Copyright (c) The nextest Contributors
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::{cmp::Ordering, fmt, time::Duration};
 
 /// Type for the retry config key.
-#[derive(Debug, Copy, Clone, Deserialize, PartialEq, Eq)]
-#[serde(tag = "backoff", rename_all = "kebab-case", deny_unknown_fields)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RetryPolicy {
     /// Fixed backoff.
-    #[serde(rename_all = "kebab-case")]
     Fixed {
         /// Maximum retry count.
         count: u32,
 
         /// Delay between retries.
-        #[serde(default, with = "humantime_serde")]
         delay: Duration,
 
         /// If set to true, randomness will be added to the delay on each retry attempt.
-        #[serde(default)]
         jitter: bool,
     },
 
     /// Exponential backoff.
-    #[serde(rename_all = "kebab-case")]
     Exponential {
         /// Maximum retry count.
         count: u32,
 
         /// Delay between retries. Not optional for exponential backoff.
-        #[serde(with = "humantime_serde")]
         delay: Duration,
 
         /// If set to true, randomness will be added to the delay on each retry attempt.
-        #[serde(default)]
         jitter: bool,
 
         /// If set, limits the delay between retries.
-        #[serde(default, with = "humantime_serde")]
         max_delay: Option<Duration>,
     },
 }
@@ -68,16 +60,96 @@ impl RetryPolicy {
     }
 }
 
+/// Controls whether a flaky test is treated as a pass or a failure.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+#[cfg_attr(test, derive(test_strategy::Arbitrary))]
+pub enum FlakyResult {
+    /// The test is marked as passed.
+    #[default]
+    Pass,
+}
+
+/// Intermediate type for deserializing retry policy from TOML. The
+/// `flaky-result` field is extracted separately from the backoff policy.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(in crate::config) struct DeserializedRetryPolicy {
+    /// The retry backoff policy.
+    pub(in crate::config) policy: RetryPolicy,
+
+    /// The flaky result behavior, if explicitly set.
+    pub(in crate::config) flaky_result: Option<FlakyResult>,
+}
+
+/// Serde-compatible intermediate type that includes the `flaky-result` field
+/// alongside backoff parameters. After deserialization, the `flaky-result` is
+/// split out into `DeserializedRetryPolicy`.
+#[derive(Debug, Copy, Clone, Deserialize)]
+#[serde(tag = "backoff", rename_all = "kebab-case", deny_unknown_fields)]
+enum RetryPolicySerde {
+    #[serde(rename_all = "kebab-case")]
+    Fixed {
+        count: u32,
+        #[serde(default, with = "humantime_serde")]
+        delay: Duration,
+        #[serde(default)]
+        jitter: bool,
+    },
+    #[serde(rename_all = "kebab-case")]
+    Exponential {
+        count: u32,
+        #[serde(with = "humantime_serde")]
+        delay: Duration,
+        #[serde(default)]
+        jitter: bool,
+        #[serde(default, with = "humantime_serde")]
+        max_delay: Option<Duration>,
+    },
+}
+
+impl RetryPolicySerde {
+    fn into_deserialized(self) -> DeserializedRetryPolicy {
+        match self {
+            RetryPolicySerde::Fixed {
+                count,
+                delay,
+                jitter,
+            } => DeserializedRetryPolicy {
+                policy: RetryPolicy::Fixed {
+                    count,
+                    delay,
+                    jitter,
+                },
+                flaky_result: None,
+            },
+            RetryPolicySerde::Exponential {
+                count,
+                delay,
+                jitter,
+                max_delay,
+            } => DeserializedRetryPolicy {
+                policy: RetryPolicy::Exponential {
+                    count,
+                    delay,
+                    jitter,
+                    max_delay,
+                },
+                flaky_result: None,
+            },
+        }
+    }
+}
+
 pub(in crate::config) fn deserialize_retry_policy<'de, D>(
     deserializer: D,
-) -> Result<Option<RetryPolicy>, D::Error>
+) -> Result<Option<DeserializedRetryPolicy>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
     struct V;
 
     impl<'de2> serde::de::Visitor<'de2> for V {
-        type Value = Option<RetryPolicy>;
+        type Value = Option<DeserializedRetryPolicy>;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
             write!(
@@ -99,7 +171,10 @@ where
                             &"a positive u32",
                         )
                     })?;
-                    Ok(Some(RetryPolicy::new_without_delay(v)))
+                    Ok(Some(DeserializedRetryPolicy {
+                        policy: RetryPolicy::new_without_delay(v),
+                        flaky_result: None,
+                    }))
                 }
                 Ordering::Less => Err(serde::de::Error::invalid_value(
                     serde::de::Unexpected::Signed(v),
@@ -112,13 +187,14 @@ where
         where
             A: serde::de::MapAccess<'de2>,
         {
-            RetryPolicy::deserialize(serde::de::value::MapAccessDeserializer::new(map)).map(Some)
+            RetryPolicySerde::deserialize(serde::de::value::MapAccessDeserializer::new(map))
+                .map(|s| Some(s.into_deserialized()))
         }
     }
 
     // Post-deserialize validation of retry policy.
-    let retry_policy = deserializer.deserialize_any(V)?;
-    match &retry_policy {
+    let deserialized = deserializer.deserialize_any(V)?;
+    match deserialized.as_ref().map(|d| &d.policy) {
         Some(RetryPolicy::Fixed {
             count: _,
             delay,
@@ -165,7 +241,7 @@ where
         None => {}
     }
 
-    Ok(retry_policy)
+    Ok(deserialized)
 }
 
 #[cfg(test)]
@@ -219,18 +295,24 @@ mod tests {
             &Default::default(),
         )
         .expect("config is valid");
+
+        let default_profile = config
+            .profile("default")
+            .expect("default profile exists")
+            .apply_build_platforms(&build_platforms());
         assert_eq!(
-            config
-                .profile("default")
-                .expect("default profile exists")
-                .apply_build_platforms(&build_platforms())
-                .retries(),
+            default_profile.retries(),
             RetryPolicy::Fixed {
                 count: 3,
                 delay: Duration::ZERO,
                 jitter: false,
             },
             "default retries matches"
+        );
+        assert_eq!(
+            default_profile.flaky_result(),
+            FlakyResult::Pass,
+            "default flaky_result matches"
         );
 
         assert_eq!(

--- a/nextest-runner/src/config/overrides/imp.rs
+++ b/nextest-runner/src/config/overrides/imp.rs
@@ -7,7 +7,8 @@ use crate::{
             EvaluatableProfile, FinalConfig, NextestConfig, NextestConfigImpl, PreBuildPlatform,
         },
         elements::{
-            LeakTimeout, RetryPolicy, SlowTimeout, TestGroup, TestPriority, ThreadsRequired,
+            DeserializedRetryPolicy, FlakyResult, LeakTimeout, RetryPolicy, SlowTimeout, TestGroup,
+            TestPriority, ThreadsRequired,
         },
         scripts::{
             CompiledProfileScripts, DeserializedProfileScriptConfig, ScriptId, WrapperScriptConfig,
@@ -105,6 +106,7 @@ pub struct TestSettings<'p, Source = ()> {
     run_wrapper: Option<(&'p WrapperScriptConfig, Source)>,
     run_extra_args: (&'p [String], Source),
     retries: (RetryPolicy, Source),
+    flaky_result: (FlakyResult, Source),
     slow_timeout: (SlowTimeout, Source),
     leak_timeout: (LeakTimeout, Source),
     test_group: (TestGroup, Source),
@@ -200,6 +202,11 @@ impl<'p> TestSettings<'p> {
         self.retries.0
     }
 
+    /// Returns the flaky result behavior for this test.
+    pub fn flaky_result(&self) -> FlakyResult {
+        self.flaky_result.0
+    }
+
     /// Returns the slow timeout for this test.
     pub fn slow_timeout(&self) -> SlowTimeout {
         self.slow_timeout.0
@@ -253,6 +260,7 @@ impl<'p, Source: Copy> TestSettings<'p, Source> {
         let mut run_wrapper = None;
         let mut run_extra_args = None;
         let mut retries = None;
+        let mut flaky_result = None;
         let mut slow_timeout = None;
         let mut leak_timeout = None;
         let mut test_group = None;
@@ -300,6 +308,11 @@ impl<'p, Source: Copy> TestSettings<'p, Source> {
                 && let Some(r) = override_.data.retries
             {
                 retries = Some(Source::track_override(r, override_));
+            }
+            if flaky_result.is_none()
+                && let Some(fr) = override_.data.flaky_result
+            {
+                flaky_result = Some(Source::track_override(fr, override_));
             }
             if slow_timeout.is_none() {
                 // Use the appropriate slow timeout based on run mode. Note that
@@ -364,6 +377,8 @@ impl<'p, Source: Copy> TestSettings<'p, Source> {
         let run_extra_args =
             run_extra_args.unwrap_or_else(|| Source::track_profile(profile.run_extra_args()));
         let retries = retries.unwrap_or_else(|| Source::track_profile(profile.retries()));
+        let flaky_result =
+            flaky_result.unwrap_or_else(|| Source::track_profile(profile.flaky_result()));
         let slow_timeout =
             slow_timeout.unwrap_or_else(|| Source::track_profile(profile.slow_timeout(run_mode)));
         let leak_timeout =
@@ -387,6 +402,7 @@ impl<'p, Source: Copy> TestSettings<'p, Source> {
             run_extra_args,
             run_wrapper,
             retries,
+            flaky_result,
             priority,
             slow_timeout,
             leak_timeout,
@@ -710,6 +726,7 @@ pub(in crate::config) struct ProfileOverrideData {
     threads_required: Option<ThreadsRequired>,
     run_extra_args: Option<Vec<String>>,
     retries: Option<RetryPolicy>,
+    flaky_result: Option<FlakyResult>,
     slow_timeout: Option<SlowTimeout>,
     bench_slow_timeout: Option<SlowTimeout>,
     leak_timeout: Option<LeakTimeout>,
@@ -792,7 +809,8 @@ impl CompiledOverride<PreBuildPlatform> {
                         priority: source.priority,
                         threads_required: source.threads_required,
                         run_extra_args: source.run_extra_args.clone(),
-                        retries: source.retries,
+                        retries: source.retries.map(|drp| drp.policy),
+                        flaky_result: source.retries.and_then(|drp| drp.flaky_result),
                         slow_timeout: source.slow_timeout,
                         bench_slow_timeout: source.bench.slow_timeout,
                         leak_timeout: source.leak_timeout,
@@ -944,7 +962,7 @@ pub(in crate::config) struct DeserializedOverride {
         default,
         deserialize_with = "crate::config::elements::deserialize_retry_policy"
     )]
-    retries: Option<RetryPolicy>,
+    retries: Option<DeserializedRetryPolicy>,
     #[serde(
         default,
         deserialize_with = "crate::config::elements::deserialize_slow_timeout"

--- a/nextest-runner/src/record/recorder.rs
+++ b/nextest-runner/src/record/recorder.rs
@@ -567,11 +567,12 @@ impl SerializeTestEventContext<'_> {
         &mut self,
         statuses: ExecutionStatuses<LiveSpec>,
     ) -> Result<ExecutionStatuses<RecordingSpec>, StoreWriterError> {
+        let flaky_result = statuses.flaky_result();
         let statuses = statuses
             .into_iter()
             .map(|status| self.convert_execute_status(status))
             .collect::<Result<Vec<_>, _>>()?;
-        Ok(ExecutionStatuses::new(statuses))
+        Ok(ExecutionStatuses::new(statuses, flaky_result))
     }
 
     fn convert_execute_status(

--- a/nextest-runner/src/record/replay.rs
+++ b/nextest-runner/src/record/replay.rs
@@ -488,12 +488,13 @@ fn convert_execution_statuses(
     reader: &mut dyn StoreReader,
     load_output: LoadOutput,
 ) -> Result<ExecutionStatuses<LiveSpec>, ReplayConversionError> {
+    let flaky_result = statuses.flaky_result();
     let statuses: Vec<ExecuteStatus<LiveSpec>> = statuses
         .iter()
         .map(|s| convert_execute_status(s, reader, load_output))
         .collect::<Result<_, _>>()?;
 
-    Ok(ExecutionStatuses::new(statuses))
+    Ok(ExecutionStatuses::new(statuses, flaky_result))
 }
 
 fn convert_setup_script_status(

--- a/nextest-runner/src/record/rerun.rs
+++ b/nextest-runner/src/record/rerun.rs
@@ -477,6 +477,7 @@ where
 mod tests {
     use super::*;
     use crate::{
+        config::elements::FlakyResult,
         output_spec::RecordingSpec,
         record::{
             OutputEventKind, StressIndexSummary, TestEventKindSummary, ZipStoreOutputDescription,
@@ -1494,7 +1495,7 @@ mod tests {
             failure_output: TestOutputDisplay::Never,
             junit_store_success_output: false,
             junit_store_failure_output: false,
-            run_statuses: ExecutionStatuses::new(vec![execute_status]),
+            run_statuses: ExecutionStatuses::new(vec![execute_status], FlakyResult::default()),
             current_stats: RunStats::default(),
             running: 0,
         })

--- a/nextest-runner/src/reporter/aggregator/junit.rs
+++ b/nextest-runner/src/reporter/aggregator/junit.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     config::{
-        elements::{JunitConfig, LeakTimeoutResult, SlowTimeoutResult},
+        elements::{FlakyResult, JunitConfig, LeakTimeoutResult, SlowTimeoutResult},
         scripts::ScriptId,
     },
     errors::{DisplayErrorChain, WriteEventError},
@@ -147,6 +147,7 @@ impl<'cfg> MetadataJunit<'cfg> {
                     ExecutionDescription::Flaky {
                         last_status,
                         prior_statuses,
+                        result: FlakyResult::Pass,
                     } => (TestCaseStatus::success(), last_status, prior_statuses),
                     ExecutionDescription::Failure {
                         first_status,

--- a/nextest-runner/src/reporter/displayer/imp.rs
+++ b/nextest-runner/src/reporter/displayer/imp.rs
@@ -20,7 +20,7 @@ use super::{
 };
 use crate::{
     config::{
-        elements::{LeakTimeoutResult, SlowTimeoutResult},
+        elements::{FlakyResult, LeakTimeoutResult, SlowTimeoutResult},
         overrides::CompiledDefaultFilter,
         scripts::ScriptId,
     },
@@ -1733,7 +1733,10 @@ impl<'a> DisplayReporterImpl<'a> {
                     }
                 }
             }
-            ExecutionDescription::Flaky { .. } => {
+            ExecutionDescription::Flaky {
+                result: FlakyResult::Pass,
+                ..
+            } => {
                 // Use the skip color to also represent a flaky test.
                 let status = match kind {
                     StatusLineKind::Intermediate => {
@@ -2306,6 +2309,10 @@ impl<'a> DisplayReporterImpl<'a> {
         is_retry: bool,
         writer: &mut dyn WriteStr,
     ) -> io::Result<()> {
+        // Styling is based on run_status.result, which is the individual
+        // attempt's result. For flaky-failed tests, this is called on the
+        // last (successful) attempt, so pass styling (green headers, no
+        // error extraction) is correct — the output content has no panics.
         let spec = self.output_spec_for_finished(&run_status.result, is_retry);
         self.unit_output.write_child_execution_output(
             &self.styles,
@@ -2799,7 +2806,7 @@ mod tests {
             output_error_slice: None,
         };
         FinalOutput::Executed {
-            run_statuses: ExecutionStatuses::new(vec![status]),
+            run_statuses: ExecutionStatuses::new(vec![status], FlakyResult::default()),
             display_output: false,
         }
     }
@@ -2825,7 +2832,7 @@ mod tests {
             output_error_slice: None,
         };
         FinalOutput::Executed {
-            run_statuses: ExecutionStatuses::new(vec![status]),
+            run_statuses: ExecutionStatuses::new(vec![status], FlakyResult::default()),
             display_output: false,
         }
     }
@@ -2896,7 +2903,8 @@ mod tests {
         };
 
         // Make an `ExecutionStatuses` with a failure and a success, indicating flakiness.
-        let statuses = ExecutionStatuses::new(vec![fail_status.clone(), flaky_status]);
+        let statuses =
+            ExecutionStatuses::new(vec![fail_status.clone(), flaky_status], FlakyResult::Pass);
         let flaky_describe = statuses.describe();
 
         let mut out = String::new();
@@ -3333,6 +3341,7 @@ mod tests {
         let flaky_describe = ExecutionDescription::Flaky {
             last_status: &flaky_last_status,
             prior_statuses: std::slice::from_ref(&flaky_first_status),
+            result: FlakyResult::Pass,
         };
         let fail_describe = ExecutionDescription::Failure {
             first_status: &fail_status,
@@ -3401,7 +3410,7 @@ mod tests {
             ("pass slow", pass_slow_describe),
             ("leak pass slow", leak_pass_slow_describe),
             ("timeout pass slow", timeout_pass_slow_describe),
-            // Flaky variant.
+            // Flaky variants.
             ("flaky", flaky_describe),
             // First-attempt failure variants.
             ("fail", fail_describe),

--- a/nextest-runner/src/reporter/displayer/progress.rs
+++ b/nextest-runner/src/reporter/displayer/progress.rs
@@ -914,6 +914,7 @@ pub(super) fn progress_bar_msg(
 mod tests {
     use super::*;
     use crate::{
+        config::elements::FlakyResult,
         output_spec::LiveSpec,
         reporter::TestOutputDisplay,
         test_output::{ChildExecutionOutput, ChildOutput, ChildSplitOutput},
@@ -1235,20 +1236,23 @@ mod tests {
                 failure_output: TestOutputDisplay::Never,
                 junit_store_success_output: false,
                 junit_store_failure_output: false,
-                run_statuses: ExecutionStatuses::new(vec![ExecuteStatus {
-                    retry_data: RetryData {
-                        attempt: 1,
-                        total_attempts: 1,
-                    },
-                    output: make_test_output(),
-                    result: ExecutionResultDescription::Pass,
-                    start_time: Local::now().fixed_offset(),
-                    time_taken: Duration::from_secs(1),
-                    is_slow: false,
-                    delay_before_start: Duration::ZERO,
-                    error_summary: None,
-                    output_error_slice: None,
-                }]),
+                run_statuses: ExecutionStatuses::new(
+                    vec![ExecuteStatus {
+                        retry_data: RetryData {
+                            attempt: 1,
+                            total_attempts: 1,
+                        },
+                        output: make_test_output(),
+                        result: ExecutionResultDescription::Pass,
+                        start_time: Local::now().fixed_offset(),
+                        time_taken: Duration::from_secs(1),
+                        is_slow: false,
+                        delay_before_start: Duration::ZERO,
+                        error_summary: None,
+                        output_error_slice: None,
+                    }],
+                    FlakyResult::default(),
+                ),
                 current_stats: finished_stats,
                 running: 2,
             },

--- a/nextest-runner/src/reporter/events.rs
+++ b/nextest-runner/src/reporter/events.rs
@@ -11,7 +11,7 @@ use super::{FinalStatusLevel, StatusLevel, TestOutputDisplay};
 use crate::output_spec::ArbitraryOutputSpec;
 use crate::{
     config::{
-        elements::{LeakTimeoutResult, SlowTimeoutResult},
+        elements::{FlakyResult, LeakTimeoutResult, SlowTimeoutResult},
         scripts::ScriptId,
     },
     errors::{ChildError, ChildFdError, ChildStartError, ErrorList},
@@ -571,7 +571,8 @@ pub struct RunStats {
     /// The number of setup scripts that timed out.
     pub setup_scripts_timed_out: usize,
 
-    /// The number of tests that passed. Includes `passed_slow`, `passed_timed_out`, `flaky` and `leaky`.
+    /// The number of tests that passed. Includes `passed_slow`, `passed_timed_out`, `flaky`, and
+    /// `leaky`.
     pub passed: usize,
 
     /// The number of slow tests that passed.
@@ -597,6 +598,8 @@ pub struct RunStats {
 
     /// The number of tests that otherwise passed, but leaked handles and were
     /// treated as failed as a result.
+    ///
+    /// Included in `failed`.
     pub leaky_failed: usize,
 
     /// The number of tests that encountered an execution failure.
@@ -722,7 +725,14 @@ impl RunStats {
                     self.passed_slow += 1;
                 }
                 if run_statuses.len() > 1 {
-                    self.flaky += 1;
+                    // The test is flaky. How it's counted depends on
+                    // flaky_result — match exhaustively so the compiler
+                    // catches new variants.
+                    match run_statuses.flaky_result() {
+                        FlakyResult::Pass => {
+                            self.flaky += 1;
+                        }
+                    }
                 }
             }
             ExecutionResultDescription::Leak {
@@ -734,7 +744,11 @@ impl RunStats {
                     self.passed_slow += 1;
                 }
                 if run_statuses.len() > 1 {
-                    self.flaky += 1;
+                    match run_statuses.flaky_result() {
+                        FlakyResult::Pass => {
+                            self.flaky += 1;
+                        }
+                    }
                 }
             }
             ExecutionResultDescription::Leak {
@@ -758,7 +772,11 @@ impl RunStats {
                 self.passed += 1;
                 self.passed_timed_out += 1;
                 if run_statuses.len() > 1 {
-                    self.flaky += 1;
+                    match run_statuses.flaky_result() {
+                        FlakyResult::Pass => {
+                            self.flaky += 1;
+                        }
+                    }
                 }
             }
             ExecutionResultDescription::Timeout {
@@ -887,6 +905,10 @@ pub struct ExecutionStatuses<S: OutputSpec> {
     /// This is guaranteed to be non-empty.
     #[cfg_attr(test, strategy(proptest::collection::vec(proptest::arbitrary::any::<ExecuteStatus<S>>(), 1..=3)))]
     statuses: Vec<ExecuteStatus<S>>,
+
+    /// Controls whether a flaky test is treated as a pass or a failure.
+    #[serde(default)]
+    flaky_result: FlakyResult,
 }
 
 impl<'de, S: SerializableOutputSpec> Deserialize<'de> for ExecutionStatuses<S> {
@@ -900,6 +922,8 @@ impl<'de, S: SerializableOutputSpec> Deserialize<'de> for ExecutionStatuses<S> {
         )]
         struct Helper<S: OutputSpec> {
             statuses: Vec<ExecuteStatus<S>>,
+            #[serde(default)]
+            flaky_result: FlakyResult,
         }
 
         let helper = Helper::<S>::deserialize(deserializer)?;
@@ -908,15 +932,24 @@ impl<'de, S: SerializableOutputSpec> Deserialize<'de> for ExecutionStatuses<S> {
         }
         Ok(Self {
             statuses: helper.statuses,
+            flaky_result: helper.flaky_result,
         })
     }
 }
 
 #[expect(clippy::len_without_is_empty)] // RunStatuses is never empty
 impl<S: OutputSpec> ExecutionStatuses<S> {
-    pub(crate) fn new(statuses: Vec<ExecuteStatus<S>>) -> Self {
+    pub(crate) fn new(statuses: Vec<ExecuteStatus<S>>, flaky_result: FlakyResult) -> Self {
         debug_assert!(!statuses.is_empty(), "ExecutionStatuses must be non-empty");
-        Self { statuses }
+        Self {
+            statuses,
+            flaky_result,
+        }
+    }
+
+    /// Returns the configured flaky result for this test.
+    pub fn flaky_result(&self) -> FlakyResult {
+        self.flaky_result
     }
 
     /// Returns the last execution status.
@@ -946,6 +979,7 @@ impl<S: OutputSpec> ExecutionStatuses<S> {
                 ExecutionDescription::Flaky {
                     last_status,
                     prior_statuses: &self.statuses[..self.statuses.len() - 1],
+                    result: self.flaky_result,
                 }
             } else {
                 ExecutionDescription::Success {
@@ -997,6 +1031,9 @@ pub enum ExecutionDescription<'a, S: OutputSpec> {
 
         /// Previous statuses, none of which are successes.
         prior_statuses: &'a [ExecuteStatus<S>],
+
+        /// Controls whether this flaky test is treated as a pass or a failure.
+        result: FlakyResult,
     },
 
     /// The test was run once, or possibly multiple times. All runs failed.
@@ -1041,7 +1078,10 @@ impl<'a, S: OutputSpec> ExecutionDescription<'a, S> {
                 ),
             },
             // A flaky test implies that we print out retry information for it.
-            ExecutionDescription::Flaky { .. } => StatusLevel::Retry,
+            ExecutionDescription::Flaky {
+                result: FlakyResult::Pass,
+                ..
+            } => StatusLevel::Retry,
             ExecutionDescription::Failure { .. } => StatusLevel::Fail,
         }
     }
@@ -1071,9 +1111,37 @@ impl<'a, S: OutputSpec> ExecutionDescription<'a, S> {
                     }
                 }
             }
-            // A flaky test implies that we print out retry information for it.
-            ExecutionDescription::Flaky { .. } => FinalStatusLevel::Flaky,
+            // A flaky test implies that we print out retry information.
+            ExecutionDescription::Flaky {
+                result: FlakyResult::Pass,
+                ..
+            } => FinalStatusLevel::Flaky,
             ExecutionDescription::Failure { .. } => FinalStatusLevel::Fail,
+        }
+    }
+
+    /// Returns whether this test's output should be treated as success output
+    /// for display and storage purposes.
+    ///
+    /// For flaky tests, the last attempt succeeded, so its output is success
+    /// output: it contains no panics or errors, and is generally not
+    /// interesting. The failure information comes from the status line and from
+    /// prior retry attempts' output (shown via `TestAttemptFailedWillRetry`
+    /// events, controlled by `failure-output`).
+    ///
+    /// This means:
+    /// - The _visibility_ is controlled by `success-output`.
+    /// - The _styling_ is pass/green headers, no error extraction.
+    /// - _JUnit storage_ is controlled by `store-success-output` (default:
+    ///   `false`).
+    pub fn is_success_for_output(&self) -> bool {
+        match self {
+            ExecutionDescription::Success { .. } => true,
+            // All flaky tests have a successful last attempt — the output
+            // from that attempt is success output regardless of the overall
+            // test outcome.
+            ExecutionDescription::Flaky { .. } => true,
+            ExecutionDescription::Failure { .. } => false,
         }
     }
 
@@ -2482,6 +2550,127 @@ mod tests {
             .summarize_final(),
             FinalRunStats::NoTestsRun,
             "setup scripts passed => success, but no tests run"
+        );
+    }
+
+    /// Helper to build a minimal `ExecuteStatus<LiveSpec>` for tests.
+    fn make_execute_status(
+        result: ExecutionResultDescription,
+        attempt: u32,
+        total_attempts: u32,
+    ) -> ExecuteStatus<LiveSpec> {
+        ExecuteStatus {
+            retry_data: RetryData {
+                attempt,
+                total_attempts,
+            },
+            output: ChildExecutionOutputDescription::Output {
+                result: Some(result.clone()),
+                output: ChildOutputDescription::Split {
+                    stdout: None,
+                    stderr: None,
+                },
+                errors: None,
+            },
+            result,
+            start_time: chrono::Utc::now().into(),
+            time_taken: Duration::from_millis(100),
+            is_slow: false,
+            delay_before_start: Duration::ZERO,
+            error_summary: None,
+            output_error_slice: None,
+        }
+    }
+
+    #[test]
+    fn is_success_for_output_by_variant() {
+        // Success: single passing run → true.
+        let pass_status = make_execute_status(ExecutionResultDescription::Pass, 1, 1);
+        let success_statuses = ExecutionStatuses::new(vec![pass_status], FlakyResult::Pass);
+        let describe = success_statuses.describe();
+        assert!(
+            matches!(describe, ExecutionDescription::Success { .. }),
+            "single pass is Success"
+        );
+        assert!(
+            describe.is_success_for_output(),
+            "Success: output is success output"
+        );
+
+        // Flaky pass: fail then pass → true.
+        let fail_status = make_execute_status(
+            ExecutionResultDescription::Fail {
+                failure: FailureDescription::ExitCode { code: 1 },
+                leaked: false,
+            },
+            1,
+            2,
+        );
+        let pass_status = make_execute_status(ExecutionResultDescription::Pass, 2, 2);
+        let flaky_pass_statuses =
+            ExecutionStatuses::new(vec![fail_status, pass_status], FlakyResult::Pass);
+        let describe = flaky_pass_statuses.describe();
+        assert!(
+            matches!(
+                describe,
+                ExecutionDescription::Flaky {
+                    result: FlakyResult::Pass,
+                    ..
+                }
+            ),
+            "fail then pass with FlakyResult::Pass is Flaky Pass"
+        );
+        assert!(
+            describe.is_success_for_output(),
+            "Flaky pass: output is success output"
+        );
+
+        // Failure: single fail → false.
+        let fail_status = make_execute_status(
+            ExecutionResultDescription::Fail {
+                failure: FailureDescription::ExitCode { code: 1 },
+                leaked: false,
+            },
+            1,
+            1,
+        );
+        let failure_statuses = ExecutionStatuses::new(vec![fail_status], FlakyResult::Pass);
+        let describe = failure_statuses.describe();
+        assert!(
+            matches!(describe, ExecutionDescription::Failure { .. }),
+            "single fail is Failure"
+        );
+        assert!(
+            !describe.is_success_for_output(),
+            "Failure: output is not success output"
+        );
+
+        // Failure with retries: all fail → false.
+        let fail1 = make_execute_status(
+            ExecutionResultDescription::Fail {
+                failure: FailureDescription::ExitCode { code: 1 },
+                leaked: false,
+            },
+            1,
+            2,
+        );
+        let fail2 = make_execute_status(
+            ExecutionResultDescription::Fail {
+                failure: FailureDescription::ExitCode { code: 1 },
+                leaked: false,
+            },
+            2,
+            2,
+        );
+        let failure_retry_statuses = ExecutionStatuses::new(vec![fail1, fail2], FlakyResult::Pass);
+        let describe = failure_retry_statuses.describe();
+        assert!(
+            matches!(describe, ExecutionDescription::Failure { .. }),
+            "all-fail with retries is Failure"
+        );
+        assert!(
+            !describe.is_success_for_output(),
+            "Failure with retries: output is not success output"
         );
     }
 

--- a/nextest-runner/src/reporter/structured/libtest.rs
+++ b/nextest-runner/src/reporter/structured/libtest.rs
@@ -23,13 +23,13 @@
 //! using before
 
 use crate::{
-    config::elements::{LeakTimeoutResult, SlowTimeoutResult},
+    config::elements::{FlakyResult, SlowTimeoutResult},
     errors::{DisplayErrorChain, FormatVersionError, FormatVersionErrorInner, WriteEventError},
     list::{RustTestSuite, TestList},
-    output_spec::LiveSpec,
+    output_spec::{LiveSpec, OutputSpec},
     reporter::events::{
-        ChildExecutionOutputDescription, ChildOutputDescription, ExecutionResultDescription,
-        StressIndex, TestEvent, TestEventKind,
+        ChildExecutionOutputDescription, ChildOutputDescription, ExecutionDescription,
+        ExecutionResultDescription, ExecutionStatuses, StressIndex, TestEvent, TestEventKind,
     },
     test_output::ChildSingleOutput,
 };
@@ -273,23 +273,7 @@ impl<'cfg> LibtestReporter<'cfg> {
 
                 (
                     KIND_TEST,
-                    match &run_statuses.last_status().result {
-                        ExecutionResultDescription::Pass
-                        | ExecutionResultDescription::Timeout {
-                            result: SlowTimeoutResult::Pass,
-                        }
-                        | ExecutionResultDescription::Leak {
-                            result: LeakTimeoutResult::Pass,
-                        } => EVENT_OK,
-                        ExecutionResultDescription::Leak {
-                            result: LeakTimeoutResult::Fail,
-                        }
-                        | ExecutionResultDescription::Fail { .. }
-                        | ExecutionResultDescription::ExecFail
-                        | ExecutionResultDescription::Timeout {
-                            result: SlowTimeoutResult::Fail,
-                        } => EVENT_FAILED,
-                    },
+                    event_for_finished_test(run_statuses),
                     stress_index,
                     test_instance,
                 )
@@ -580,6 +564,20 @@ impl<'cfg> LibtestReporter<'cfg> {
     }
 }
 
+/// Returns the libtest JSON event string for a finished test.
+///
+/// Uses `ExecutionDescription` to determine the overall outcome.
+fn event_for_finished_test<S: OutputSpec>(run_statuses: &ExecutionStatuses<S>) -> &'static str {
+    match run_statuses.describe() {
+        ExecutionDescription::Success { .. }
+        | ExecutionDescription::Flaky {
+            result: FlakyResult::Pass,
+            ..
+        } => EVENT_OK,
+        ExecutionDescription::Failure { .. } => EVENT_FAILED,
+    }
+}
+
 /// Unfortunately, to replicate the libtest json output, we need to do our own
 /// filtering of the output to strip out the data emitted by libtest in the
 /// human format.
@@ -769,17 +767,27 @@ impl std::fmt::Display for EscapedString<'_> {
 #[cfg(test)]
 mod test {
     use crate::{
+        config::elements::{FlakyResult, LeakTimeoutResult, SlowTimeoutResult},
         errors::ChildStartError,
+        output_spec::LiveSpec,
         reporter::{
-            events::ChildExecutionOutputDescription,
-            structured::libtest::strip_human_output_from_failed_test,
+            events::{
+                ChildExecutionOutputDescription, ExecuteStatus, ExecutionResult,
+                ExecutionResultDescription, ExecutionStatuses, FailureDescription, FailureStatus,
+                RetryData,
+            },
+            structured::libtest::{
+                EVENT_FAILED, EVENT_OK, event_for_finished_test,
+                strip_human_output_from_failed_test,
+            },
         },
         test_output::{ChildExecutionOutput, ChildOutput, ChildSplitOutput},
     };
-    use bytes::BytesMut;
+    use bytes::{Bytes, BytesMut};
+    use chrono::Local;
     use color_eyre::eyre::eyre;
     use nextest_metadata::TestCaseName;
-    use std::{io, sync::Arc};
+    use std::{io, sync::Arc, time::Duration};
 
     /// Validates that the human output portion from a failed test is stripped
     /// out when writing a JSON string, as it is not part of the output when
@@ -914,5 +922,154 @@ note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose bac
         .unwrap();
 
         insta::assert_snapshot!(std::str::from_utf8(&actual).unwrap());
+    }
+
+    fn make_test_output(result: ExecutionResult) -> ChildExecutionOutputDescription<LiveSpec> {
+        ChildExecutionOutput::Output {
+            result: Some(result),
+            output: ChildOutput::Split(ChildSplitOutput {
+                stdout: Some(Bytes::new().into()),
+                stderr: Some(Bytes::new().into()),
+            }),
+            errors: None,
+        }
+        .into()
+    }
+
+    fn make_passing_status(attempt: u32, total_attempts: u32) -> ExecuteStatus<LiveSpec> {
+        ExecuteStatus {
+            retry_data: RetryData {
+                attempt,
+                total_attempts,
+            },
+            output: make_test_output(ExecutionResult::Pass),
+            result: ExecutionResultDescription::Pass,
+            start_time: Local::now().fixed_offset(),
+            time_taken: Duration::from_secs(1),
+            is_slow: false,
+            delay_before_start: Duration::ZERO,
+            error_summary: None,
+            output_error_slice: None,
+        }
+    }
+
+    fn make_failing_status(attempt: u32, total_attempts: u32) -> ExecuteStatus<LiveSpec> {
+        ExecuteStatus {
+            retry_data: RetryData {
+                attempt,
+                total_attempts,
+            },
+            output: make_test_output(ExecutionResult::Fail {
+                failure_status: FailureStatus::ExitCode(1),
+                leaked: false,
+            }),
+            result: ExecutionResultDescription::Fail {
+                failure: FailureDescription::ExitCode { code: 1 },
+                leaked: false,
+            },
+            start_time: Local::now().fixed_offset(),
+            time_taken: Duration::from_secs(1),
+            is_slow: false,
+            delay_before_start: Duration::ZERO,
+            error_summary: None,
+            output_error_slice: None,
+        }
+    }
+
+    #[test]
+    fn event_for_finished_test_variants() {
+        // Single pass.
+        let statuses =
+            ExecutionStatuses::new(vec![make_passing_status(1, 1)], FlakyResult::default());
+        assert_eq!(event_for_finished_test(&statuses), EVENT_OK, "single pass");
+
+        // Single failure.
+        let statuses =
+            ExecutionStatuses::new(vec![make_failing_status(1, 1)], FlakyResult::default());
+        assert_eq!(
+            event_for_finished_test(&statuses),
+            EVENT_FAILED,
+            "single failure"
+        );
+
+        // Flaky pass: fail then pass, default result (pass).
+        let statuses = ExecutionStatuses::new(
+            vec![make_failing_status(1, 2), make_passing_status(2, 2)],
+            FlakyResult::Pass,
+        );
+        assert_eq!(
+            event_for_finished_test(&statuses),
+            EVENT_OK,
+            "flaky with result = pass"
+        );
+
+        // All retries failed.
+        let statuses = ExecutionStatuses::new(
+            vec![make_failing_status(1, 2), make_failing_status(2, 2)],
+            FlakyResult::Pass,
+        );
+        assert_eq!(
+            event_for_finished_test(&statuses),
+            EVENT_FAILED,
+            "all retries failed"
+        );
+
+        // Leak { Pass } → success.
+        let mut leak_pass = make_passing_status(1, 1);
+        leak_pass.result = ExecutionResultDescription::Leak {
+            result: LeakTimeoutResult::Pass,
+        };
+        let statuses = ExecutionStatuses::new(vec![leak_pass], FlakyResult::default());
+        assert_eq!(
+            event_for_finished_test(&statuses),
+            EVENT_OK,
+            "leak with result = pass"
+        );
+
+        // Leak { Fail } → failure.
+        let mut leak_fail = make_passing_status(1, 1);
+        leak_fail.result = ExecutionResultDescription::Leak {
+            result: LeakTimeoutResult::Fail,
+        };
+        let statuses = ExecutionStatuses::new(vec![leak_fail], FlakyResult::default());
+        assert_eq!(
+            event_for_finished_test(&statuses),
+            EVENT_FAILED,
+            "leak with result = fail"
+        );
+
+        // Timeout { Pass } → success.
+        let mut timeout_pass = make_passing_status(1, 1);
+        timeout_pass.result = ExecutionResultDescription::Timeout {
+            result: SlowTimeoutResult::Pass,
+        };
+        let statuses = ExecutionStatuses::new(vec![timeout_pass], FlakyResult::default());
+        assert_eq!(
+            event_for_finished_test(&statuses),
+            EVENT_OK,
+            "timeout with result = pass"
+        );
+
+        // Timeout { Fail } → failure.
+        let mut timeout_fail = make_passing_status(1, 1);
+        timeout_fail.result = ExecutionResultDescription::Timeout {
+            result: SlowTimeoutResult::Fail,
+        };
+        let statuses = ExecutionStatuses::new(vec![timeout_fail], FlakyResult::default());
+        assert_eq!(
+            event_for_finished_test(&statuses),
+            EVENT_FAILED,
+            "timeout with result = fail"
+        );
+
+        // ExecFail → failure.
+        let mut exec_fail = make_passing_status(1, 1);
+        exec_fail.result = ExecutionResultDescription::ExecFail;
+        let statuses = ExecutionStatuses::new(vec![exec_fail], FlakyResult::default());
+        assert_eq!(
+            event_for_finished_test(&statuses),
+            EVENT_FAILED,
+            "exec fail"
+        );
     }
 }

--- a/nextest-runner/src/runner/dispatcher.rs
+++ b/nextest-runner/src/runner/dispatcher.rs
@@ -10,7 +10,7 @@
 use super::{RunUnitRequest, RunnerTaskState, ShutdownRequest};
 use crate::{
     config::{
-        elements::{MaxFail, TerminateMode},
+        elements::{FlakyResult, MaxFail, TerminateMode},
         scripts::{ScriptId, SetupScriptConfig},
     },
     input::{InputEvent, InputHandler},
@@ -659,6 +659,7 @@ where
                 test_instance,
                 command_line,
                 req_rx_tx,
+                flaky_result,
             }) => {
                 if self.run_stats.cancel_reason.is_some() {
                     // The run has been cancelled: don't start any new units.
@@ -674,7 +675,7 @@ where
                         return HandleEventResponse::None;
                     }
                 }
-                self.new_test(test_instance, req_tx);
+                self.new_test(test_instance, req_tx, flaky_result);
                 self.callback_none_response(TestEventKind::TestStarted {
                     stress_index,
                     test_instance: test_instance.id(),
@@ -888,6 +889,7 @@ where
         &mut self,
         instance: TestInstance<'a>,
         req_tx: UnboundedSender<RunUnitRequest<'a>>,
+        flaky_result: FlakyResult,
     ) {
         // Track this test as seen for rerun tracking.
         self.rerun_cx.mark_seen(instance.id());
@@ -898,6 +900,7 @@ where
                 instance,
                 past_attempts: Vec::new(),
                 req_tx,
+                flaky_result,
             },
         );
         if let Some(prev) = prev {
@@ -1389,6 +1392,7 @@ struct ContextTestInstance<'a> {
     instance: TestInstance<'a>,
     past_attempts: Vec<ExecuteStatus<LiveSpec>>,
     req_tx: UnboundedSender<RunUnitRequest<'a>>,
+    flaky_result: FlakyResult,
 }
 
 impl ContextTestInstance<'_> {
@@ -1399,7 +1403,7 @@ impl ContextTestInstance<'_> {
     fn finish(self, last_run_status: ExecuteStatus<LiveSpec>) -> ExecutionStatuses<LiveSpec> {
         let mut attempts = self.past_attempts;
         attempts.push(last_run_status);
-        ExecutionStatuses::new(attempts)
+        ExecutionStatuses::new(attempts, self.flaky_result)
     }
 }
 

--- a/nextest-runner/src/runner/executor.rs
+++ b/nextest-runner/src/runner/executor.rs
@@ -205,6 +205,7 @@ impl<'a> ExecutorContext<'a> {
         let settings = Arc::new(test.settings);
 
         let retry_policy = self.force_retries.unwrap_or_else(|| settings.retries());
+        let flaky_result = settings.flaky_result();
         let total_attempts = retry_policy.count() + 1;
         let mut backoff_iter = BackoffIter::new(retry_policy);
 
@@ -239,6 +240,7 @@ impl<'a> ExecutorContext<'a> {
             test_instance: test.instance,
             command_line: command_line.clone(),
             req_rx_tx,
+            flaky_result,
         });
         let mut req_rx = match req_rx_rx.await {
             Ok(rx) => rx,

--- a/nextest-runner/src/runner/internal_events.rs
+++ b/nextest-runner/src/runner/internal_events.rs
@@ -9,7 +9,10 @@
 
 use super::{SetupScriptPacket, TestPacket};
 use crate::{
-    config::scripts::{ScriptId, SetupScriptConfig},
+    config::{
+        elements::FlakyResult,
+        scripts::{ScriptId, SetupScriptConfig},
+    },
     errors::DisplayErrorChain,
     list::TestInstance,
     output_spec::LiveSpec,
@@ -84,6 +87,8 @@ pub(super) enum ExecutorEvent<'a> {
         // Why do we use unbounded channels? Mostly to make life simpler --
         // these are low-traffic channels that we don't expect to be backed up.
         req_rx_tx: oneshot::Sender<UnboundedReceiver<RunUnitRequest<'a>>>,
+        // The configured result for flaky tests.
+        flaky_result: FlakyResult,
     },
     Slow {
         stress_index: Option<StressIndex>,


### PR DESCRIPTION
We're going to introduce `FlakyResult::Fail` in an upcoming PR. Prepare for this by threading it throughout the nextest codebase.

We split `RetryPolicy` into two components since we want to allow overriding the retry configuration and flaky policy separately.