### PR TITLE
[nextest-runner] add the ability to fail tests if flaky

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2918,9 +2918,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-junit"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee9342d671fae8d66b3ae9fd7a9714dfd089c04d2a8b1ec0436ef77aee15e5f"
+checksum = "e3e64c58c4c88fc1045e8fe98a1b7cec3643187e3dd678f9bbcdd8f12a6933d6"
 dependencies = [
  "chrono",
  "indexmap",
@@ -2933,9 +2933,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.3"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a232e7487fc2ef313d96dde7948e7a3c05101870d8985e4fd8d26aedd27b89"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ petgraph = "0.8.3"
 pin-project-lite = "0.2.17"
 pretty_assertions = "1.4.1"
 proptest = "1.10.0"
-quick-junit = "0.5.2"
+quick-junit = "0.6.0"
 rand = "0.9.2"
 recursion = "0.5.4"
 regex = "1.12.3"
@@ -188,4 +188,4 @@ nextest-workspace-hack = { path = "workspace-hack" }
 # target-spec = { path = "../guppy/target-spec" }
 # target-spec-miette = { path = "../guppy/target-spec-miette" }
 # tokio = { path = "../../tokio/tokio" }
-# quick-junit = { path = "../quick-junit" }
+# quick-junit = { path = "../quick-junit/crates/quick-junit" }

--- a/cargo-nextest/src/dispatch/core/run.rs
+++ b/cargo-nextest/src/dispatch/core/run.rs
@@ -7,8 +7,8 @@ use super::{
     base::BaseApp,
     filter::TestBuildFilter,
     value_enums::{
-        FinalStatusLevelOpt, MessageFormat, NoTestsBehaviorOpt, ShowProgressOpt, StatusLevelOpt,
-        TestOutputDisplayOpt,
+        FinalStatusLevelOpt, FlakyResultOpt, MessageFormat, NoTestsBehaviorOpt, ShowProgressOpt,
+        StatusLevelOpt, TestOutputDisplayOpt,
     },
 };
 use crate::{
@@ -153,6 +153,13 @@ pub struct TestRunnerOpts {
     #[arg(long, env = "NEXTEST_RETRIES", value_name = "N")]
     retries: Option<u32>,
 
+    /// Flaky test result behavior [default: from profile].
+    ///
+    /// Controls whether tests that pass on retry are treated as passing or
+    /// failing.
+    #[arg(long, env = "NEXTEST_FLAKY_RESULT", value_name = "RESULT", value_enum)]
+    flaky_result: Option<FlakyResultOpt>,
+
     /// Cancel test run on the first failure.
     #[arg(
         long,
@@ -220,6 +227,9 @@ impl TestRunnerOpts {
         if self.retries.is_some() && self.no_run {
             warn!("ignoring --retries because --no-run is specified");
         }
+        if self.flaky_result.is_some() && self.no_run {
+            warn!("ignoring --flaky-result because --no-run is specified");
+        }
         if self.no_tests.is_some() && self.no_run {
             warn!("ignoring --no-tests because --no-run is specified");
         }
@@ -234,6 +244,9 @@ impl TestRunnerOpts {
         builder.set_capture_strategy(cap_strat);
         if let Some(retries) = self.retries {
             builder.set_retries(RetryPolicy::new_without_delay(retries));
+        }
+        if let Some(flaky_result) = self.flaky_result {
+            builder.set_flaky_result(flaky_result.into());
         }
 
         if let Some(max_fail) = self.max_fail {

--- a/cargo-nextest/src/dispatch/core/value_enums.rs
+++ b/cargo-nextest/src/dispatch/core/value_enums.rs
@@ -247,6 +247,25 @@ impl From<ShowProgressOpt> for ShowProgress {
     }
 }
 
+/// Flaky test result behavior.
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub(crate) enum FlakyResultOpt {
+    /// Flaky tests are treated as passing.
+    Pass,
+
+    /// Flaky tests are treated as failing.
+    Fail,
+}
+
+impl From<FlakyResultOpt> for nextest_runner::config::elements::FlakyResult {
+    fn from(opt: FlakyResultOpt) -> Self {
+        match opt {
+            FlakyResultOpt::Pass => Self::Pass,
+            FlakyResultOpt::Fail => Self::Fail,
+        }
+    }
+}
+
 /// Ignore overrides options.
 #[derive(Clone, Copy, Debug, ValueEnum)]
 pub(crate) enum IgnoreOverridesOpt {

--- a/fixture-data/src/models.rs
+++ b/fixture-data/src/models.rs
@@ -23,6 +23,7 @@ pub enum CheckResult {
     Leak,
     LeakFail,
     Fail,
+    FlakyFail,
     FailLeak,
     Abort,
     Timeout,
@@ -39,6 +40,7 @@ impl CheckResult {
             CheckResult::Pass | CheckResult::Leak => false,
             CheckResult::LeakFail
             | CheckResult::Fail
+            | CheckResult::FlakyFail
             | CheckResult::FailLeak
             | CheckResult::Abort
             | CheckResult::Timeout => true,
@@ -100,6 +102,15 @@ bitflags::bitflags! {
         /// Allow skipped test names to appear in output (e.g., for replay which shows SKIP lines).
         /// Without this flag, verification fails if any skipped test name appears in the output.
         const ALLOW_SKIPPED_NAMES_IN_OUTPUT = 0x40000;
+        /// Run with the with-retries-flaky-fail profile. Flaky tests with
+        /// `flaky-result = "fail"` should count as failures.
+        const WITH_RETRIES_FLAKY_FAIL = 0x80000;
+        /// Run with `--flaky-result fail` CLI flag. All flaky tests should
+        /// count as failures, regardless of per-test config.
+        const WITH_CLI_FLAKY_RESULT_FAIL = 0x100000;
+        /// Run with `--flaky-result pass` CLI flag. No flaky tests should
+        /// count as failures, even if config has `flaky-result = "fail"`.
+        const WITH_CLI_FLAKY_RESULT_PASS = 0x200000;
     }
 }
 
@@ -404,6 +415,22 @@ impl TestCaseFixture {
             TestCaseFixtureStatus::LeakFail => CheckResult::LeakFail,
             TestCaseFixtureStatus::Fail => CheckResult::Fail,
             TestCaseFixtureStatus::Flaky { .. } => {
+                // CLI --flaky-result overrides all config-level settings.
+                if properties.contains(RunProperties::WITH_CLI_FLAKY_RESULT_FAIL) {
+                    return CheckResult::FlakyFail;
+                }
+                if properties.contains(RunProperties::WITH_CLI_FLAKY_RESULT_PASS) {
+                    return CheckResult::Pass;
+                }
+                // With retries and flaky-result = "fail", flaky tests that eventually
+                // pass are still counted as failures.
+                if properties.contains(RunProperties::WITH_RETRIES_FLAKY_FAIL) {
+                    if self.has_property(TestCaseFixtureProperties::FLAKY_RESULT_FAIL) {
+                        return CheckResult::FlakyFail;
+                    } else {
+                        return CheckResult::Pass;
+                    }
+                }
                 // With retries, flaky tests eventually pass. (Retries are
                 // configured in a way which ensures that all tests eventually
                 // pass.)
@@ -454,9 +481,13 @@ impl TestCaseFixture {
     /// Computes the expected rerun behavior for a test case based on its
     /// fixture status, the check result, and the run properties.
     fn expected_reruns(&self, result: CheckResult, properties: RunProperties) -> ExpectedReruns {
+        // Flaky tests that eventually pass have a known rerun count.
+        // This applies both to flaky-pass (CheckResult::Pass) and
+        // flaky-fail (CheckResult::FlakyFail) — either way, the test ran
+        // pass_attempt - 1 failing attempts before the passing one.
         if let TestCaseFixtureStatus::Flaky { pass_attempt }
         | TestCaseFixtureStatus::IgnoredFlaky { pass_attempt } = self.status
-            && result == CheckResult::Pass
+            && (result == CheckResult::Pass || result == CheckResult::FlakyFail)
         {
             debug_assert!(
                 pass_attempt >= 2,
@@ -468,7 +499,13 @@ impl TestCaseFixture {
         // Failing tests with retries configured will have reruns, but the exact
         // count depends on per-test profile overrides which the fixture data
         // model doesn't track.
-        if properties.contains(RunProperties::WITH_RETRIES) && result.is_failure() {
+        let has_retries = properties.intersects(
+            RunProperties::WITH_RETRIES
+                | RunProperties::WITH_RETRIES_FLAKY_FAIL
+                | RunProperties::WITH_CLI_FLAKY_RESULT_FAIL
+                | RunProperties::WITH_CLI_FLAKY_RESULT_PASS,
+        );
+        if has_retries && result.is_failure() {
             return ExpectedReruns::SomeReruns;
         }
 
@@ -561,5 +598,7 @@ bitflags::bitflags! {
         const FLAKY_SLOW_TIMEOUT_SUBSTRING = 0x800;
         /// Exactly test_slow_timeout (not test_slow_timeout_2 or test_slow_timeout_subprocess).
         const EXACT_TEST_SLOW_TIMEOUT = 0x1000;
+        /// Flaky test configured with `flaky-result = "fail"`.
+        const FLAKY_RESULT_FAIL = 0x2000;
     }
 }

--- a/fixture-data/src/nextest_tests.rs
+++ b/fixture-data/src/nextest_tests.rs
@@ -32,7 +32,8 @@ pub static EXPECTED_TEST_SUITES: LazyLock<IdOrdMap<TestSuiteFixture>> = LazyLock
                     "test_flaky_mod_4",
                     TestCaseFixtureStatus::Flaky { pass_attempt: 4 },
                 )
-                .with_property(TestCaseFixtureProperties::NOT_IN_DEFAULT_SET),
+                .with_property(TestCaseFixtureProperties::NOT_IN_DEFAULT_SET)
+                .with_property(TestCaseFixtureProperties::FLAKY_RESULT_FAIL),
                 TestCaseFixture::new(
                     "test_flaky_mod_6",
                     TestCaseFixtureStatus::Flaky { pass_attempt: 6 },

--- a/fixtures/nextest-tests/.config/nextest.toml
+++ b/fixtures/nextest-tests/.config/nextest.toml
@@ -79,6 +79,21 @@ filter = """
 retries = 4
 test-group = 'flaky'
 
+[profile.with-retries-flaky-fail]
+retries = 2
+
+# test_flaky_mod_4 passes on attempt 4 of 5, but flaky-result = "fail" means it
+# counts as a failure despite eventually passing.
+[[profile.with-retries-flaky-fail.overrides]]
+filter = "test(=test_flaky_mod_4)"
+retries = { backoff = "fixed", count = 4 }
+flaky-result = "fail"
+
+# test_flaky_mod_6 passes on attempt 6 of 6, with default result (= "pass").
+[[profile.with-retries-flaky-fail.overrides]]
+filter = "test(=test_flaky_mod_6)"
+retries = 5
+
 [profile.with-termination]
 slow-timeout = { period = "1s", terminate-after = 2 }
 

--- a/integration-tests/tests/integration/fixtures.rs
+++ b/integration-tests/tests/integration/fixtures.rs
@@ -19,7 +19,7 @@ use nextest_metadata::{
     BinaryListSummary, BuildPlatform, RustBinaryId, RustTestSuiteStatusSummary, TestCaseName,
     TestListSummary,
 };
-use quick_junit::Report;
+use quick_junit::{FlakyOrRerun, Report};
 use regex::Regex;
 use std::{collections::BTreeSet, process::Command, sync::LazyLock};
 
@@ -410,7 +410,7 @@ impl ExpectedSummary {
                 self.fail_count += 1;
                 self.leak_fail_count += 1;
             }
-            CheckResult::Fail => {
+            CheckResult::Fail | CheckResult::FlakyFail => {
                 self.fail_count += 1;
             }
             CheckResult::FailLeak => {
@@ -533,6 +533,12 @@ static TIMEOUT_RE: LazyLock<Regex> = LazyLock::new(|| {
 static TIMEOUT_PASS_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^\s*(?:TRY (\d+) )?(?:TIMEOUT-PASS|TMPASS|SLOW\+TMPASS) \[[^\]]+\] \([^\)]+\) +(.+?) +(.+)").unwrap()
 });
+// FLKY-FL is shown for tests that eventually passed but have flaky-result = "fail".
+// Format: "FLKY-FL 4/5 [duration] (count/total) binary_id test_name"
+// Must be checked before FLAKY_RE since both start with "FL".
+static FLAKY_FAIL_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^\s*FLKY-FL (\d+)/(\d+) \[[^\]]+\] \([^\)]+\) +(.+?) +(.+)").unwrap()
+});
 // FLAKY is shown in the summary section for tests that eventually passed.
 // Format: "FLAKY 4/5 [duration] (count/total) binary_id test_name"
 static FLAKY_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -540,7 +546,10 @@ static FLAKY_RE: LazyLock<Regex> = LazyLock::new(|| {
 });
 static SUMMARY_RE: LazyLock<Regex> = LazyLock::new(|| {
     // Note: "failed" can also be "timed out" for timeout failures.
-    Regex::new(r"Summary \[.*\] +(\d+) (?:tests?|benchmarks?) run: (\d+) passed(?: \((\d+) leaky\))?,?(?: (\d+) (?:failed|timed out)(?: \((\d+) due to being leaky\))?,?)? (\d+) skipped").unwrap()
+    // The "passed" parenthetical may contain "N flaky" and/or "N leaky"
+    // (e.g., "22 passed (1 flaky, 1 leaky)"). We capture only the leaky
+    // count; flaky count is not tracked in ExpectedSummary.
+    Regex::new(r"Summary \[.*\] +(\d+) (?:tests?|benchmarks?) run: (\d+) passed(?: \((?:\d+ flaky(?:, )?)?(?:(\d+) leaky)?\))?,?(?: (\d+) (?:failed|timed out)(?: \((\d+) due to being leaky\))?,?)? (\d+) skipped").unwrap()
 });
 
 impl ActualTestResults {
@@ -581,9 +590,91 @@ impl ActualTestResults {
             }
         }
 
+        /// Handle a FLKY-FL line. These appear both during the run and in the
+        /// post-summary footer. They override the final PASS attempt with
+        /// FlakyFail.
+        fn handle_flaky_fail(tests: &mut IdOrdMap<ActualOutcome>, caps: &regex::Captures) {
+            // Groups: 1=pass_attempt, 2=total_attempts, 3=binary_id, 4=test_name
+            let test_name = TestCaseName::new(&caps[4]);
+            let id = TestInstanceId::new(&caps[3], &test_name);
+            let attempt_record = TestAttempt {
+                attempt: caps[1].parse().expect("parsed attempt number"),
+                result: CheckResult::FlakyFail,
+            };
+
+            match tests.entry(&id) {
+                iddqd::id_ord_map::Entry::Occupied(mut entry) => {
+                    // FLKY-FL appears after the individual attempts,
+                    // including a TRY N PASS for the passing attempt.
+                    // Replace that final PASS with FlakyFail to reflect
+                    // the overall result.
+                    let attempts = &mut entry.get_mut().attempts;
+                    if let Some(last) = attempts.last_mut() {
+                        last.result = CheckResult::FlakyFail;
+                    } else {
+                        attempts.push(attempt_record);
+                    }
+                }
+                iddqd::id_ord_map::Entry::Vacant(entry) => {
+                    entry.insert(ActualOutcome {
+                        id,
+                        attempts: vec![attempt_record],
+                    });
+                }
+            }
+        }
+
+        /// Handle a FLAKY line. These appear in the post-summary footer for
+        /// tests that eventually passed. They confirm the final PASS result
+        /// (no-op if already recorded).
+        fn handle_flaky_pass(tests: &mut IdOrdMap<ActualOutcome>, caps: &regex::Captures) {
+            // Groups: 1=pass_attempt, 2=total_attempts, 3=binary_id, 4=test_name
+            let test_name = TestCaseName::new(&caps[4]);
+            let id = TestInstanceId::new(&caps[3], &test_name);
+            let attempt_record = TestAttempt {
+                attempt: caps[1].parse().expect("parsed attempt number"),
+                result: CheckResult::Pass,
+            };
+
+            match tests.entry(&id) {
+                iddqd::id_ord_map::Entry::Occupied(mut entry) => {
+                    // FLAKY line appears after individual attempts, so it may
+                    // duplicate the final PASS. Only add if not already a PASS.
+                    let attempts = &mut entry.get_mut().attempts;
+                    if attempts.last().map(|a| a.result) != Some(CheckResult::Pass) {
+                        attempts.push(attempt_record);
+                    }
+                }
+                iddqd::id_ord_map::Entry::Vacant(entry) => {
+                    entry.insert(ActualOutcome {
+                        id,
+                        attempts: vec![attempt_record],
+                    });
+                }
+            }
+        }
+
         // Parse each line for test results. Check more specific patterns first
         // (e.g., "FAIL + LEAK" before "FAIL" or "LEAK").
+        //
+        // After the summary line, nextest repeats failure and flaky status
+        // lines. We must continue parsing past the summary to pick up FLKY-FL
+        // and FLAKY lines (which update the final result for flaky tests), but
+        // we skip the duplicate TRY/status lines that would inflate attempt
+        // counts.
+        let mut past_summary = false;
         for line in output.lines() {
+            if past_summary {
+                // After the summary, only parse FLKY-FL and FLAKY lines.
+                // Other status lines are duplicates of earlier output.
+                if let Some(caps) = FLAKY_FAIL_RE.captures(line) {
+                    handle_flaky_fail(&mut tests, &caps);
+                } else if let Some(caps) = FLAKY_RE.captures(line) {
+                    handle_flaky_pass(&mut tests, &caps);
+                }
+                continue;
+            }
+
             // Track all attempts for each test to analyze retry behavior.
             if let Some(caps) = FAIL_LEAK_RE.captures(line) {
                 add_attempt(&mut tests, &caps, CheckResult::FailLeak);
@@ -603,34 +694,6 @@ impl ActualTestResults {
                 add_attempt(&mut tests, &caps, CheckResult::Fail);
             } else if let Some(caps) = PASS_RE.captures(line) {
                 add_attempt(&mut tests, &caps, CheckResult::Pass);
-            } else if let Some(caps) = FLAKY_RE.captures(line) {
-                // FLAKY appears in summary section for tests that eventually passed.
-                // It's in a different format: "FLAKY 4/5 [duration] (count/total) binary_id test_name"
-                // Groups: 1=pass_attempt, 2=total_attempts, 3=binary_id, 4=test_name
-                // We record this as a PASS since the test eventually passed.
-                let test_name = TestCaseName::new(&caps[4]);
-                let id = TestInstanceId::new(&caps[3], &test_name);
-                let attempt_record = TestAttempt {
-                    attempt: caps[1].parse().expect("parsed attempt number"),
-                    result: CheckResult::Pass,
-                };
-
-                match tests.entry(&id) {
-                    iddqd::id_ord_map::Entry::Occupied(mut entry) => {
-                        // FLAKY line appears after individual attempts, so it may
-                        // duplicate the final PASS. Only add if not already a PASS.
-                        let attempts = &mut entry.get_mut().attempts;
-                        if attempts.last().map(|a| a.result) != Some(CheckResult::Pass) {
-                            attempts.push(attempt_record);
-                        }
-                    }
-                    iddqd::id_ord_map::Entry::Vacant(entry) => {
-                        entry.insert(ActualOutcome {
-                            id,
-                            attempts: vec![attempt_record],
-                        });
-                    }
-                }
             } else if let Some(caps) = SUMMARY_RE.captures(line) {
                 let run_count = caps[1].parse().unwrap();
                 let pass_count = caps[2].parse().unwrap();
@@ -657,9 +720,7 @@ impl ActualTestResults {
                     skip_count,
                 });
 
-                // Failures are shown after the summary line, as part of the
-                // final status. Skip over them by breaking out of the loop.
-                break;
+                past_summary = true;
             }
         }
 
@@ -1031,6 +1092,7 @@ fn filter_for_rerun(expected: &ExpectedTestResults) -> ExpectedTestResults {
         match outcome.expected.result {
             // Failed tests are still outstanding and should run.
             CheckResult::Fail
+            | CheckResult::FlakyFail
             | CheckResult::Abort
             | CheckResult::Timeout
             | CheckResult::LeakFail
@@ -1097,9 +1159,7 @@ struct JunitOutcome {
     id: TestInstanceId,
     /// Non-success information, or None for success.
     non_success: Option<JunitNonSuccess>,
-    /// The number of rerun elements (flaky_runs for Success, reruns for
-    /// NonSuccess).
-    rerun_count: usize,
+    rerun_info: JunitRerunInfo,
 }
 
 /// Non-success information extracted from JUnit XML.
@@ -1108,6 +1168,18 @@ struct JunitNonSuccess {
     kind: quick_junit::NonSuccessKind,
     ty: String,
     message: Option<String>,
+}
+
+/// Rerun information extracted from JUnit XML.
+#[derive(Clone, Debug)]
+enum JunitRerunInfo {
+    /// The test passed.
+    Success { rerun_count: usize },
+    /// The test failed.
+    NonSuccess {
+        rerun_kind: FlakyOrRerun,
+        rerun_count: usize,
+    },
 }
 
 impl IdOrdItem for JunitOutcome {
@@ -1141,8 +1213,13 @@ impl ActualJunitResults {
                 let test_name = TestCaseName::new(test_case.name.as_str());
                 let id = TestInstanceId::new(binary_id, &test_name);
 
-                let (non_success, rerun_count) = match &test_case.status {
-                    quick_junit::TestCaseStatus::Success { flaky_runs } => (None, flaky_runs.len()),
+                let (non_success, rerun_info) = match &test_case.status {
+                    quick_junit::TestCaseStatus::Success { flaky_runs } => (
+                        None,
+                        JunitRerunInfo::Success {
+                            rerun_count: flaky_runs.len(),
+                        },
+                    ),
                     quick_junit::TestCaseStatus::NonSuccess {
                         kind,
                         ty,
@@ -1155,7 +1232,10 @@ impl ActualJunitResults {
                             ty: ty.as_ref().map(|s| s.to_string()).unwrap_or_default(),
                             message: message.as_ref().map(|s| s.to_string()),
                         }),
-                        reruns.len(),
+                        JunitRerunInfo::NonSuccess {
+                            rerun_kind: reruns.kind,
+                            rerun_count: reruns.runs.len(),
+                        },
                     ),
                     quick_junit::TestCaseStatus::Skipped { .. } => {
                         // Skipped tests are filtered out during test execution and don't appear
@@ -1168,7 +1248,7 @@ impl ActualJunitResults {
                 let outcome = JunitOutcome {
                     id: id.clone(),
                     non_success,
-                    rerun_count,
+                    rerun_info,
                 };
                 tests
                     .insert_unique(outcome)
@@ -1194,6 +1274,7 @@ fn verify_junit(expected: &ExpectedTestResults, junit_path: &Utf8Path, propertie
 // junit.rs. The Rust test harness always uses exit code 101 for test failures.
 const JUNIT_FAIL: &str = "test failure with exit code 101";
 const JUNIT_FAIL_LEAK: &str = "test failure with exit code 101, and leaked handles";
+const JUNIT_FLAKY_FAIL: &str = "flaky failure";
 const JUNIT_ABORT: &str = "test abort";
 
 /// Expected JUnit properties for a non-success test case.
@@ -1225,6 +1306,10 @@ enum JunitExpectedMessage<'a> {
     /// This is used for failure types where the message format is known but
     /// the exact content is test-specific.
     StartsWithOneOf(&'a [&'a str]),
+    /// The message must start with the given prefix and end with the given
+    /// suffix. Useful for messages with variable content in the middle (e.g.
+    /// attempt numbers).
+    StartsAndEndsWith(&'a str, &'a str),
 }
 
 impl JunitExpectedMessage<'_> {
@@ -1265,6 +1350,25 @@ impl JunitExpectedMessage<'_> {
                     debug_run_properties(properties),
                 );
             }
+            JunitExpectedMessage::StartsAndEndsWith(prefix, suffix) => {
+                let message = actual_message.unwrap_or_else(|| {
+                    panic!(
+                        "{test_name}: expected a JUnit message starting with {prefix:?} \
+                         and ending with {suffix:?}, but no message was present \
+                         (properties: {})\n\
+                         JUnit path: {junit_path}",
+                        debug_run_properties(properties),
+                    );
+                });
+                assert!(
+                    message.starts_with(prefix) && message.ends_with(suffix),
+                    "{test_name}: expected JUnit message starting with {prefix:?} \
+                     and ending with {suffix:?}, but got {message:?} \
+                     (properties: {})\n\
+                     JUnit path: {junit_path}",
+                    debug_run_properties(properties),
+                );
+            }
         }
     }
 }
@@ -1296,6 +1400,14 @@ fn expected_junit_for_result(
             ty: JUNIT_FAIL,
             message: JunitExpectedMessage::StartsWithOneOf(FAIL_MESSAGE_PREFIXES),
         }),
+        CheckResult::FlakyFail => Some(ExpectedJunit {
+            kind: quick_junit::NonSuccessKind::Failure,
+            ty: JUNIT_FLAKY_FAIL,
+            message: JunitExpectedMessage::StartsAndEndsWith(
+                "test passed on attempt ",
+                " but is configured to fail when flaky",
+            ),
+        }),
         CheckResult::FailLeak => Some(ExpectedJunit {
             kind: quick_junit::NonSuccessKind::Failure,
             ty: JUNIT_FAIL_LEAK,
@@ -1321,6 +1433,21 @@ fn expected_junit_for_result(
                 message: JunitExpectedMessage::None,
             })
         }
+    }
+}
+
+/// Returns the expected rerun kind for a `CheckResult`, or `None` for success
+/// cases. `FlakyFail` expects `Flaky` (reruns serialize as `<flakyFailure>`);
+/// other failures expect `Rerun` (reruns serialize as `<rerunFailure>`).
+fn expected_rerun_kind_for_result(result: CheckResult) -> Option<FlakyOrRerun> {
+    match result {
+        CheckResult::Pass | CheckResult::Leak => None,
+        CheckResult::FlakyFail => Some(FlakyOrRerun::Flaky),
+        CheckResult::LeakFail
+        | CheckResult::Fail
+        | CheckResult::FailLeak
+        | CheckResult::Abort
+        | CheckResult::Timeout => Some(FlakyOrRerun::Rerun),
     }
 }
 
@@ -1412,39 +1539,97 @@ fn verify_expected_in_junit(
                     }
                 }
 
-                // Verify that the rerun count matches the expected value.
+                // Verify rerun information: count and kind.
+                let actual_rerun_count = match &actual.rerun_info {
+                    JunitRerunInfo::Success { rerun_count }
+                    | JunitRerunInfo::NonSuccess { rerun_count, .. } => *rerun_count,
+                };
                 match expected_outcome.expected.expected_reruns {
                     ExpectedReruns::None => {
                         assert_eq!(
-                            actual.rerun_count,
+                            actual_rerun_count,
                             0,
                             "{}: expected no reruns but found {} (properties: {})\n\
                              JUnit path: {}",
                             expected_outcome.id.full_name(),
-                            actual.rerun_count,
+                            actual_rerun_count,
                             debug_run_properties(properties),
                             junit_path,
                         );
                     }
                     ExpectedReruns::FlakyRunCount(expected_count) => {
                         assert_eq!(
-                            actual.rerun_count,
+                            actual_rerun_count,
                             expected_count,
                             "{}: expected {} flaky runs but found {} (properties: {})\n\
                              JUnit path: {}",
                             expected_outcome.id.full_name(),
                             expected_count,
-                            actual.rerun_count,
+                            actual_rerun_count,
                             debug_run_properties(properties),
                             junit_path,
                         );
                     }
                     ExpectedReruns::SomeReruns => {
                         assert!(
-                            actual.rerun_count > 0,
+                            actual_rerun_count > 0,
                             "{}: expected reruns but found none (properties: {})\n\
                              JUnit path: {}",
                             expected_outcome.id.full_name(),
+                            debug_run_properties(properties),
+                            junit_path,
+                        );
+                    }
+                }
+
+                // Verify rerun kind matches expectations derived from the
+                // check result.
+                match (
+                    expected_rerun_kind_for_result(expected_outcome.expected.result),
+                    &actual.rerun_info,
+                ) {
+                    (
+                        Some(expected_rerun_kind),
+                        JunitRerunInfo::NonSuccess {
+                            rerun_kind,
+                            rerun_count,
+                        },
+                    ) => {
+                        assert_eq!(
+                            *rerun_kind,
+                            expected_rerun_kind,
+                            "{}: expected rerun kind {:?} but got {:?} \
+                             (rerun_count: {}, properties: {})\n\
+                             JUnit path: {}",
+                            expected_outcome.id.full_name(),
+                            expected_rerun_kind,
+                            rerun_kind,
+                            rerun_count,
+                            debug_run_properties(properties),
+                            junit_path,
+                        );
+                    }
+                    (Some(expected_rerun_kind), JunitRerunInfo::Success { .. }) => {
+                        panic!(
+                            "{}: expected NonSuccess rerun info (rerun kind {:?}) \
+                             but got Success (properties: {})\n\
+                             JUnit path: {}",
+                            expected_outcome.id.full_name(),
+                            expected_rerun_kind,
+                            debug_run_properties(properties),
+                            junit_path,
+                        );
+                    }
+                    (None, JunitRerunInfo::Success { .. }) => {
+                        // Success result with Success rerun info — expected.
+                    }
+                    (None, JunitRerunInfo::NonSuccess { rerun_kind, .. }) => {
+                        panic!(
+                            "{}: expected Success rerun info but got NonSuccess \
+                             (rerun kind {:?}, properties: {})\n\
+                             JUnit path: {}",
+                            expected_outcome.id.full_name(),
+                            rerun_kind,
                             debug_run_properties(properties),
                             junit_path,
                         );

--- a/integration-tests/tests/integration/main.rs
+++ b/integration-tests/tests/integration/main.rs
@@ -2559,6 +2559,173 @@ fn test_retries() {
     );
 }
 
+/// Test that `flaky-result = "fail"` works correctly for flaky tests.
+///
+/// The `with-retries-flaky-fail` profile has:
+/// - `retries = 2` (default for the profile)
+/// - Override for test_flaky_mod_4: `retries = { backoff = "fixed", count = 4, flaky-result = "fail" }`
+/// - Override for test_flaky_mod_6: `retries = 5`
+///
+/// test_flaky_mod_4 passes on attempt 4 of 5, but `flaky-result = "fail"` means it
+/// counts as a failure. test_flaky_mod_6 passes on attempt 6 of 6 and is not
+/// configured to fail, so it counts as passed (FLAKY 6/6).
+#[test]
+fn test_retries_flaky_fail() {
+    let env_info = set_env_vars_for_test();
+    let p = TempProject::new(&env_info).unwrap();
+
+    let output = CargoNextestCli::for_test(&env_info)
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "run",
+            "--workspace",
+            "--all-targets",
+            "--profile",
+            "with-retries-flaky-fail",
+        ])
+        .unchecked(true)
+        .output();
+
+    // Should fail because test_flaky_mod_4 has flaky-result = "fail" and other
+    // tests also fail normally.
+    assert_eq!(
+        output.exit_status.code(),
+        Some(NextestExitCode::TEST_RUN_FAILED),
+        "flaky test with flaky-result = \"fail\" should cause failure\n{output}"
+    );
+    check_run_output_with_junit(
+        &output.stderr,
+        &p.junit_path("with-retries-flaky-fail"),
+        RunProperties::WITH_RETRIES_FLAKY_FAIL | RunProperties::SKIP_SUMMARY_CHECK,
+    );
+}
+
+/// Test that `--retries` CLI flag preserves config-level `flaky-result = "fail"`.
+///
+/// This is the key scenario for independent resolution: `--retries 5` overrides
+/// the retry count, but the `flaky-result = "fail"` from the config override for
+/// test_flaky_mod_4 should be preserved. Before the split of `FlakyResult`
+/// from `RetryPolicy`, `--retries` would replace the entire policy including
+/// the result.
+#[test]
+fn test_retries_cli_preserves_flaky_fail() {
+    let env_info = set_env_vars_for_test();
+    let p = TempProject::new(&env_info).unwrap();
+
+    let output = CargoNextestCli::for_test(&env_info)
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "run",
+            "--workspace",
+            "--all-targets",
+            "--profile",
+            "with-retries-flaky-fail",
+            "--retries",
+            "5",
+            "-E",
+            "test(=test_flaky_mod_4) | test(=test_flaky_mod_6)",
+        ])
+        .unchecked(true)
+        .output();
+
+    // test_flaky_mod_4 has flaky-result = "fail" in config, so it should be a
+    // failure even though --retries overrides the count.
+    assert_eq!(
+        output.exit_status.code(),
+        Some(NextestExitCode::TEST_RUN_FAILED),
+        "--retries should preserve config flaky-result = \"fail\"\n{output}"
+    );
+    check_run_output_for_test_names(
+        &output.stderr,
+        &["test_flaky_mod_4", "test_flaky_mod_6"],
+        RunProperties::WITH_RETRIES_FLAKY_FAIL,
+    );
+}
+
+/// Test that `--flaky-result fail` CLI flag makes all flaky tests fail.
+///
+/// With `--flaky-result fail`, every test that passes on retry should be
+/// counted as a failure, regardless of per-test config. This is useful for
+/// CI pipelines that want to treat all flakiness as failures.
+#[test]
+fn test_flaky_result_fail_cli() {
+    let env_info = set_env_vars_for_test();
+    let p = TempProject::new(&env_info).unwrap();
+
+    let output = CargoNextestCli::for_test(&env_info)
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "run",
+            "--workspace",
+            "--all-targets",
+            "--profile",
+            "with-retries-flaky-fail",
+            "--flaky-result",
+            "fail",
+            "-E",
+            "test(=test_flaky_mod_4) | test(=test_flaky_mod_6)",
+        ])
+        .unchecked(true)
+        .output();
+
+    // Both flaky tests should be failures: test_flaky_mod_4 has
+    // flaky-result = "fail" in config (would fail anyway), and test_flaky_mod_6
+    // now also fails due to the CLI flag.
+    assert_eq!(
+        output.exit_status.code(),
+        Some(NextestExitCode::TEST_RUN_FAILED),
+        "--flaky-result fail should make all flaky tests fail\n{output}"
+    );
+    check_run_output_for_test_names(
+        &output.stderr,
+        &["test_flaky_mod_4", "test_flaky_mod_6"],
+        RunProperties::WITH_CLI_FLAKY_RESULT_FAIL,
+    );
+}
+
+/// Test that `--flaky-result pass` CLI flag overrides config `flaky-result = "fail"`.
+///
+/// With `--flaky-result pass`, even tests configured with `flaky-result = "fail"` in
+/// the profile should be treated as passing when they eventually succeed.
+#[test]
+fn test_flaky_result_pass_cli() {
+    let env_info = set_env_vars_for_test();
+    let p = TempProject::new(&env_info).unwrap();
+
+    let output = CargoNextestCli::for_test(&env_info)
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "run",
+            "--workspace",
+            "--all-targets",
+            "--profile",
+            "with-retries-flaky-fail",
+            "--flaky-result",
+            "pass",
+            "-E",
+            "test(=test_flaky_mod_4) | test(=test_flaky_mod_6)",
+        ])
+        .unchecked(true)
+        .output();
+
+    // Both flaky tests should pass: --flaky-result pass overrides the config's
+    // flaky-result = "fail" for test_flaky_mod_4.
+    assert_eq!(
+        output.exit_status.code(),
+        Some(0),
+        "--flaky-result pass should override config flaky-result = \"fail\"\n{output}"
+    );
+    check_run_output_for_test_names(
+        &output.stderr,
+        &["test_flaky_mod_4", "test_flaky_mod_6"],
+        RunProperties::WITH_CLI_FLAKY_RESULT_PASS,
+    );
+}
+
 /// Test that tests time out correctly with the with-termination profile.
 ///
 /// The `with-termination` profile has slow-timeout configured such that tests

--- a/nextest-runner/src/config/elements/retry_policy.rs
+++ b/nextest-runner/src/config/elements/retry_policy.rs
@@ -65,6 +65,9 @@ impl RetryPolicy {
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 pub enum FlakyResult {
+    /// The test is marked as failed.
+    Fail,
+
     /// The test is marked as passed.
     #[default]
     Pass,
@@ -260,12 +263,20 @@ mod tests {
             [profile.exp-with-max-delay-and-jitter]
             retries = { backoff = "exponential", count = 6, delay = "4s", max-delay = "1m", jitter = true }
 
+            [profile.with-flaky-result-fail]
+            retries = { backoff = "fixed", count = 2 }
+            flaky-result = "fail"
+
             [profile.with-flaky-result-pass]
             retries = { backoff = "fixed", count = 2 }
             flaky-result = "pass"
 
+            [profile.exp-with-flaky-result-fail]
+            retries = { backoff = "exponential", count = 3, delay = "1s" }
+            flaky-result = "fail"
+
             [profile.flaky-result-only]
-            flaky-result = "pass"
+            flaky-result = "fail"
         "#};
 
         let workspace_dir = tempdir().unwrap();
@@ -370,6 +381,21 @@ mod tests {
             "exp-with-max-delay-and-jitter retries matches"
         );
 
+        let with_flaky_result_fail = config
+            .profile("with-flaky-result-fail")
+            .expect("profile exists")
+            .apply_build_platforms(&build_platforms());
+        assert_eq!(
+            with_flaky_result_fail.retries(),
+            RetryPolicy::new_without_delay(2),
+            "with-flaky-result-fail retries matches"
+        );
+        assert_eq!(
+            with_flaky_result_fail.flaky_result(),
+            FlakyResult::Fail,
+            "with-flaky-result-fail flaky_result matches"
+        );
+
         let with_flaky_result_pass = config
             .profile("with-flaky-result-pass")
             .expect("profile exists")
@@ -385,8 +411,28 @@ mod tests {
             "with-flaky-result-pass flaky_result matches"
         );
 
+        let exp_with_flaky_result_fail = config
+            .profile("exp-with-flaky-result-fail")
+            .expect("profile exists")
+            .apply_build_platforms(&build_platforms());
+        assert_eq!(
+            exp_with_flaky_result_fail.retries(),
+            RetryPolicy::Exponential {
+                count: 3,
+                delay: Duration::from_secs(1),
+                jitter: false,
+                max_delay: None,
+            },
+            "exp-with-flaky-result-fail retries matches"
+        );
+        assert_eq!(
+            exp_with_flaky_result_fail.flaky_result(),
+            FlakyResult::Fail,
+            "exp-with-flaky-result-fail flaky_result matches"
+        );
+
         // flaky-result-only: retries inherited from default (count=3), flaky
-        // result set to pass.
+        // result set to fail.
         let flaky_result_only = config
             .profile("flaky-result-only")
             .expect("profile exists")
@@ -402,7 +448,7 @@ mod tests {
         );
         assert_eq!(
             flaky_result_only.flaky_result(),
-            FlakyResult::Pass,
+            FlakyResult::Fail,
             "flaky-result-only flaky_result matches"
         );
     }
@@ -495,6 +541,14 @@ mod tests {
         ConfigErrorKind::Message,
         "`max-delay` cannot be less than delay"
         ; "max-delay greater than delay")]
+    #[test_case(
+        indoc!{r#"
+            [profile.default]
+            flaky-result = "unknown"
+        "#},
+        ConfigErrorKind::Message,
+        "enum FlakyResult does not have variant constructor unknown"
+        ; "invalid flaky-result value")]
     fn parse_retries_invalid(
         config_contents: &str,
         expected_kind: ConfigErrorKind,
@@ -780,7 +834,7 @@ mod tests {
             [[profile.default.overrides]]
             filter = "test(=my_test)"
             retries = { backoff = "fixed", count = 3 }
-            flaky-result = "pass"
+            flaky-result = "fail"
 
             [[profile.default.overrides]]
             filter = "test(=other_test)"
@@ -808,7 +862,7 @@ mod tests {
             .expect("ci profile is defined")
             .apply_build_platforms(&build_platforms());
 
-        // my_test has flaky-result = "pass" set explicitly.
+        // my_test has flaky-result = "fail" set explicitly.
         let binary_query = binary_query(
             &graph,
             package_id,
@@ -824,8 +878,8 @@ mod tests {
         let settings = profile.settings_for(NextestRunMode::Test, &query);
         assert_eq!(
             settings.flaky_result(),
-            FlakyResult::Pass,
-            "my_test flaky_result is pass"
+            FlakyResult::Fail,
+            "my_test flaky_result is fail"
         );
 
         // other_test uses shorthand retries = 2, which does not set
@@ -854,11 +908,11 @@ mod tests {
             filter = "test(=my_test)"
             retries = 5
 
-            # Override 2: sets retries with flaky-result = "pass".
+            # Override 2: sets retries with flaky-result = "fail".
             [[profile.default.overrides]]
             filter = "all()"
             retries = { backoff = "fixed", count = 2 }
-            flaky-result = "pass"
+            flaky-result = "fail"
 
             [profile.ci]
         "#};
@@ -905,12 +959,12 @@ mod tests {
         // Flaky result comes from override 2 (first override didn't set it).
         assert_eq!(
             settings.flaky_result(),
-            FlakyResult::Pass,
+            FlakyResult::Fail,
             "flaky_result from second override"
         );
     }
 
-    /// Test that `flaky-result = "pass"` (without retries) sets only the flaky
+    /// Test that `flaky-result = "fail"` (without retries) sets only the flaky
     /// result, with the retry policy inherited from a lower-priority override.
     #[test]
     fn overrides_flaky_result_only() {
@@ -918,7 +972,7 @@ mod tests {
             # Override 1: sets only flaky-result, no retry policy.
             [[profile.default.overrides]]
             filter = "test(=my_test)"
-            flaky-result = "pass"
+            flaky-result = "fail"
 
             # Override 2: sets retries count for all tests.
             [[profile.default.overrides]]
@@ -970,7 +1024,7 @@ mod tests {
         // Flaky result comes from override 1.
         assert_eq!(
             settings.flaky_result(),
-            FlakyResult::Pass,
+            FlakyResult::Fail,
             "flaky_result from first override"
         );
 

--- a/nextest-runner/src/record/format.rs
+++ b/nextest-runner/src/record/format.rs
@@ -198,9 +198,13 @@ pub(super) const RUNS_JSON_FORMAT_VERSION: RunsJsonFormatVersion = RunsJsonForma
 /// This combines a major version (for breaking changes) and a minor version
 /// (for additive changes). Readers check compatibility via
 /// [`StoreFormatVersion::check_readable_by`].
+///
+/// Changelog:
+///
+/// - 1.1: Addition of the `flaky_result` field to `ExecutionStatuses`.
 pub const STORE_FORMAT_VERSION: StoreFormatVersion = StoreFormatVersion::new(
     StoreFormatMajorVersion::new(1),
-    StoreFormatMinorVersion::new(0),
+    StoreFormatMinorVersion::new(1),
 );
 
 /// Whether a runs.json.zst file can be written to.

--- a/nextest-runner/src/record/rerun.rs
+++ b/nextest-runner/src/record/rerun.rs
@@ -7,6 +7,7 @@
 //! didn't complete in a previous recorded run.
 
 use crate::{
+    config::elements::FlakyResult,
     errors::RecordReadError,
     list::OwnedTestInstanceId,
     record::{
@@ -14,6 +15,7 @@ use crate::{
         TestEventKindSummary,
         format::{RerunInfo, RerunRootInfo, RerunTestSuiteInfo},
     },
+    reporter::events::ExecutionDescription,
 };
 use iddqd::IdOrdMap;
 use nextest_metadata::{
@@ -437,10 +439,20 @@ where
                 ..
             }) => {
                 // Determine outcome for this iteration/finish event.
-                let outcome = if run_statuses.last_status().result.is_success() {
-                    TestOutcome::Passed
-                } else {
-                    TestOutcome::Failed
+                // Use describe() to account for flaky-fail tests: the last
+                // attempt may have succeeded, but the overall test result is
+                // a failure if flaky_result is Fail.
+                let outcome = match run_statuses.describe() {
+                    ExecutionDescription::Success { .. } => TestOutcome::Passed,
+                    ExecutionDescription::Flaky {
+                        result: FlakyResult::Pass,
+                        ..
+                    } => TestOutcome::Passed,
+                    ExecutionDescription::Flaky {
+                        result: FlakyResult::Fail,
+                        ..
+                    } => TestOutcome::Failed,
+                    ExecutionDescription::Failure { .. } => TestOutcome::Failed,
                 };
 
                 // For stress runs: multiple TestFinished events occur for the
@@ -477,7 +489,6 @@ where
 mod tests {
     use super::*;
     use crate::{
-        config::elements::FlakyResult,
         output_spec::RecordingSpec,
         record::{
             OutputEventKind, StressIndexSummary, TestEventKindSummary, ZipStoreOutputDescription,
@@ -1499,6 +1510,111 @@ mod tests {
             current_stats: RunStats::default(),
             running: 0,
         })
+    }
+
+    /// Creates a flaky `TestFinished` event: one failed attempt followed by a
+    /// passing attempt, with the given `FlakyResult`.
+    fn make_flaky_test_finished(
+        test_instance: OwnedTestInstanceId,
+        flaky_result: FlakyResult,
+    ) -> TestEventKindSummary<RecordingSpec> {
+        let fail_result = ExecutionResultDescription::Fail {
+            failure: FailureDescription::ExitCode { code: 1 },
+            leaked: false,
+        };
+        let pass_result = ExecutionResultDescription::Pass;
+
+        let fail_status = ExecuteStatus {
+            retry_data: RetryData {
+                attempt: 1,
+                total_attempts: 2,
+            },
+            output: ChildExecutionOutputDescription::Output {
+                result: Some(fail_result.clone()),
+                output: ZipStoreOutputDescription::Split {
+                    stdout: None,
+                    stderr: None,
+                },
+                errors: None,
+            },
+            result: fail_result,
+            start_time: Utc::now().into(),
+            time_taken: Duration::from_millis(100),
+            is_slow: false,
+            delay_before_start: Duration::ZERO,
+            error_summary: None,
+            output_error_slice: None,
+        };
+
+        let pass_status = ExecuteStatus {
+            retry_data: RetryData {
+                attempt: 2,
+                total_attempts: 2,
+            },
+            output: ChildExecutionOutputDescription::Output {
+                result: Some(pass_result.clone()),
+                output: ZipStoreOutputDescription::Split {
+                    stdout: None,
+                    stderr: None,
+                },
+                errors: None,
+            },
+            result: pass_result,
+            start_time: Utc::now().into(),
+            time_taken: Duration::from_millis(100),
+            is_slow: false,
+            delay_before_start: Duration::ZERO,
+            error_summary: None,
+            output_error_slice: None,
+        };
+
+        TestEventKindSummary::Output(OutputEventKind::TestFinished {
+            stress_index: None,
+            test_instance,
+            success_output: TestOutputDisplay::Never,
+            failure_output: TestOutputDisplay::Never,
+            junit_store_success_output: false,
+            junit_store_failure_output: false,
+            run_statuses: ExecutionStatuses::new(vec![fail_status, pass_status], flaky_result),
+            current_stats: RunStats::default(),
+            running: 0,
+        })
+    }
+
+    /// Test that flaky-fail tests are treated as Failed for rerun purposes.
+    ///
+    /// A flaky test is one that fails on the first attempt but passes on
+    /// retry. With `FlakyResult::Fail`, the overall outcome should be Failed
+    /// so that the test is rerun. With `FlakyResult::Pass`, it should be
+    /// Passed.
+    #[test]
+    fn flaky_result_affects_rerun_outcome() {
+        let test_flaky_fail = OwnedTestInstanceId {
+            binary_id: RustBinaryId::new("test-binary"),
+            test_name: TestCaseName::new("flaky_fail"),
+        };
+        let test_flaky_pass = OwnedTestInstanceId {
+            binary_id: RustBinaryId::new("test-binary"),
+            test_name: TestCaseName::new("flaky_pass"),
+        };
+
+        let events = [
+            make_flaky_test_finished(test_flaky_fail.clone(), FlakyResult::Fail),
+            make_flaky_test_finished(test_flaky_pass.clone(), FlakyResult::Pass),
+        ];
+
+        let outcomes = collect_from_events(events.iter().map(Ok::<_, Infallible>)).unwrap();
+
+        assert_eq!(
+            outcomes.get(&test_flaky_fail),
+            Some(&TestOutcome::Failed),
+            "flaky test with FlakyResult::Fail should be Failed for rerun"
+        );
+        assert_eq!(
+            outcomes.get(&test_flaky_pass),
+            Some(&TestOutcome::Passed),
+            "flaky test with FlakyResult::Pass should be Passed for rerun"
+        );
     }
 
     /// Test stress run accumulation: if any iteration fails, the test is Failed.

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_cancelled.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_cancelled.snap
@@ -5,7 +5,7 @@ expression: json
 {
   "run-id": "550e8400-e29b-41d4-a716-446655440000",
   "store-format-version": 1,
-  "store-format-minor-version": 0,
+  "store-format-minor-version": 1,
   "nextest-version": "0.9.111",
   "started-at": "2024-12-19T14:22:33-08:00",
   "last-written-at": "2024-12-19T22:22:33Z",

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_completed.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_completed.snap
@@ -5,7 +5,7 @@ expression: json
 {
   "run-id": "550e8400-e29b-41d4-a716-446655440000",
   "store-format-version": 1,
-  "store-format-minor-version": 0,
+  "store-format-minor-version": 1,
   "nextest-version": "0.9.111",
   "started-at": "2024-12-19T14:22:33-08:00",
   "last-written-at": "2024-12-19T22:22:33Z",

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_incomplete.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_incomplete.snap
@@ -5,7 +5,7 @@ expression: json
 {
   "run-id": "550e8400-e29b-41d4-a716-446655440000",
   "store-format-version": 1,
-  "store-format-minor-version": 0,
+  "store-format-minor-version": 1,
   "nextest-version": "0.9.111",
   "started-at": "2024-12-19T14:22:33-08:00",
   "last-written-at": "2024-12-19T22:22:33Z",

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_cancelled.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_cancelled.snap
@@ -5,7 +5,7 @@ expression: json
 {
   "run-id": "550e8400-e29b-41d4-a716-446655440000",
   "store-format-version": 1,
-  "store-format-minor-version": 0,
+  "store-format-minor-version": 1,
   "nextest-version": "0.9.111",
   "started-at": "2024-12-19T14:22:33-08:00",
   "last-written-at": "2024-12-19T22:22:33Z",

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_completed.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_completed.snap
@@ -5,7 +5,7 @@ expression: json
 {
   "run-id": "550e8400-e29b-41d4-a716-446655440000",
   "store-format-version": 1,
-  "store-format-minor-version": 0,
+  "store-format-minor-version": 1,
   "nextest-version": "0.9.111",
   "started-at": "2024-12-19T14:22:33-08:00",
   "last-written-at": "2024-12-19T22:22:33Z",

--- a/nextest-runner/src/reporter/aggregator/junit.rs
+++ b/nextest-runner/src/reporter/aggregator/junit.rs
@@ -26,7 +26,7 @@ use debug_ignore::DebugIgnore;
 use indexmap::IndexMap;
 use nextest_metadata::RustBinaryId;
 use quick_junit::{
-    NonSuccessKind, Report, TestCase, TestCaseStatus, TestRerun, TestSuite, XmlString,
+    FlakyOrRerun, NonSuccessKind, Report, TestCase, TestCaseStatus, TestRerun, TestSuite, XmlString,
 };
 use std::{fmt, fs::File};
 
@@ -140,7 +140,10 @@ impl<'cfg> MetadataJunit<'cfg> {
             } => {
                 let testsuite = self.testsuite_for_test(stress_index, test_instance);
 
-                let (mut testcase_status, main_status, reruns) = match run_statuses.describe() {
+                let describe = run_statuses.describe();
+                let is_success_for_output = describe.is_success_for_output();
+
+                let (mut testcase_status, main_status, reruns) = match describe {
                     ExecutionDescription::Success { single_status } => {
                         (TestCaseStatus::success(), single_status, &[][..])
                     }
@@ -149,6 +152,23 @@ impl<'cfg> MetadataJunit<'cfg> {
                         prior_statuses,
                         result: FlakyResult::Pass,
                     } => (TestCaseStatus::success(), last_status, prior_statuses),
+                    ExecutionDescription::Flaky {
+                        last_status,
+                        prior_statuses,
+                        result: FlakyResult::Fail,
+                    } => {
+                        let mut testcase_status =
+                            TestCaseStatus::non_success(NonSuccessKind::Failure);
+                        testcase_status.set_type("flaky failure");
+                        testcase_status.set_message(format!(
+                            "test passed on attempt {}/{} but is configured to fail when flaky",
+                            last_status.retry_data.attempt, last_status.retry_data.total_attempts,
+                        ));
+                        // The test exhibited flakiness (eventually passed), so
+                        // prior runs should serialize as <flakyFailure>.
+                        testcase_status.set_rerun_kind(FlakyOrRerun::Flaky);
+                        (testcase_status, last_status, prior_statuses)
+                    }
                     ExecutionDescription::Failure {
                         first_status,
                         retries,
@@ -186,13 +206,18 @@ impl<'cfg> MetadataJunit<'cfg> {
                     .set_timestamp(main_status.start_time)
                     .set_time(main_status.time_taken);
 
+                // For flaky tests (both pass and fail), the last attempt
+                // succeeded, so its output is success output: governed by
+                // store-success-output. For flaky-failed tests this is
+                // intentional — the successful run's output is not
+                // interesting.
+                //
                 // TODO: allure seems to want the output to be in a format where text files are
                 // written out to disk:
                 // https://github.com/allure-framework/allure2/blob/master/plugins/junit-xml-plugin/src/main/java/io/qameta/allure/junitxml/JunitXmlPlugin.java#L192-L196
                 // we may have to update this format to handle that.
-                let is_success = main_status.result.is_success();
-                let store_stdout_stderr = (junit_store_success_output && is_success)
-                    || (junit_store_failure_output && !is_success);
+                let store_stdout_stderr = (junit_store_success_output && is_success_for_output)
+                    || (junit_store_failure_output && !is_success_for_output);
 
                 set_execute_status_props(
                     &main_status.output,

--- a/nextest-runner/src/reporter/displayer/imp.rs
+++ b/nextest-runner/src/reporter/displayer/imp.rs
@@ -363,14 +363,10 @@ impl OutputLoadDecider {
         run_statuses: &ExecutionStatuses<RecordingSpec>,
     ) -> LoadOutput {
         let describe = run_statuses.describe();
-        let last_status = describe.last_status();
 
-        // Determine which display setting applies based on the result.
-        let display = self.overrides.resolve_test_output_display(
-            success_output,
-            failure_output,
-            &last_status.result,
-        );
+        let display =
+            self.overrides
+                .resolve_for_describe(success_output, failure_output, &describe);
 
         Self::should_load_for_display(display)
     }
@@ -986,10 +982,10 @@ impl<'a> DisplayReporterImpl<'a> {
             } => {
                 let describe = run_statuses.describe();
                 let last_status = run_statuses.last_status();
-                let test_output_display = self.unit_output.resolve_test_output_display(
+                let test_output_display = self.unit_output.overrides().resolve_for_describe(
                     *success_output,
                     *failure_output,
-                    &last_status.result,
+                    &describe,
                 );
 
                 let output_on_test_finished = self.status_levels.compute_output_on_test_finished(
@@ -1649,6 +1645,23 @@ impl<'a> DisplayReporterImpl<'a> {
             write_windows_abort_line(abort, &self.styles, writer)?;
         }
 
+        // For flaky tests configured with flaky-result = "fail", print a
+        // supplementary line in intermediate output explaining why the passing
+        // test is actually a failure.
+        if kind == StatusLineKind::Intermediate
+            && let ExecutionDescription::Flaky {
+                result: FlakyResult::Fail,
+                ..
+            } = describe
+        {
+            writeln!(
+                writer,
+                "{:>12} test configured to {} if flaky",
+                "-",
+                "fail".style(self.styles.fail),
+            )?;
+        }
+
         Ok(())
     }
 
@@ -1750,6 +1763,24 @@ impl<'a> DisplayReporterImpl<'a> {
                     }
                 };
                 write!(writer, "{:>12} ", status.style(self.styles.skip))?;
+            }
+            ExecutionDescription::Flaky {
+                result: FlakyResult::Fail,
+                ..
+            } => {
+                // Use the fail color for flaky tests configured as failures.
+                let status = match kind {
+                    StatusLineKind::Intermediate => {
+                        format!("TRY {} PASS", last_status.retry_data.attempt)
+                    }
+                    StatusLineKind::Final => {
+                        format!(
+                            "FLKY-FL {}/{}",
+                            last_status.retry_data.attempt, last_status.retry_data.total_attempts
+                        )
+                    }
+                };
+                write!(writer, "{:>12} ", status.style(self.styles.fail))?;
             }
             ExecutionDescription::Failure { .. } => {
                 if last_status.retry_data.attempt == 1 {
@@ -3343,6 +3374,11 @@ mod tests {
             prior_statuses: std::slice::from_ref(&flaky_first_status),
             result: FlakyResult::Pass,
         };
+        let flaky_fail_describe = ExecutionDescription::Flaky {
+            last_status: &flaky_last_status,
+            prior_statuses: std::slice::from_ref(&flaky_first_status),
+            result: FlakyResult::Fail,
+        };
         let fail_describe = ExecutionDescription::Failure {
             first_status: &fail_status,
             last_status: &fail_status,
@@ -3412,6 +3448,7 @@ mod tests {
             ("timeout pass slow", timeout_pass_slow_describe),
             // Flaky variants.
             ("flaky", flaky_describe),
+            ("flaky fail", flaky_fail_describe),
             // First-attempt failure variants.
             ("fail", fail_describe),
             ("fail leak", fail_leak_describe),

--- a/nextest-runner/src/reporter/displayer/snapshots/nextest_runner__reporter__displayer__imp__tests__status_line_all_variants.snap
+++ b/nextest-runner/src/reporter/displayer/snapshots/nextest_runner__reporter__displayer__imp__tests__status_line_all_variants.snap
@@ -17,64 +17,69 @@ TIMEOUT-PASS [ 240.000s] (  3/100) my-binary-id test_name
 TIMEOUT-PASS [ 300.000s] (  6/100) my-binary-id test_name
 # flaky: 
   TRY 2 PASS [   1.000s] (  7/100) my-binary-id test_name
+# flaky fail: 
+  TRY 2 PASS [   1.000s] (  8/100) my-binary-id test_name
+           - test configured to fail if flaky
 # fail: 
-        FAIL [   1.000s] (  8/100) my-binary-id test_name
+        FAIL [   1.000s] (  9/100) my-binary-id test_name
 # fail leak: 
- FAIL + LEAK [   1.000s] (  9/100) my-binary-id test_name
+ FAIL + LEAK [   1.000s] ( 10/100) my-binary-id test_name
 # exec fail: 
-       XFAIL [   1.000s] ( 10/100) my-binary-id test_name
+       XFAIL [   1.000s] ( 11/100) my-binary-id test_name
 # leak fail: 
-   LEAK-FAIL [   1.000s] ( 11/100) my-binary-id test_name
+   LEAK-FAIL [   1.000s] ( 12/100) my-binary-id test_name
 # timeout fail: 
-     TIMEOUT [  60.000s] ( 12/100) my-binary-id test_name
+     TIMEOUT [  60.000s] ( 13/100) my-binary-id test_name
 # abort unix: 
-     SIGSEGV [   1.000s] ( 13/100) my-binary-id test_name
+     SIGSEGV [   1.000s] ( 14/100) my-binary-id test_name
 # abort windows: 
-       ABORT [   1.000s] ( 14/100) my-binary-id test_name
+       ABORT [   1.000s] ( 15/100) my-binary-id test_name
            - with code 0xc0000005: Access violation
 # fail retry: 
-  TRY 2 FAIL [   1.000s] ( 15/100) my-binary-id test_name
+  TRY 2 FAIL [   1.000s] ( 16/100) my-binary-id test_name
 # fail leak retry: 
- TRY 2 FL+LK [   1.000s] ( 16/100) my-binary-id test_name
+ TRY 2 FL+LK [   1.000s] ( 17/100) my-binary-id test_name
 # leak fail retry: 
-TRY 2 LKFAIL [   1.000s] ( 17/100) my-binary-id test_name
+TRY 2 LKFAIL [   1.000s] ( 18/100) my-binary-id test_name
 # timeout fail retry: 
-   TRY 2 TMT [  60.000s] ( 18/100) my-binary-id test_name
+   TRY 2 TMT [  60.000s] ( 19/100) my-binary-id test_name
 === final ===
 # pass: 
-        PASS [   1.000s] ( 19/100) my-binary-id test_name
+        PASS [   1.000s] ( 20/100) my-binary-id test_name
 # leak pass: 
-        LEAK [   2.000s] ( 20/100) my-binary-id test_name
+        LEAK [   2.000s] ( 21/100) my-binary-id test_name
 # timeout pass: 
-TIMEOUT-PASS [ 240.000s] ( 21/100) my-binary-id test_name
+TIMEOUT-PASS [ 240.000s] ( 22/100) my-binary-id test_name
 # pass slow: 
-        SLOW [  30.000s] ( 22/100) my-binary-id test_name
+        SLOW [  30.000s] ( 23/100) my-binary-id test_name
 # leak pass slow: 
- SLOW + LEAK [  30.000s] ( 23/100) my-binary-id test_name
+ SLOW + LEAK [  30.000s] ( 24/100) my-binary-id test_name
 # timeout pass slow: 
- SLOW+TMPASS [ 300.000s] ( 24/100) my-binary-id test_name
+ SLOW+TMPASS [ 300.000s] ( 25/100) my-binary-id test_name
 # flaky: 
-   FLAKY 2/2 [   1.000s] ( 25/100) my-binary-id test_name
+   FLAKY 2/2 [   1.000s] ( 26/100) my-binary-id test_name
+# flaky fail: 
+ FLKY-FL 2/2 [   1.000s] ( 27/100) my-binary-id test_name
 # fail: 
-        FAIL [   1.000s] ( 26/100) my-binary-id test_name
+        FAIL [   1.000s] ( 28/100) my-binary-id test_name
 # fail leak: 
- FAIL + LEAK [   1.000s] ( 27/100) my-binary-id test_name
+ FAIL + LEAK [   1.000s] ( 29/100) my-binary-id test_name
 # exec fail: 
-       XFAIL [   1.000s] ( 28/100) my-binary-id test_name
+       XFAIL [   1.000s] ( 30/100) my-binary-id test_name
 # leak fail: 
-   LEAK-FAIL [   1.000s] ( 29/100) my-binary-id test_name
+   LEAK-FAIL [   1.000s] ( 31/100) my-binary-id test_name
 # timeout fail: 
-     TIMEOUT [  60.000s] ( 30/100) my-binary-id test_name
+     TIMEOUT [  60.000s] ( 32/100) my-binary-id test_name
 # abort unix: 
-     SIGSEGV [   1.000s] ( 31/100) my-binary-id test_name
+     SIGSEGV [   1.000s] ( 33/100) my-binary-id test_name
 # abort windows: 
-       ABORT [   1.000s] ( 32/100) my-binary-id test_name
+       ABORT [   1.000s] ( 34/100) my-binary-id test_name
            - with code 0xc0000005: Access violation
 # fail retry: 
-  TRY 2 FAIL [   1.000s] ( 33/100) my-binary-id test_name
+  TRY 2 FAIL [   1.000s] ( 35/100) my-binary-id test_name
 # fail leak retry: 
- TRY 2 FL+LK [   1.000s] ( 34/100) my-binary-id test_name
+ TRY 2 FL+LK [   1.000s] ( 36/100) my-binary-id test_name
 # leak fail retry: 
-TRY 2 LKFAIL [   1.000s] ( 35/100) my-binary-id test_name
+TRY 2 LKFAIL [   1.000s] ( 37/100) my-binary-id test_name
 # timeout fail retry: 
-   TRY 2 TMT [  60.000s] ( 36/100) my-binary-id test_name
+   TRY 2 TMT [  60.000s] ( 38/100) my-binary-id test_name

--- a/nextest-runner/src/reporter/displayer/status_level.rs
+++ b/nextest-runner/src/reporter/displayer/status_level.rs
@@ -777,11 +777,10 @@ mod tests {
             let describe = run_statuses.describe();
             let last_status = describe.last_status();
 
-            let display = decider.overrides.resolve_test_output_display(
-                success_output,
-                failure_output,
-                &last_status.result,
-            );
+            let display =
+                decider
+                    .overrides
+                    .resolve_for_describe(success_output, failure_output, &describe);
 
             let test_status_level = describe.status_level();
             let test_final_status_level = describe.final_status_level();

--- a/nextest-runner/src/reporter/displayer/unit_output.rs
+++ b/nextest-runner/src/reporter/displayer/unit_output.rs
@@ -8,7 +8,7 @@ use crate::{
     config::elements::{LeakTimeoutResult, SlowTimeoutResult},
     errors::DisplayErrorChain,
     indenter::indented,
-    output_spec::LiveSpec,
+    output_spec::{LiveSpec, OutputSpec},
     reporter::{
         ByteSubslice, TestOutputErrorSlice, UnitErrorDescription,
         events::*,
@@ -89,9 +89,32 @@ impl OutputDisplayOverrides {
         self.force_exec_fail_output.unwrap_or(event_setting)
     }
 
+    /// Resolves the output display for a finished test based on its
+    /// [`ExecutionDescription`].
+    ///
+    /// For tests whose last attempt succeeded (including flaky-fail), uses
+    /// `success_output`. For failures, dispatches on the execution result to
+    /// distinguish regular failures from exec-fail.
+    pub(super) fn resolve_for_describe<S: OutputSpec>(
+        &self,
+        success_output: TestOutputDisplay,
+        failure_output: TestOutputDisplay,
+        describe: &ExecutionDescription<'_, S>,
+    ) -> TestOutputDisplay {
+        if describe.is_success_for_output() {
+            self.success_output(success_output)
+        } else {
+            self.resolve_test_output_display(
+                success_output,
+                failure_output,
+                &describe.last_status().result,
+            )
+        }
+    }
+
     /// Resolves the output display setting for a test based on the execution
     /// result, applying any forced overrides.
-    pub(super) fn resolve_test_output_display(
+    fn resolve_test_output_display(
         &self,
         success_output: TestOutputDisplay,
         failure_output: TestOutputDisplay,
@@ -157,18 +180,6 @@ impl UnitOutputReporter {
     /// Returns the output display overrides.
     pub(super) fn overrides(&self) -> OutputDisplayOverrides {
         self.overrides
-    }
-
-    /// Resolves the output display setting for a test based on the execution
-    /// result, applying any forced overrides.
-    pub(super) fn resolve_test_output_display(
-        &self,
-        success_output: TestOutputDisplay,
-        failure_output: TestOutputDisplay,
-        result: &ExecutionResultDescription,
-    ) -> TestOutputDisplay {
-        self.overrides
-            .resolve_test_output_display(success_output, failure_output, result)
     }
 
     pub(super) fn write_child_execution_output(

--- a/nextest-runner/src/reporter/events.rs
+++ b/nextest-runner/src/reporter/events.rs
@@ -591,7 +591,8 @@ pub struct RunStats {
     /// The number of tests that passed on retry.
     pub flaky: usize,
 
-    /// The number of tests that failed. Includes `leaky_failed`.
+    /// The number of tests that failed. Includes `leaky_failed` and tests that
+    /// were flaky but treated as failed due to `flaky-result = "fail"` configuration.
     pub failed: usize,
 
     /// The number of failed tests that were slow.
@@ -727,34 +728,61 @@ impl RunStats {
         let last_status = run_statuses.last_status();
         match last_status.result {
             ExecutionResultDescription::Pass => {
-                self.passed += 1;
-                if last_status.is_slow {
-                    self.passed_slow += 1;
-                }
-                if run_statuses.len() > 1 {
-                    // The test is flaky. How it's counted depends on
-                    // flaky_result — match exhaustively so the compiler
-                    // catches new variants.
+                // The test is flaky if there were multiple attempts. How
+                // it's counted depends on flaky_result — match
+                // exhaustively so the compiler catches new variants.
+                let is_flaky = run_statuses.len() > 1;
+                if is_flaky {
                     match run_statuses.flaky_result() {
+                        FlakyResult::Fail => {
+                            self.failed += 1;
+                            if last_status.is_slow {
+                                self.failed_slow += 1;
+                            }
+                        }
                         FlakyResult::Pass => {
+                            self.passed += 1;
+                            if last_status.is_slow {
+                                self.passed_slow += 1;
+                            }
                             self.flaky += 1;
                         }
+                    }
+                } else {
+                    self.passed += 1;
+                    if last_status.is_slow {
+                        self.passed_slow += 1;
                     }
                 }
             }
             ExecutionResultDescription::Leak {
                 result: LeakTimeoutResult::Pass,
             } => {
-                self.passed += 1;
-                self.leaky += 1;
-                if last_status.is_slow {
-                    self.passed_slow += 1;
-                }
-                if run_statuses.len() > 1 {
+                let is_flaky = run_statuses.len() > 1;
+                if is_flaky {
                     match run_statuses.flaky_result() {
+                        FlakyResult::Fail => {
+                            self.failed += 1;
+                            if last_status.is_slow {
+                                self.failed_slow += 1;
+                            }
+                            // Still count as leaky since the leak was detected.
+                            self.leaky += 1;
+                        }
                         FlakyResult::Pass => {
+                            self.passed += 1;
+                            self.leaky += 1;
+                            if last_status.is_slow {
+                                self.passed_slow += 1;
+                            }
                             self.flaky += 1;
                         }
+                    }
+                } else {
+                    self.passed += 1;
+                    self.leaky += 1;
+                    if last_status.is_slow {
+                        self.passed_slow += 1;
                     }
                 }
             }
@@ -776,14 +804,26 @@ impl RunStats {
             ExecutionResultDescription::Timeout {
                 result: SlowTimeoutResult::Pass,
             } => {
-                self.passed += 1;
-                self.passed_timed_out += 1;
-                if run_statuses.len() > 1 {
+                let is_flaky = run_statuses.len() > 1;
+                if is_flaky {
                     match run_statuses.flaky_result() {
+                        FlakyResult::Fail => {
+                            self.failed += 1;
+                            // Track as failed_slow since the overall result
+                            // is failure.
+                            if last_status.is_slow {
+                                self.failed_slow += 1;
+                            }
+                        }
                         FlakyResult::Pass => {
+                            self.passed += 1;
+                            self.passed_timed_out += 1;
                             self.flaky += 1;
                         }
                     }
+                } else {
+                    self.passed += 1;
+                    self.passed_timed_out += 1;
                 }
             }
             ExecutionResultDescription::Timeout {
@@ -1089,6 +1129,10 @@ impl<'a, S: OutputSpec> ExecutionDescription<'a, S> {
                 result: FlakyResult::Pass,
                 ..
             } => StatusLevel::Retry,
+            ExecutionDescription::Flaky {
+                result: FlakyResult::Fail,
+                ..
+            } => StatusLevel::Fail,
             ExecutionDescription::Failure { .. } => StatusLevel::Fail,
         }
     }
@@ -1118,11 +1162,16 @@ impl<'a, S: OutputSpec> ExecutionDescription<'a, S> {
                     }
                 }
             }
-            // A flaky test implies that we print out retry information.
+            // A flaky-pass test implies that we print out retry information.
             ExecutionDescription::Flaky {
                 result: FlakyResult::Pass,
                 ..
             } => FinalStatusLevel::Flaky,
+            // A flaky-fail test is treated as a failure.
+            ExecutionDescription::Flaky {
+                result: FlakyResult::Fail,
+                ..
+            } => FinalStatusLevel::Fail,
             ExecutionDescription::Failure { .. } => FinalStatusLevel::Fail,
         }
     }
@@ -1130,17 +1179,20 @@ impl<'a, S: OutputSpec> ExecutionDescription<'a, S> {
     /// Returns whether this test's output should be treated as success output
     /// for display and storage purposes.
     ///
-    /// For flaky tests, the last attempt succeeded, so its output is success
-    /// output: it contains no panics or errors, and is generally not
-    /// interesting. The failure information comes from the status line and from
-    /// prior retry attempts' output (shown via `TestAttemptFailedWillRetry`
-    /// events, controlled by `failure-output`).
+    /// For flaky tests (both pass and fail variants), the last attempt
+    /// succeeded, so its output is success output: it contains no panics or
+    /// errors, and is generally not interesting. The failure information comes
+    /// from the status line and from prior retry attempts' output (shown via
+    /// `TestAttemptFailedWillRetry` events, controlled by `failure-output`).
     ///
     /// This means:
     /// - The _visibility_ is controlled by `success-output`.
     /// - The _styling_ is pass/green headers, no error extraction.
     /// - _JUnit storage_ is controlled by `store-success-output` (default:
     ///   `false`).
+    ///
+    /// The status line uses failure semantics independently (e.g. `FLKY-FL` in
+    /// red for flaky-fail tests).
     pub fn is_success_for_output(&self) -> bool {
         match self {
             ExecutionDescription::Success { .. } => true,
@@ -2558,6 +2610,9 @@ mod tests {
             FinalRunStats::NoTestsRun,
             "setup scripts passed => success, but no tests run"
         );
+
+        // Flaky tests with flaky-result = "fail" are included in `failed`, so this
+        // is covered by the general failure tests above.
     }
 
     /// Helper to build a minimal `ExecuteStatus<LiveSpec>` for tests.
@@ -2565,6 +2620,17 @@ mod tests {
         result: ExecutionResultDescription,
         attempt: u32,
         total_attempts: u32,
+    ) -> ExecuteStatus<LiveSpec> {
+        make_execute_status_slow(result, attempt, total_attempts, false)
+    }
+
+    /// Helper to build a minimal `ExecuteStatus<LiveSpec>` for tests, with
+    /// the `is_slow` flag set.
+    fn make_execute_status_slow(
+        result: ExecutionResultDescription,
+        attempt: u32,
+        total_attempts: u32,
+        is_slow: bool,
     ) -> ExecuteStatus<LiveSpec> {
         ExecuteStatus {
             retry_data: RetryData {
@@ -2582,7 +2648,7 @@ mod tests {
             result,
             start_time: chrono::Utc::now().into(),
             time_taken: Duration::from_millis(100),
-            is_slow: false,
+            is_slow,
             delay_before_start: Duration::ZERO,
             error_summary: None,
             output_error_slice: None,
@@ -2630,6 +2696,34 @@ mod tests {
         assert!(
             describe.is_success_for_output(),
             "Flaky pass: output is success output"
+        );
+
+        // Flaky fail: fail then pass with result=fail → true.
+        let fail_status = make_execute_status(
+            ExecutionResultDescription::Fail {
+                failure: FailureDescription::ExitCode { code: 1 },
+                leaked: false,
+            },
+            1,
+            2,
+        );
+        let pass_status = make_execute_status(ExecutionResultDescription::Pass, 2, 2);
+        let flaky_fail_statuses =
+            ExecutionStatuses::new(vec![fail_status, pass_status], FlakyResult::Fail);
+        let describe = flaky_fail_statuses.describe();
+        assert!(
+            matches!(
+                describe,
+                ExecutionDescription::Flaky {
+                    result: FlakyResult::Fail,
+                    ..
+                }
+            ),
+            "fail then pass with FlakyResult::Fail is Flaky Fail"
+        );
+        assert!(
+            describe.is_success_for_output(),
+            "Flaky fail: output is still success output (last attempt passed)"
         );
 
         // Failure: single fail → false.
@@ -2970,5 +3064,176 @@ mod tests {
         insta::assert_snapshot!("timeout_fail", json);
         let roundtrip: ExecutionResultDescription = serde_json::from_str(&json).unwrap();
         assert_eq!(timeout_fail, roundtrip);
+    }
+
+    // --- on_test_finished tests ---
+
+    /// Helper to create a fail-then-pass `ExecutionStatuses` for flaky
+    /// test scenarios.
+    fn make_flaky_statuses(
+        pass_result: ExecutionResultDescription,
+        flaky_result: FlakyResult,
+        is_slow: bool,
+    ) -> ExecutionStatuses<LiveSpec> {
+        let fail = make_execute_status(
+            ExecutionResultDescription::Fail {
+                failure: FailureDescription::ExitCode { code: 1 },
+                leaked: false,
+            },
+            1,
+            2,
+        );
+        let pass = make_execute_status_slow(pass_result, 2, 2, is_slow);
+        ExecutionStatuses::new(vec![fail, pass], flaky_result)
+    }
+
+    /// Helper to run `on_test_finished` on a fresh `RunStats` and return it.
+    fn run_on_test_finished(statuses: &ExecutionStatuses<LiveSpec>) -> RunStats {
+        let mut stats = RunStats {
+            initial_run_count: 1,
+            ..RunStats::default()
+        };
+        stats.on_test_finished(statuses);
+        stats
+    }
+
+    #[test]
+    fn on_test_finished_pass_flaky() {
+        // FlakyResult::Fail (not slow): counts as failed.
+        let stats = run_on_test_finished(&make_flaky_statuses(
+            ExecutionResultDescription::Pass,
+            FlakyResult::Fail,
+            false,
+        ));
+        assert_eq!(stats.finished_count, 1);
+        assert_eq!(stats.failed, 1);
+        assert_eq!(stats.failed_slow, 0, "not slow");
+        assert_eq!(stats.passed, 0);
+        assert_eq!(stats.flaky, 0);
+
+        // FlakyResult::Fail (slow): counts as failed and failed_slow.
+        let stats = run_on_test_finished(&make_flaky_statuses(
+            ExecutionResultDescription::Pass,
+            FlakyResult::Fail,
+            true,
+        ));
+        assert_eq!(stats.failed, 1);
+        assert_eq!(stats.failed_slow, 1);
+        assert_eq!(stats.passed, 0);
+        assert_eq!(stats.flaky, 0);
+
+        // FlakyResult::Pass: counts as passed and flaky.
+        let stats = run_on_test_finished(&make_flaky_statuses(
+            ExecutionResultDescription::Pass,
+            FlakyResult::Pass,
+            true,
+        ));
+        assert_eq!(stats.passed, 1);
+        assert_eq!(stats.passed_slow, 1);
+        assert_eq!(stats.flaky, 1);
+        assert_eq!(stats.failed, 0);
+    }
+
+    #[test]
+    fn on_test_finished_leak_pass_flaky() {
+        // FlakyResult::Fail (not slow): counts as failed and leaky.
+        let stats = run_on_test_finished(&make_flaky_statuses(
+            ExecutionResultDescription::Leak {
+                result: LeakTimeoutResult::Pass,
+            },
+            FlakyResult::Fail,
+            false,
+        ));
+        assert_eq!(stats.failed, 1);
+        assert_eq!(stats.failed_slow, 0, "not slow");
+        assert_eq!(stats.leaky, 1, "leak still tracked");
+        assert_eq!(stats.passed, 0);
+        assert_eq!(stats.flaky, 0);
+
+        // FlakyResult::Fail (slow): also tracks failed_slow.
+        let stats = run_on_test_finished(&make_flaky_statuses(
+            ExecutionResultDescription::Leak {
+                result: LeakTimeoutResult::Pass,
+            },
+            FlakyResult::Fail,
+            true,
+        ));
+        assert_eq!(stats.failed, 1);
+        assert_eq!(stats.failed_slow, 1);
+        assert_eq!(stats.leaky, 1);
+        assert_eq!(stats.passed, 0);
+        assert_eq!(stats.flaky, 0);
+
+        // FlakyResult::Pass: counts as passed, leaky, and flaky.
+        let stats = run_on_test_finished(&make_flaky_statuses(
+            ExecutionResultDescription::Leak {
+                result: LeakTimeoutResult::Pass,
+            },
+            FlakyResult::Pass,
+            true,
+        ));
+        assert_eq!(stats.passed, 1);
+        assert_eq!(stats.passed_slow, 1);
+        assert_eq!(stats.leaky, 1);
+        assert_eq!(stats.flaky, 1);
+        assert_eq!(stats.failed, 0);
+    }
+
+    #[test]
+    fn on_test_finished_timeout_pass_flaky() {
+        // FlakyResult::Fail (slow): counts as failed and failed_slow,
+        // not passed_timed_out.
+        let stats = run_on_test_finished(&make_flaky_statuses(
+            ExecutionResultDescription::Timeout {
+                result: SlowTimeoutResult::Pass,
+            },
+            FlakyResult::Fail,
+            true,
+        ));
+        assert_eq!(stats.failed, 1);
+        assert_eq!(stats.failed_slow, 1);
+        assert_eq!(stats.passed, 0);
+        assert_eq!(stats.passed_timed_out, 0);
+        assert_eq!(stats.flaky, 0);
+
+        // FlakyResult::Pass: counts as passed, passed_timed_out, and flaky.
+        let stats = run_on_test_finished(&make_flaky_statuses(
+            ExecutionResultDescription::Timeout {
+                result: SlowTimeoutResult::Pass,
+            },
+            FlakyResult::Pass,
+            false,
+        ));
+        assert_eq!(stats.passed, 1);
+        assert_eq!(stats.passed_timed_out, 1);
+        assert_eq!(stats.flaky, 1);
+        assert_eq!(stats.failed, 0);
+    }
+
+    #[test]
+    fn on_test_finished_non_flaky() {
+        // Single-attempt pass (slow): counts as passed, not flaky.
+        let pass = make_execute_status_slow(ExecutionResultDescription::Pass, 1, 1, true);
+        let stats = run_on_test_finished(&ExecutionStatuses::new(vec![pass], FlakyResult::Pass));
+        assert_eq!(stats.passed, 1);
+        assert_eq!(stats.passed_slow, 1);
+        assert_eq!(stats.flaky, 0);
+        assert_eq!(stats.failed, 0);
+
+        // Single-attempt failure (slow): counts as failed and failed_slow.
+        let fail = make_execute_status_slow(
+            ExecutionResultDescription::Fail {
+                failure: FailureDescription::ExitCode { code: 1 },
+                leaked: false,
+            },
+            1,
+            1,
+            true,
+        );
+        let stats = run_on_test_finished(&ExecutionStatuses::new(vec![fail], FlakyResult::Pass));
+        assert_eq!(stats.failed, 1);
+        assert_eq!(stats.failed_slow, 1);
+        assert_eq!(stats.passed, 0);
+        assert_eq!(stats.flaky, 0);
     }
 }

--- a/nextest-runner/src/reporter/structured/libtest.rs
+++ b/nextest-runner/src/reporter/structured/libtest.rs
@@ -416,30 +416,45 @@ impl<'cfg> LibtestReporter<'cfg> {
                 )
                 .map_err(fmt_err)?;
 
-                match &last_status.result {
-                    ExecutionResultDescription::Fail { .. }
-                    | ExecutionResultDescription::ExecFail => {
-                        test_suite_mut.failed += 1;
-
-                        // Write the output from the test into the `stdout` (even
-                        // though it could contain stderr output as well).
-                        write!(out, r#","stdout":""#).map_err(fmt_err)?;
-
-                        strip_human_output_from_failed_test(
-                            &last_status.output,
-                            out,
-                            test_instance.test_name,
-                        )?;
-                        out.extend_from_slice(b"\"");
+                // Check for flaky-fail: a test that passed on retry but is
+                // configured to be treated as a failure.
+                let is_flaky_fail = matches!(
+                    run_statuses.describe(),
+                    ExecutionDescription::Flaky {
+                        result: FlakyResult::Fail,
+                        ..
                     }
-                    ExecutionResultDescription::Timeout {
-                        result: SlowTimeoutResult::Fail,
-                    } => {
-                        test_suite_mut.failed += 1;
-                        out.extend_from_slice(br#","reason":"time limit exceeded""#);
-                    }
-                    _ => {
-                        test_suite_mut.succeeded += 1;
+                );
+
+                if is_flaky_fail {
+                    test_suite_mut.failed += 1;
+                    out.extend_from_slice(br#","reason":"flaky test treated as failure""#);
+                } else {
+                    match &last_status.result {
+                        ExecutionResultDescription::Fail { .. }
+                        | ExecutionResultDescription::ExecFail => {
+                            test_suite_mut.failed += 1;
+
+                            // Write the output from the test into the `stdout` (even
+                            // though it could contain stderr output as well).
+                            write!(out, r#","stdout":""#).map_err(fmt_err)?;
+
+                            strip_human_output_from_failed_test(
+                                &last_status.output,
+                                out,
+                                test_instance.test_name,
+                            )?;
+                            out.extend_from_slice(b"\"");
+                        }
+                        ExecutionResultDescription::Timeout {
+                            result: SlowTimeoutResult::Fail,
+                        } => {
+                            test_suite_mut.failed += 1;
+                            out.extend_from_slice(br#","reason":"time limit exceeded""#);
+                        }
+                        _ => {
+                            test_suite_mut.succeeded += 1;
+                        }
                     }
                 }
             }
@@ -566,7 +581,8 @@ impl<'cfg> LibtestReporter<'cfg> {
 
 /// Returns the libtest JSON event string for a finished test.
 ///
-/// Uses `ExecutionDescription` to determine the overall outcome.
+/// Uses `ExecutionDescription` to determine the overall outcome, which
+/// correctly accounts for flaky tests configured with `flaky-result = "fail"`.
 fn event_for_finished_test<S: OutputSpec>(run_statuses: &ExecutionStatuses<S>) -> &'static str {
     match run_statuses.describe() {
         ExecutionDescription::Success { .. }
@@ -574,7 +590,11 @@ fn event_for_finished_test<S: OutputSpec>(run_statuses: &ExecutionStatuses<S>) -
             result: FlakyResult::Pass,
             ..
         } => EVENT_OK,
-        ExecutionDescription::Failure { .. } => EVENT_FAILED,
+        ExecutionDescription::Flaky {
+            result: FlakyResult::Fail,
+            ..
+        }
+        | ExecutionDescription::Failure { .. } => EVENT_FAILED,
     }
 }
 
@@ -1001,6 +1021,17 @@ note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose bac
             event_for_finished_test(&statuses),
             EVENT_OK,
             "flaky with result = pass"
+        );
+
+        // Flaky fail: fail then pass, result = fail.
+        let statuses = ExecutionStatuses::new(
+            vec![make_failing_status(1, 2), make_passing_status(2, 2)],
+            FlakyResult::Fail,
+        );
+        assert_eq!(
+            event_for_finished_test(&statuses),
+            EVENT_FAILED,
+            "flaky with result = fail"
         );
 
         // All retries failed.

--- a/nextest-runner/src/runner/executor.rs
+++ b/nextest-runner/src/runner/executor.rs
@@ -15,7 +15,9 @@ use super::{ChildPid, HandleSignalResult, Interceptor, VersionEnvVars};
 use crate::{
     config::{
         core::EvaluatableProfile,
-        elements::{LeakTimeout, LeakTimeoutResult, RetryPolicy, SlowTimeout, TestGroup},
+        elements::{
+            FlakyResult, LeakTimeout, LeakTimeoutResult, RetryPolicy, SlowTimeout, TestGroup,
+        },
         overrides::TestSettings,
         scripts::{ScriptId, SetupScriptCommand, SetupScriptConfig, SetupScriptExecuteData},
     },
@@ -68,6 +70,9 @@ pub(super) struct ExecutorContext<'a> {
     capture_strategy: CaptureStrategy,
     // This is Some if the user specifies a retry policy over the command-line.
     force_retries: Option<RetryPolicy>,
+    // This is Some if the user specifies flaky result behavior over the
+    // command-line.
+    force_flaky_result: Option<FlakyResult>,
     interceptor: Interceptor,
     version_env_vars: Option<VersionEnvVars>,
 }
@@ -83,6 +88,7 @@ impl<'a> ExecutorContext<'a> {
         target_runner: TargetRunner,
         capture_strategy: CaptureStrategy,
         force_retries: Option<RetryPolicy>,
+        force_flaky_result: Option<FlakyResult>,
         interceptor: Interceptor,
         version_env_vars: Option<VersionEnvVars>,
     ) -> Self {
@@ -95,6 +101,7 @@ impl<'a> ExecutorContext<'a> {
             target_runner,
             capture_strategy,
             force_retries,
+            force_flaky_result,
             interceptor,
             version_env_vars,
         }
@@ -205,7 +212,9 @@ impl<'a> ExecutorContext<'a> {
         let settings = Arc::new(test.settings);
 
         let retry_policy = self.force_retries.unwrap_or_else(|| settings.retries());
-        let flaky_result = settings.flaky_result();
+        let flaky_result = self
+            .force_flaky_result
+            .unwrap_or_else(|| settings.flaky_result());
         let total_attempts = retry_policy.count() + 1;
         let mut backoff_iter = BackoffIter::new(retry_policy);
 

--- a/nextest-runner/src/runner/imp.rs
+++ b/nextest-runner/src/runner/imp.rs
@@ -5,7 +5,7 @@ use super::{DispatcherContext, ExecutorContext, RunnerTaskState};
 use crate::{
     config::{
         core::EvaluatableProfile,
-        elements::{MaxFail, RetryPolicy, TestGroup, TestThreads},
+        elements::{FlakyResult, MaxFail, RetryPolicy, TestGroup, TestThreads},
         scripts::SetupScriptExecuteData,
     },
     double_spawn::DoubleSpawnInfo,
@@ -261,6 +261,7 @@ impl ChildPid {
 pub struct TestRunnerBuilder {
     capture_strategy: CaptureStrategy,
     retries: Option<RetryPolicy>,
+    flaky_result: Option<FlakyResult>,
     max_fail: Option<MaxFail>,
     test_threads: Option<TestThreads>,
     stress_condition: Option<StressCondition>,
@@ -288,6 +289,12 @@ impl TestRunnerBuilder {
     /// Sets the number of retries for this test runner.
     pub fn set_retries(&mut self, retries: RetryPolicy) -> &mut Self {
         self.retries = Some(retries);
+        self
+    }
+
+    /// Sets the flaky result behavior for this test runner.
+    pub fn set_flaky_result(&mut self, flaky_result: FlakyResult) -> &mut Self {
+        self.flaky_result = Some(flaky_result);
         self
     }
 
@@ -378,6 +385,7 @@ impl TestRunnerBuilder {
                 target_runner,
                 capture_strategy: self.capture_strategy,
                 force_retries: self.retries,
+                force_flaky_result: self.flaky_result,
                 cli_args,
                 max_fail,
                 stress_condition: self.stress_condition,
@@ -548,6 +556,7 @@ struct TestRunnerInner<'a> {
     target_runner: TargetRunner,
     capture_strategy: CaptureStrategy,
     force_retries: Option<RetryPolicy>,
+    force_flaky_result: Option<FlakyResult>,
     cli_args: Vec<String>,
     max_fail: MaxFail,
     stress_condition: Option<StressCondition>,
@@ -598,6 +607,7 @@ impl<'a> TestRunnerInner<'a> {
             self.target_runner.clone(),
             self.capture_strategy,
             self.force_retries,
+            self.force_flaky_result,
             self.interceptor.clone(),
             self.version_env_vars.clone(),
         );


### PR DESCRIPTION
There are some use cases where we would like to retry failing tests, but then mark them as failures (and the test as a failure) in the end. Add support for this via both configuration and as `--flaky-result=pass/fail`.

TODO:

- [x] Get a quick-junit release out (this currently uses a local patch)