### PR TITLE
[nextest-runner] make flaky-result a top-level config field

### DIFF
--- a/nextest-runner/default-config.toml
+++ b/nextest-runner/default-config.toml
@@ -21,6 +21,9 @@ default-filter = "all()"
 # * retries = { backoff = "exponential", count = 10, delay = "1s", jitter = true, max-delay = "10s" }
 retries = 0
 
+# Controls whether a flaky test is treated as passing or failing.
+flaky-result = "pass"
+
 # The number of threads to run tests with. Supported values are either an integer or
 # the string "num-cpus". Can be overridden through the `--test-threads` option.
 test-threads = "num-cpus"

--- a/nextest-runner/src/config/core/imp.rs
+++ b/nextest-runner/src/config/core/imp.rs
@@ -7,10 +7,10 @@ use crate::{
         core::ConfigExperimental,
         elements::{
             ArchiveConfig, BenchConfig, CustomTestGroup, DefaultBenchConfig, DefaultJunitImpl,
-            DeserializedRetryPolicy, FlakyResult, GlobalTimeout, Inherits, JunitConfig, JunitImpl,
-            JunitSettings, LeakTimeout, MaxFail, RetryPolicy, SlowTimeout, TestGroup,
-            TestGroupConfig, TestThreads, ThreadsRequired, deserialize_fail_fast,
-            deserialize_leak_timeout, deserialize_retry_policy, deserialize_slow_timeout,
+            FlakyResult, GlobalTimeout, Inherits, JunitConfig, JunitImpl, JunitSettings,
+            LeakTimeout, MaxFail, RetryPolicy, SlowTimeout, TestGroup, TestGroupConfig,
+            TestThreads, ThreadsRequired, deserialize_fail_fast, deserialize_leak_timeout,
+            deserialize_retry_policy, deserialize_slow_timeout,
         },
         overrides::{
             CompiledByProfile, CompiledData, CompiledDefaultFilter, DeserializedOverride,
@@ -1082,20 +1082,12 @@ impl<'cfg> EvaluatableProfile<'cfg> {
 
     /// Returns the retry policy for this profile.
     pub fn retries(&self) -> RetryPolicy {
-        self.custom_profile
-            .iter()
-            .chain(self.inheritance_chain.iter())
-            .find_map(|p| p.retries.as_ref().map(|drp| drp.policy))
-            .unwrap_or(self.default_profile.retries)
+        profile_field!(self.retries)
     }
 
     /// Returns the flaky result behavior for this profile.
     pub fn flaky_result(&self) -> FlakyResult {
-        self.custom_profile
-            .iter()
-            .chain(self.inheritance_chain.iter())
-            .find_map(|p| p.retries.as_ref().and_then(|drp| drp.flaky_result))
-            .unwrap_or(self.default_profile.flaky_result)
+        profile_field!(self.flaky_result)
     }
 
     /// Returns the number of threads to run against for this profile.
@@ -1533,7 +1525,6 @@ pub(in crate::config) struct DefaultProfileImpl {
 
 impl DefaultProfileImpl {
     fn new(p: CustomProfileImpl) -> Self {
-        let deserialized_retries = p.retries.expect("retries present in default profile");
         Self {
             default_filter: p
                 .default_filter
@@ -1547,8 +1538,10 @@ impl DefaultProfileImpl {
             run_extra_args: p
                 .run_extra_args
                 .expect("run-extra-args present in default profile"),
-            retries: deserialized_retries.policy,
-            flaky_result: deserialized_retries.flaky_result.unwrap_or_default(),
+            retries: p.retries.expect("retries present in default profile"),
+            flaky_result: p
+                .flaky_result
+                .expect("flaky-result present in default profile"),
             status_level: p
                 .status_level
                 .expect("status-level present in default profile"),
@@ -1620,7 +1613,9 @@ pub(in crate::config) struct CustomProfileImpl {
     #[serde(default)]
     default_filter: Option<String>,
     #[serde(default, deserialize_with = "deserialize_retry_policy")]
-    retries: Option<DeserializedRetryPolicy>,
+    retries: Option<RetryPolicy>,
+    #[serde(default)]
+    flaky_result: Option<FlakyResult>,
     #[serde(default)]
     test_threads: Option<TestThreads>,
     #[serde(default)]

--- a/nextest-runner/src/config/elements/retry_policy.rs
+++ b/nextest-runner/src/config/elements/retry_policy.rs
@@ -70,20 +70,8 @@ pub enum FlakyResult {
     Pass,
 }
 
-/// Intermediate type for deserializing retry policy from TOML. The
-/// `flaky-result` field is extracted separately from the backoff policy.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub(in crate::config) struct DeserializedRetryPolicy {
-    /// The retry backoff policy.
-    pub(in crate::config) policy: RetryPolicy,
-
-    /// The flaky result behavior, if explicitly set.
-    pub(in crate::config) flaky_result: Option<FlakyResult>,
-}
-
-/// Serde-compatible intermediate type that includes the `flaky-result` field
-/// alongside backoff parameters. After deserialization, the `flaky-result` is
-/// split out into `DeserializedRetryPolicy`.
+/// Serde-compatible intermediate type for the `retries` config field. After
+/// deserialization, this is converted into a `RetryPolicy`.
 #[derive(Debug, Copy, Clone, Deserialize)]
 #[serde(tag = "backoff", rename_all = "kebab-case", deny_unknown_fields)]
 enum RetryPolicySerde {
@@ -108,33 +96,27 @@ enum RetryPolicySerde {
 }
 
 impl RetryPolicySerde {
-    fn into_deserialized(self) -> DeserializedRetryPolicy {
+    fn into_policy(self) -> RetryPolicy {
         match self {
             RetryPolicySerde::Fixed {
                 count,
                 delay,
                 jitter,
-            } => DeserializedRetryPolicy {
-                policy: RetryPolicy::Fixed {
-                    count,
-                    delay,
-                    jitter,
-                },
-                flaky_result: None,
+            } => RetryPolicy::Fixed {
+                count,
+                delay,
+                jitter,
             },
             RetryPolicySerde::Exponential {
                 count,
                 delay,
                 jitter,
                 max_delay,
-            } => DeserializedRetryPolicy {
-                policy: RetryPolicy::Exponential {
-                    count,
-                    delay,
-                    jitter,
-                    max_delay,
-                },
-                flaky_result: None,
+            } => RetryPolicy::Exponential {
+                count,
+                delay,
+                jitter,
+                max_delay,
             },
         }
     }
@@ -142,19 +124,19 @@ impl RetryPolicySerde {
 
 pub(in crate::config) fn deserialize_retry_policy<'de, D>(
     deserializer: D,
-) -> Result<Option<DeserializedRetryPolicy>, D::Error>
+) -> Result<Option<RetryPolicy>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
     struct V;
 
     impl<'de2> serde::de::Visitor<'de2> for V {
-        type Value = Option<DeserializedRetryPolicy>;
+        type Value = Option<RetryPolicy>;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
             write!(
                 formatter,
-                "a table ({{ count = 5, backoff = \"exponential\", delay = \"1s\", max-delay = \"10s\", jitter = true }}) or a number (5)"
+                "a table ({{ backoff = \"fixed\", count = 5 }}) or a number (5)"
             )
         }
 
@@ -171,10 +153,7 @@ where
                             &"a positive u32",
                         )
                     })?;
-                    Ok(Some(DeserializedRetryPolicy {
-                        policy: RetryPolicy::new_without_delay(v),
-                        flaky_result: None,
-                    }))
+                    Ok(Some(RetryPolicy::new_without_delay(v)))
                 }
                 Ordering::Less => Err(serde::de::Error::invalid_value(
                     serde::de::Unexpected::Signed(v),
@@ -188,13 +167,13 @@ where
             A: serde::de::MapAccess<'de2>,
         {
             RetryPolicySerde::deserialize(serde::de::value::MapAccessDeserializer::new(map))
-                .map(|s| Some(s.into_deserialized()))
+                .map(|s| Some(s.into_policy()))
         }
     }
 
     // Post-deserialize validation of retry policy.
-    let deserialized = deserializer.deserialize_any(V)?;
-    match deserialized.as_ref().map(|d| &d.policy) {
+    let policy = deserializer.deserialize_any(V)?;
+    match &policy {
         Some(RetryPolicy::Fixed {
             count: _,
             delay,
@@ -241,7 +220,7 @@ where
         None => {}
     }
 
-    Ok(deserialized)
+    Ok(policy)
 }
 
 #[cfg(test)]
@@ -280,6 +259,13 @@ mod tests {
 
             [profile.exp-with-max-delay-and-jitter]
             retries = { backoff = "exponential", count = 6, delay = "4s", max-delay = "1m", jitter = true }
+
+            [profile.with-flaky-result-pass]
+            retries = { backoff = "fixed", count = 2 }
+            flaky-result = "pass"
+
+            [profile.flaky-result-only]
+            flaky-result = "pass"
         "#};
 
         let workspace_dir = tempdir().unwrap();
@@ -382,6 +368,42 @@ mod tests {
                 max_delay: Some(Duration::from_secs(60)),
             },
             "exp-with-max-delay-and-jitter retries matches"
+        );
+
+        let with_flaky_result_pass = config
+            .profile("with-flaky-result-pass")
+            .expect("profile exists")
+            .apply_build_platforms(&build_platforms());
+        assert_eq!(
+            with_flaky_result_pass.retries(),
+            RetryPolicy::new_without_delay(2),
+            "with-flaky-result-pass retries matches"
+        );
+        assert_eq!(
+            with_flaky_result_pass.flaky_result(),
+            FlakyResult::Pass,
+            "with-flaky-result-pass flaky_result matches"
+        );
+
+        // flaky-result-only: retries inherited from default (count=3), flaky
+        // result set to pass.
+        let flaky_result_only = config
+            .profile("flaky-result-only")
+            .expect("profile exists")
+            .apply_build_platforms(&build_platforms());
+        assert_eq!(
+            flaky_result_only.retries(),
+            RetryPolicy::Fixed {
+                count: 3,
+                delay: Duration::ZERO,
+                jitter: false,
+            },
+            "flaky-result-only retries inherited from default"
+        );
+        assert_eq!(
+            flaky_result_only.flaky_result(),
+            FlakyResult::Pass,
+            "flaky-result-only flaky_result matches"
         );
     }
 
@@ -749,6 +771,226 @@ mod tests {
             settings_for.retries(),
             retries,
             "actual retries don't match expected retries"
+        );
+    }
+
+    #[test]
+    fn overrides_flaky_result() {
+        let config_contents = indoc! {r#"
+            [[profile.default.overrides]]
+            filter = "test(=my_test)"
+            retries = { backoff = "fixed", count = 3 }
+            flaky-result = "pass"
+
+            [[profile.default.overrides]]
+            filter = "test(=other_test)"
+            retries = 2
+
+            [profile.ci]
+        "#};
+        let workspace_dir = tempdir().unwrap();
+
+        let graph = temp_workspace(&workspace_dir, config_contents);
+        let package_id = graph.workspace().iter().next().unwrap().id();
+        let pcx = ParseContext::new(&graph);
+
+        let config = NextestConfig::from_sources(
+            graph.workspace().root(),
+            &pcx,
+            None,
+            &[][..],
+            &Default::default(),
+        )
+        .unwrap();
+
+        let profile = config
+            .profile("ci")
+            .expect("ci profile is defined")
+            .apply_build_platforms(&build_platforms());
+
+        // my_test has flaky-result = "pass" set explicitly.
+        let binary_query = binary_query(
+            &graph,
+            package_id,
+            "lib",
+            "my-binary",
+            BuildPlatform::Target,
+        );
+        let test_name = TestCaseName::new("my_test");
+        let query = TestQuery {
+            binary_query: binary_query.to_query(),
+            test_name: &test_name,
+        };
+        let settings = profile.settings_for(NextestRunMode::Test, &query);
+        assert_eq!(
+            settings.flaky_result(),
+            FlakyResult::Pass,
+            "my_test flaky_result is pass"
+        );
+
+        // other_test uses shorthand retries = 2, which does not set
+        // flaky-result.
+        let test_name = TestCaseName::new("other_test");
+        let query = TestQuery {
+            binary_query: binary_query.to_query(),
+            test_name: &test_name,
+        };
+        let settings = profile.settings_for(NextestRunMode::Test, &query);
+        assert_eq!(
+            settings.flaky_result(),
+            FlakyResult::Pass,
+            "other_test flaky_result defaults to pass"
+        );
+    }
+
+    /// Test that retries and flaky_result resolve independently through the
+    /// override chain. An override that sets only retries should not override
+    /// a flaky_result set by a later (lower-priority) override.
+    #[test]
+    fn overrides_flaky_result_independent_resolution() {
+        let config_contents = indoc! {r#"
+            # Override 1: sets retries count only.
+            [[profile.default.overrides]]
+            filter = "test(=my_test)"
+            retries = 5
+
+            # Override 2: sets retries with flaky-result = "pass".
+            [[profile.default.overrides]]
+            filter = "all()"
+            retries = { backoff = "fixed", count = 2 }
+            flaky-result = "pass"
+
+            [profile.ci]
+        "#};
+        let workspace_dir = tempdir().unwrap();
+
+        let graph = temp_workspace(&workspace_dir, config_contents);
+        let package_id = graph.workspace().iter().next().unwrap().id();
+        let pcx = ParseContext::new(&graph);
+
+        let config = NextestConfig::from_sources(
+            graph.workspace().root(),
+            &pcx,
+            None,
+            &[][..],
+            &Default::default(),
+        )
+        .unwrap();
+
+        let profile = config
+            .profile("ci")
+            .expect("ci profile is defined")
+            .apply_build_platforms(&build_platforms());
+
+        let binary_query = binary_query(
+            &graph,
+            package_id,
+            "lib",
+            "my-binary",
+            BuildPlatform::Target,
+        );
+        let test_name = TestCaseName::new("my_test");
+        let query = TestQuery {
+            binary_query: binary_query.to_query(),
+            test_name: &test_name,
+        };
+        let settings = profile.settings_for(NextestRunMode::Test, &query);
+
+        // Retries count comes from override 1 (higher priority).
+        assert_eq!(
+            settings.retries(),
+            RetryPolicy::new_without_delay(5),
+            "retries count from first override"
+        );
+        // Flaky result comes from override 2 (first override didn't set it).
+        assert_eq!(
+            settings.flaky_result(),
+            FlakyResult::Pass,
+            "flaky_result from second override"
+        );
+    }
+
+    /// Test that `flaky-result = "pass"` (without retries) sets only the flaky
+    /// result, with the retry policy inherited from a lower-priority override.
+    #[test]
+    fn overrides_flaky_result_only() {
+        let config_contents = indoc! {r#"
+            # Override 1: sets only flaky-result, no retry policy.
+            [[profile.default.overrides]]
+            filter = "test(=my_test)"
+            flaky-result = "pass"
+
+            # Override 2: sets retries count for all tests.
+            [[profile.default.overrides]]
+            filter = "all()"
+            retries = 3
+
+            [profile.ci]
+        "#};
+        let workspace_dir = tempdir().unwrap();
+
+        let graph = temp_workspace(&workspace_dir, config_contents);
+        let package_id = graph.workspace().iter().next().unwrap().id();
+        let pcx = ParseContext::new(&graph);
+
+        let config = NextestConfig::from_sources(
+            graph.workspace().root(),
+            &pcx,
+            None,
+            &[][..],
+            &Default::default(),
+        )
+        .unwrap();
+
+        let profile = config
+            .profile("ci")
+            .expect("ci profile is defined")
+            .apply_build_platforms(&build_platforms());
+
+        let binary_query = binary_query(
+            &graph,
+            package_id,
+            "lib",
+            "my-binary",
+            BuildPlatform::Target,
+        );
+        let test_name = TestCaseName::new("my_test");
+        let query = TestQuery {
+            binary_query: binary_query.to_query(),
+            test_name: &test_name,
+        };
+        let settings = profile.settings_for(NextestRunMode::Test, &query);
+
+        // Retries come from override 2 (override 1 didn't set a policy).
+        assert_eq!(
+            settings.retries(),
+            RetryPolicy::new_without_delay(3),
+            "retries from second override"
+        );
+        // Flaky result comes from override 1.
+        assert_eq!(
+            settings.flaky_result(),
+            FlakyResult::Pass,
+            "flaky_result from first override"
+        );
+
+        // For a test that doesn't match override 1, flaky_result defaults to
+        // pass.
+        let test_name = TestCaseName::new("other_test");
+        let query = TestQuery {
+            binary_query: binary_query.to_query(),
+            test_name: &test_name,
+        };
+        let settings = profile.settings_for(NextestRunMode::Test, &query);
+        assert_eq!(
+            settings.retries(),
+            RetryPolicy::new_without_delay(3),
+            "other_test retries from second override"
+        );
+        assert_eq!(
+            settings.flaky_result(),
+            FlakyResult::Pass,
+            "other_test flaky_result defaults to pass"
         );
     }
 }

--- a/nextest-runner/src/config/overrides/imp.rs
+++ b/nextest-runner/src/config/overrides/imp.rs
@@ -7,8 +7,8 @@ use crate::{
             EvaluatableProfile, FinalConfig, NextestConfig, NextestConfigImpl, PreBuildPlatform,
         },
         elements::{
-            DeserializedRetryPolicy, FlakyResult, LeakTimeout, RetryPolicy, SlowTimeout, TestGroup,
-            TestPriority, ThreadsRequired,
+            FlakyResult, LeakTimeout, RetryPolicy, SlowTimeout, TestGroup, TestPriority,
+            ThreadsRequired,
         },
         scripts::{
             CompiledProfileScripts, DeserializedProfileScriptConfig, ScriptId, WrapperScriptConfig,
@@ -809,8 +809,8 @@ impl CompiledOverride<PreBuildPlatform> {
                         priority: source.priority,
                         threads_required: source.threads_required,
                         run_extra_args: source.run_extra_args.clone(),
-                        retries: source.retries.map(|drp| drp.policy),
-                        flaky_result: source.retries.and_then(|drp| drp.flaky_result),
+                        retries: source.retries,
+                        flaky_result: source.flaky_result,
                         slow_timeout: source.slow_timeout,
                         bench_slow_timeout: source.bench.slow_timeout,
                         leak_timeout: source.leak_timeout,
@@ -962,7 +962,9 @@ pub(in crate::config) struct DeserializedOverride {
         default,
         deserialize_with = "crate::config::elements::deserialize_retry_policy"
     )]
-    retries: Option<DeserializedRetryPolicy>,
+    retries: Option<RetryPolicy>,
+    #[serde(default)]
+    flaky_result: Option<FlakyResult>,
     #[serde(
         default,
         deserialize_with = "crate::config::elements::deserialize_slow_timeout"


### PR DESCRIPTION
Having `flaky-result` as part of `retries` adds a lot of friction and confusion because it's resolved separately. Let's make it a separate config field.

This partially reverts #3145.