### PR TITLE
[nextest-runner] add test global and group slots to portable recordings

### DIFF
--- a/nextest-runner/src/config/elements/test_group.rs
+++ b/nextest-runner/src/config/elements/test_group.rs
@@ -5,7 +5,7 @@ use crate::{
     config::{core::ConfigIdentifier, elements::TestThreads},
     errors::InvalidCustomTestGroupName,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use std::{fmt, str::FromStr};
 
@@ -41,13 +41,25 @@ impl TestGroup {
     }
 }
 
+impl Serialize for TestGroup {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            TestGroup::Global => serializer.serialize_str("@global"),
+            TestGroup::Custom(group) => serializer.serialize_str(group.as_str()),
+        }
+    }
+}
+
 impl<'de> Deserialize<'de> for TestGroup {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
         // Try and deserialize the group as a string. (Note: we don't deserialize a
-        // `CustomTestGroup` directly because that errors out on None.
+        // `CustomTestGroup` directly because that errors out on None.)
         let group = SmolStr::deserialize(deserializer)?;
         if group == Self::GLOBAL_STR {
             Ok(TestGroup::Global)

--- a/nextest-runner/src/record/display.rs
+++ b/nextest-runner/src/record/display.rs
@@ -2255,11 +2255,11 @@ mod tests {
             .to_string()
         );
 
-        // Test: store format incompatible (major mismatch).
+        // Test: store format incompatible (archive too new).
         let format_too_new = ReplayabilityStatus::NotReplayable(vec![
             NonReplayableReason::StoreVersionIncompatible {
-                incompatibility: StoreVersionIncompatibility::MajorMismatch {
-                    archive_major: StoreFormatMajorVersion::new(5),
+                incompatibility: StoreVersionIncompatibility::RecordingTooNew {
+                    recording_major: StoreFormatMajorVersion::new(5),
                     supported_major: StoreFormatMajorVersion::new(1),
                 },
             },

--- a/nextest-runner/src/record/format.rs
+++ b/nextest-runner/src/record/format.rs
@@ -117,15 +117,22 @@ impl StoreFormatVersion {
     /// Checks if an archive with version `self` can be read by a reader that
     /// supports `supported`.
     pub fn check_readable_by(self, supported: Self) -> Result<(), StoreVersionIncompatibility> {
-        if self.major != supported.major {
-            return Err(StoreVersionIncompatibility::MajorMismatch {
-                archive_major: self.major,
+        if self.major < supported.major {
+            return Err(StoreVersionIncompatibility::RecordingTooOld {
+                recording_major: self.major,
+                supported_major: supported.major,
+                last_nextest_version: self.major.last_nextest_version(),
+            });
+        }
+        if self.major > supported.major {
+            return Err(StoreVersionIncompatibility::RecordingTooNew {
+                recording_major: self.major,
                 supported_major: supported.major,
             });
         }
         if self.minor > supported.minor {
             return Err(StoreVersionIncompatibility::MinorTooNew {
-                archive_minor: self.minor,
+                recording_minor: self.minor,
                 supported_minor: supported.minor,
             });
         }
@@ -139,21 +146,45 @@ impl fmt::Display for StoreFormatVersion {
     }
 }
 
-/// An incompatibility between an archive's store format version and what the
+impl StoreFormatMajorVersion {
+    /// Returns the last nextest version that supported this store format major
+    /// version, if known.
+    ///
+    /// This is used to provide actionable guidance when an archive is too old
+    /// for the current nextest.
+    pub fn last_nextest_version(self) -> Option<&'static str> {
+        match self.0 {
+            1 => Some("0.9.130"),
+            _ => None,
+        }
+    }
+}
+
+/// An incompatibility between a recording's store format version and what the
 /// reader supports.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum StoreVersionIncompatibility {
-    /// The archive's major version differs from the supported major version.
-    MajorMismatch {
-        /// The major version in the archive.
-        archive_major: StoreFormatMajorVersion,
+    /// The recording's major version is older than the supported major version.
+    RecordingTooOld {
+        /// The major version in the recording.
+        recording_major: StoreFormatMajorVersion,
+        /// The major version this nextest supports.
+        supported_major: StoreFormatMajorVersion,
+        /// The last nextest version that supported the recording's major version,
+        /// if known.
+        last_nextest_version: Option<&'static str>,
+    },
+    /// The recording's major version is newer than the supported major version.
+    RecordingTooNew {
+        /// The major version in the recording.
+        recording_major: StoreFormatMajorVersion,
         /// The major version this nextest supports.
         supported_major: StoreFormatMajorVersion,
     },
-    /// The archive's minor version is newer than the supported minor version.
+    /// The recording's minor version is newer than the supported minor version.
     MinorTooNew {
-        /// The minor version in the archive.
-        archive_minor: StoreFormatMinorVersion,
+        /// The minor version in the recording.
+        recording_minor: StoreFormatMinorVersion,
         /// The maximum minor version this nextest supports.
         supported_minor: StoreFormatMinorVersion,
     },
@@ -162,24 +193,40 @@ pub enum StoreVersionIncompatibility {
 impl fmt::Display for StoreVersionIncompatibility {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::MajorMismatch {
-                archive_major,
+            Self::RecordingTooOld {
+                recording_major,
+                supported_major,
+                last_nextest_version,
+            } => {
+                write!(
+                    f,
+                    "recording has major version {recording_major}, \
+                     but this nextest requires version {supported_major}"
+                )?;
+                if let Some(version) = last_nextest_version {
+                    write!(f, " (use nextest <= {version} to replay this recording)")?;
+                }
+                Ok(())
+            }
+            Self::RecordingTooNew {
+                recording_major,
                 supported_major,
             } => {
                 write!(
                     f,
-                    "major version {} differs from supported version {}",
-                    archive_major, supported_major
+                    "recording has major version {recording_major}, \
+                     but this nextest only supports version {supported_major} \
+                     (upgrade nextest to replay this recording)"
                 )
             }
             Self::MinorTooNew {
-                archive_minor,
+                recording_minor,
                 supported_minor,
             } => {
                 write!(
                     f,
                     "minor version {} is newer than supported version {}",
-                    archive_minor, supported_minor
+                    recording_minor, supported_minor
                 )
             }
         }
@@ -202,9 +249,11 @@ pub(super) const RUNS_JSON_FORMAT_VERSION: RunsJsonFormatVersion = RunsJsonForma
 /// Changelog:
 ///
 /// - 1.1: Addition of the `flaky_result` field to `ExecutionStatuses`.
+/// - 2.0: `slot_assignment` is now mandatory in `TestStarted` and
+///   `TestRetryStarted` events.
 pub const STORE_FORMAT_VERSION: StoreFormatVersion = StoreFormatVersion::new(
-    StoreFormatMajorVersion::new(1),
-    StoreFormatMinorVersion::new(1),
+    StoreFormatMajorVersion::new(2),
+    StoreFormatMinorVersion::new(0),
 );
 
 /// Whether a runs.json.zst file can be written to.
@@ -745,13 +794,13 @@ impl PortableRecordingFormatVersion {
     ) -> Result<(), PortableRecordingVersionIncompatibility> {
         if self.major != supported.major {
             return Err(PortableRecordingVersionIncompatibility::MajorMismatch {
-                archive_major: self.major,
+                recording_major: self.major,
                 supported_major: supported.major,
             });
         }
         if self.minor > supported.minor {
             return Err(PortableRecordingVersionIncompatibility::MinorTooNew {
-                archive_minor: self.minor,
+                recording_minor: self.minor,
                 supported_minor: supported.minor,
             });
         }
@@ -772,14 +821,14 @@ pub enum PortableRecordingVersionIncompatibility {
     /// The archive's major version differs from the supported major version.
     MajorMismatch {
         /// The major version in the archive.
-        archive_major: PortableRecordingFormatMajorVersion,
+        recording_major: PortableRecordingFormatMajorVersion,
         /// The major version this nextest supports.
         supported_major: PortableRecordingFormatMajorVersion,
     },
     /// The archive's minor version is newer than the supported minor version.
     MinorTooNew {
         /// The minor version in the archive.
-        archive_minor: PortableRecordingFormatMinorVersion,
+        recording_minor: PortableRecordingFormatMinorVersion,
         /// The maximum minor version this nextest supports.
         supported_minor: PortableRecordingFormatMinorVersion,
     },
@@ -789,23 +838,23 @@ impl fmt::Display for PortableRecordingVersionIncompatibility {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::MajorMismatch {
-                archive_major,
+                recording_major,
                 supported_major,
             } => {
                 write!(
                     f,
                     "major version {} differs from supported version {}",
-                    archive_major, supported_major
+                    recording_major, supported_major
                 )
             }
             Self::MinorTooNew {
-                archive_minor,
+                recording_minor,
                 supported_minor,
             } => {
                 write!(
                     f,
                     "minor version {} is newer than supported version {}",
-                    archive_minor, supported_minor
+                    recording_minor, supported_minor
                 )
             }
         }
@@ -1256,23 +1305,56 @@ mod tests {
         assert_eq!(
             error,
             StoreVersionIncompatibility::MinorTooNew {
-                archive_minor: StoreFormatMinorVersion::new(3),
+                recording_minor: StoreFormatMinorVersion::new(3),
                 supported_minor: StoreFormatMinorVersion::new(2),
             },
             "newer minor version should be incompatible"
         );
         insta::assert_snapshot!(error.to_string(), @"minor version 3 is newer than supported version 2");
 
+        // Archive newer than supported → RecordingTooNew.
         let error = version(2, 0).check_readable_by(version(1, 5)).unwrap_err();
         assert_eq!(
             error,
-            StoreVersionIncompatibility::MajorMismatch {
-                archive_major: StoreFormatMajorVersion::new(2),
+            StoreVersionIncompatibility::RecordingTooNew {
+                recording_major: StoreFormatMajorVersion::new(2),
                 supported_major: StoreFormatMajorVersion::new(1),
             },
-            "different major version should be incompatible"
         );
-        insta::assert_snapshot!(error.to_string(), @"major version 2 differs from supported version 1");
+        insta::assert_snapshot!(
+            error.to_string(),
+            @"recording has major version 2, but this nextest only supports version 1 (upgrade nextest to replay this recording)"
+        );
+
+        // Archive older than supported → ArchiveTooOld (with known version).
+        let error = version(1, 0).check_readable_by(version(2, 0)).unwrap_err();
+        assert_eq!(
+            error,
+            StoreVersionIncompatibility::RecordingTooOld {
+                recording_major: StoreFormatMajorVersion::new(1),
+                supported_major: StoreFormatMajorVersion::new(2),
+                last_nextest_version: Some("0.9.130"),
+            },
+        );
+        insta::assert_snapshot!(
+            error.to_string(),
+            @"recording has major version 1, but this nextest requires version 2 (use nextest <= 0.9.130 to replay this recording)"
+        );
+
+        // Archive older than supported → ArchiveTooOld (unknown version).
+        let error = version(3, 0).check_readable_by(version(5, 0)).unwrap_err();
+        assert_eq!(
+            error,
+            StoreVersionIncompatibility::RecordingTooOld {
+                recording_major: StoreFormatMajorVersion::new(3),
+                supported_major: StoreFormatMajorVersion::new(5),
+                last_nextest_version: None,
+            },
+        );
+        insta::assert_snapshot!(
+            error.to_string(),
+            @"recording has major version 3, but this nextest requires version 5"
+        );
 
         insta::assert_snapshot!(version(1, 2).to_string(), @"1.2");
     }
@@ -1349,7 +1431,7 @@ mod tests {
         assert_eq!(
             error,
             PortableRecordingVersionIncompatibility::MinorTooNew {
-                archive_minor: PortableRecordingFormatMinorVersion::new(3),
+                recording_minor: PortableRecordingFormatMinorVersion::new(3),
                 supported_minor: PortableRecordingFormatMinorVersion::new(2),
             },
             "newer minor version should be incompatible"
@@ -1362,7 +1444,7 @@ mod tests {
         assert_eq!(
             error,
             PortableRecordingVersionIncompatibility::MajorMismatch {
-                archive_major: PortableRecordingFormatMajorVersion::new(2),
+                recording_major: PortableRecordingFormatMajorVersion::new(2),
                 supported_major: PortableRecordingFormatMajorVersion::new(1),
             },
             "different major version should be incompatible"

--- a/nextest-runner/src/record/replay.rs
+++ b/nextest-runner/src/record/replay.rs
@@ -186,6 +186,7 @@ impl<'a> ReplayContext<'a> {
             CoreEventKind::TestStarted {
                 stress_index,
                 test_instance,
+                slot_assignment,
                 current_stats,
                 running,
                 command_line,
@@ -199,6 +200,7 @@ impl<'a> ReplayContext<'a> {
                 Ok(TestEventKind::TestStarted {
                     stress_index: stress_index.as_ref().map(convert_stress_index),
                     test_instance: instance_id,
+                    slot_assignment: slot_assignment.clone(),
                     current_stats: *current_stats,
                     running: *running,
                     command_line: command_line.clone(),
@@ -230,6 +232,7 @@ impl<'a> ReplayContext<'a> {
             CoreEventKind::TestRetryStarted {
                 stress_index,
                 test_instance,
+                slot_assignment,
                 retry_data,
                 running,
                 command_line,
@@ -243,6 +246,7 @@ impl<'a> ReplayContext<'a> {
                 Ok(TestEventKind::TestRetryStarted {
                     stress_index: stress_index.as_ref().map(convert_stress_index),
                     test_instance: instance_id,
+                    slot_assignment: slot_assignment.clone(),
                     retry_data: *retry_data,
                     running: *running,
                     command_line: command_line.clone(),

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__display__tests__replayability_format_too_new.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__display__tests__replayability_format_too_new.snap
@@ -9,7 +9,7 @@ Run 550e8400-e29b-41d4-a716-446655440000
   started at:       2024-06-15 10:30:00 +00:00 (10d ago)
   last written at:  2024-06-15 10:30:00 +00:00 (10d ago)
   duration:         1.000s
-  replayable:       no: store format version incompatible: major version 5 differs from supported version 1
+  replayable:       no: store format version incompatible: recording has major version 5, but this nextest only supports version 1 (upgrade nextest to replay this recording)
 
   tests:
     passed:         100

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_cancelled.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_cancelled.snap
@@ -4,8 +4,8 @@ expression: json
 ---
 {
   "run-id": "550e8400-e29b-41d4-a716-446655440000",
-  "store-format-version": 1,
-  "store-format-minor-version": 1,
+  "store-format-version": 2,
+  "store-format-minor-version": 0,
   "nextest-version": "0.9.111",
   "started-at": "2024-12-19T14:22:33-08:00",
   "last-written-at": "2024-12-19T22:22:33Z",

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_completed.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_completed.snap
@@ -4,8 +4,8 @@ expression: json
 ---
 {
   "run-id": "550e8400-e29b-41d4-a716-446655440000",
-  "store-format-version": 1,
-  "store-format-minor-version": 1,
+  "store-format-version": 2,
+  "store-format-minor-version": 0,
   "nextest-version": "0.9.111",
   "started-at": "2024-12-19T14:22:33-08:00",
   "last-written-at": "2024-12-19T22:22:33Z",

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_incomplete.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_incomplete.snap
@@ -4,8 +4,8 @@ expression: json
 ---
 {
   "run-id": "550e8400-e29b-41d4-a716-446655440000",
-  "store-format-version": 1,
-  "store-format-minor-version": 1,
+  "store-format-version": 2,
+  "store-format-minor-version": 0,
   "nextest-version": "0.9.111",
   "started-at": "2024-12-19T14:22:33-08:00",
   "last-written-at": "2024-12-19T22:22:33Z",

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_cancelled.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_cancelled.snap
@@ -4,8 +4,8 @@ expression: json
 ---
 {
   "run-id": "550e8400-e29b-41d4-a716-446655440000",
-  "store-format-version": 1,
-  "store-format-minor-version": 1,
+  "store-format-version": 2,
+  "store-format-minor-version": 0,
   "nextest-version": "0.9.111",
   "started-at": "2024-12-19T14:22:33-08:00",
   "last-written-at": "2024-12-19T22:22:33Z",

--- a/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_completed.snap
+++ b/nextest-runner/src/record/snapshots/nextest_runner__record__format__tests__recorded_run_serialize_stress_completed.snap
@@ -4,8 +4,8 @@ expression: json
 ---
 {
   "run-id": "550e8400-e29b-41d4-a716-446655440000",
-  "store-format-version": 1,
-  "store-format-minor-version": 1,
+  "store-format-version": 2,
+  "store-format-minor-version": 0,
   "nextest-version": "0.9.111",
   "started-at": "2024-12-19T14:22:33-08:00",
   "last-written-at": "2024-12-19T22:22:33Z",

--- a/nextest-runner/src/record/summary.rs
+++ b/nextest-runner/src/record/summary.rs
@@ -25,6 +25,7 @@ use crate::{
         events::{
             CancelReason, ExecuteStatus, ExecutionStatuses, RetryData, RunFinishedStats, RunStats,
             SetupScriptExecuteStatus, StressIndex, StressProgress, TestEvent, TestEventKind,
+            TestSlotAssignment,
         },
     },
     run_mode::NextestRunMode,
@@ -217,6 +218,8 @@ pub enum CoreEventKind {
         stress_index: Option<StressIndexSummary>,
         /// The test instance.
         test_instance: OwnedTestInstanceId,
+        /// Scheduling information (slot and group assignment).
+        slot_assignment: TestSlotAssignment,
         /// The current run statistics.
         current_stats: RunStats,
         /// The number of tests currently running.
@@ -248,6 +251,8 @@ pub enum CoreEventKind {
         stress_index: Option<StressIndexSummary>,
         /// The test instance.
         test_instance: OwnedTestInstanceId,
+        /// Scheduling information (slot and group assignment).
+        slot_assignment: TestSlotAssignment,
         /// Retry data.
         retry_data: RetryData,
         /// The number of tests currently running.
@@ -480,12 +485,14 @@ impl TestEventKindSummary<LiveSpec> {
             TestEventKind::TestStarted {
                 stress_index,
                 test_instance,
+                slot_assignment,
                 current_stats,
                 running,
                 command_line,
             } => Self::Core(CoreEventKind::TestStarted {
                 stress_index: stress_index.map(StressIndexSummary::from),
                 test_instance: test_instance.to_owned(),
+                slot_assignment,
                 current_stats,
                 running,
                 command_line,
@@ -506,12 +513,14 @@ impl TestEventKindSummary<LiveSpec> {
             TestEventKind::TestRetryStarted {
                 stress_index,
                 test_instance,
+                slot_assignment,
                 retry_data,
                 running,
                 command_line,
             } => Self::Core(CoreEventKind::TestRetryStarted {
                 stress_index: stress_index.map(StressIndexSummary::from),
                 test_instance: test_instance.to_owned(),
+                slot_assignment,
                 retry_data,
                 running,
                 command_line,

--- a/nextest-runner/src/reporter/displayer/imp.rs
+++ b/nextest-runner/src/reporter/displayer/imp.rs
@@ -948,6 +948,7 @@ impl<'a> DisplayReporterImpl<'a> {
             TestEventKind::TestRetryStarted {
                 stress_index,
                 test_instance,
+                slot_assignment: _,
                 retry_data: RetryData { attempt, .. },
                 running: _,
                 command_line,
@@ -2710,6 +2711,7 @@ mod tests {
                 ChildExecutionOutputDescription, ExecutionResult, FailureStatus,
                 UnitTerminateReason,
             },
+            test_helpers::global_slot_assignment,
         },
         test_output::{ChildExecutionOutput, ChildOutput, ChildSplitOutput},
     };
@@ -4128,6 +4130,7 @@ mod tests {
                                 binary_id: &binary_id,
                                 test_name: &test_name,
                             },
+                            slot_assignment: global_slot_assignment(0),
                             current_stats,
                             running: 1,
                             command_line: vec![
@@ -4150,6 +4153,7 @@ mod tests {
                                 binary_id: &binary_id,
                                 test_name: &test_with_spaces,
                             },
+                            slot_assignment: global_slot_assignment(1),
                             current_stats,
                             running: 2,
                             command_line: vec![
@@ -4173,6 +4177,7 @@ mod tests {
                                 binary_id: &binary_id,
                                 test_name: &test_special_chars,
                             },
+                            slot_assignment: global_slot_assignment(2),
                             current_stats,
                             running: 3,
                             command_line: vec![
@@ -4195,6 +4200,7 @@ mod tests {
                                 binary_id: &binary_id,
                                 test_name: &test_retry,
                             },
+                            slot_assignment: global_slot_assignment(0),
                             retry_data: RetryData {
                                 attempt: 2,
                                 total_attempts: 3,
@@ -4220,6 +4226,7 @@ mod tests {
                                 binary_id: &binary_id,
                                 test_name: &test_retry,
                             },
+                            slot_assignment: global_slot_assignment(0),
                             retry_data: RetryData {
                                 attempt: 3,
                                 total_attempts: 3,

--- a/nextest-runner/src/reporter/displayer/progress.rs
+++ b/nextest-runner/src/reporter/displayer/progress.rs
@@ -916,7 +916,7 @@ mod tests {
     use crate::{
         config::elements::FlakyResult,
         output_spec::LiveSpec,
-        reporter::TestOutputDisplay,
+        reporter::{TestOutputDisplay, test_helpers::global_slot_assignment},
         test_output::{ChildExecutionOutput, ChildOutput, ChildSplitOutput},
     };
     use bytes::Bytes;
@@ -1197,6 +1197,7 @@ mod tests {
                     binary_id: &binary_id,
                     test_name: &test_name,
                 },
+                slot_assignment: global_slot_assignment(0),
                 current_stats: started_stats,
                 running: 3,
                 command_line: vec![],

--- a/nextest-runner/src/reporter/events.rs
+++ b/nextest-runner/src/reporter/events.rs
@@ -11,7 +11,7 @@ use super::{FinalStatusLevel, StatusLevel, TestOutputDisplay};
 use crate::output_spec::ArbitraryOutputSpec;
 use crate::{
     config::{
-        elements::{FlakyResult, LeakTimeoutResult, SlowTimeoutResult},
+        elements::{FlakyResult, LeakTimeoutResult, SlowTimeoutResult, TestGroup},
         scripts::ScriptId,
     },
     errors::{ChildError, ChildFdError, ChildStartError, ErrorList},
@@ -58,6 +58,25 @@ pub struct TestEvent<'a> {
 
     /// The kind of test event this is.
     pub kind: TestEventKind<'a>,
+}
+
+/// Scheduling information about a test's slot and group assignment.
+///
+/// This information is assigned by the `future_queue` scheduler and remains
+/// constant across all retry attempts of the same test.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct TestSlotAssignment {
+    /// The global slot number assigned to this test. Compact: starts from 0
+    /// and is always the smallest available number at assignment time.
+    pub global_slot: u64,
+
+    /// The slot number within this test's group, if the test is in a custom
+    /// group. `None` for tests in the global group.
+    pub group_slot: Option<u64>,
+
+    /// The test group this test belongs to.
+    pub test_group: TestGroup,
 }
 
 /// The kind of test event this is.
@@ -180,6 +199,9 @@ pub enum TestEventKind<'a> {
         /// The test instance that was started.
         test_instance: TestInstanceId<'a>,
 
+        /// Scheduling information (slot and group assignment).
+        slot_assignment: TestSlotAssignment,
+
         /// Current run statistics so far.
         current_stats: RunStats,
 
@@ -238,6 +260,10 @@ pub enum TestEventKind<'a> {
 
         /// The test instance that is being retried.
         test_instance: TestInstanceId<'a>,
+
+        /// Scheduling information (slot and group assignment). Same as the
+        /// initial `TestStarted` event for this test.
+        slot_assignment: TestSlotAssignment,
 
         /// Data related to retries.
         retry_data: RetryData,

--- a/nextest-runner/src/reporter/test_helpers.rs
+++ b/nextest-runner/src/reporter/test_helpers.rs
@@ -3,7 +3,14 @@
 
 //! Test helpers for proptest support in reporter types.
 
-use crate::config::{core::ConfigIdentifier, scripts::ScriptId};
+use crate::{
+    config::{
+        core::ConfigIdentifier,
+        elements::{CustomTestGroup, TestGroup},
+        scripts::ScriptId,
+    },
+    reporter::events::TestSlotAssignment,
+};
 use chrono::{DateTime, FixedOffset, TimeZone, Utc};
 use proptest::prelude::*;
 use smol_str::SmolStr;
@@ -61,5 +68,43 @@ impl Arbitrary for ScriptId {
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         any::<ConfigIdentifier>().prop_map(ScriptId).boxed()
+    }
+}
+
+/// Creates a `TestSlotAssignment` for the global group with the given slot.
+pub fn global_slot_assignment(global_slot: u64) -> TestSlotAssignment {
+    TestSlotAssignment {
+        global_slot,
+        group_slot: None,
+        test_group: TestGroup::Global,
+    }
+}
+
+impl Arbitrary for TestGroup {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        prop_oneof![
+            1 => Just(TestGroup::Global),
+            3 => any::<ConfigIdentifier>()
+                .prop_map(|id| TestGroup::Custom(CustomTestGroup::from_identifier(id))),
+        ]
+        .boxed()
+    }
+}
+
+impl Arbitrary for TestSlotAssignment {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        (any::<u64>(), any::<Option<u64>>(), any::<TestGroup>())
+            .prop_map(|(global_slot, group_slot, test_group)| TestSlotAssignment {
+                global_slot,
+                group_slot,
+                test_group,
+            })
+            .boxed()
     }
 }

--- a/nextest-runner/src/runner/dispatcher.rs
+++ b/nextest-runner/src/runner/dispatcher.rs
@@ -657,6 +657,7 @@ where
             InternalEvent::Executor(ExecutorEvent::Started {
                 stress_index,
                 test_instance,
+                slot_assignment,
                 command_line,
                 req_rx_tx,
                 flaky_result,
@@ -679,6 +680,7 @@ where
                 self.callback_none_response(TestEventKind::TestStarted {
                     stress_index,
                     test_instance: test_instance.id(),
+                    slot_assignment,
                     current_stats: self.run_stats,
                     running: self.running_tests.len(),
                     command_line,
@@ -738,6 +740,7 @@ where
             InternalEvent::Executor(ExecutorEvent::RetryStarted {
                 stress_index,
                 test_instance,
+                slot_assignment,
                 retry_data,
                 command_line,
                 tx,
@@ -760,6 +763,7 @@ where
                 self.callback_none_response(TestEventKind::TestRetryStarted {
                     stress_index,
                     test_instance: test_instance.id(),
+                    slot_assignment,
                     retry_data,
                     running: self.running_tests.len(),
                     command_line,

--- a/nextest-runner/src/runner/executor.rs
+++ b/nextest-runner/src/runner/executor.rs
@@ -26,7 +26,7 @@ use crate::{
     list::{TestExecuteContext, TestInstance, TestInstanceWithSettings, TestList},
     reporter::events::{
         ExecutionResult, FailureStatus, InfoResponse, RetryData, SetupScriptInfoResponse,
-        StressIndex, TestInfoResponse, UnitKind, UnitState,
+        StressIndex, TestInfoResponse, TestSlotAssignment, UnitKind, UnitState,
     },
     runner::{
         ExecutorEvent, InternalExecuteStatus, InternalSetupScriptExecuteStatus,
@@ -234,6 +234,12 @@ impl<'a> ExecutorContext<'a> {
 
         let (req_rx_tx, req_rx_rx) = oneshot::channel();
 
+        let slot_assignment = TestSlotAssignment {
+            global_slot: cx.global_slot(),
+            group_slot: cx.group_slot(),
+            test_group: settings.test_group().clone(),
+        };
+
         let ctx = self.test_execute_context();
         let command_line = test.instance.command_line(
             &ctx,
@@ -247,6 +253,7 @@ impl<'a> ExecutorContext<'a> {
         _ = resp_tx.send(ExecutorEvent::Started {
             stress_index,
             test_instance: test.instance,
+            slot_assignment: slot_assignment.clone(),
             command_line: command_line.clone(),
             req_rx_tx,
             flaky_result,
@@ -278,6 +285,7 @@ impl<'a> ExecutorContext<'a> {
                 _ = resp_tx.send(ExecutorEvent::RetryStarted {
                     stress_index,
                     test_instance: test.instance,
+                    slot_assignment: slot_assignment.clone(),
                     retry_data,
                     command_line: command_line.clone(),
                     tx,

--- a/nextest-runner/src/runner/internal_events.rs
+++ b/nextest-runner/src/runner/internal_events.rs
@@ -21,7 +21,7 @@ use crate::{
         events::{
             ChildExecutionOutputDescription, ErrorSummary, ExecuteStatus, ExecutionResult,
             InfoResponse, OutputErrorSlice, RetryData, SetupScriptEnvMap, SetupScriptExecuteStatus,
-            StressIndex, UnitKind, UnitState,
+            StressIndex, TestSlotAssignment, UnitKind, UnitState,
         },
     },
     signal::ShutdownEvent,
@@ -75,6 +75,7 @@ pub(super) enum ExecutorEvent<'a> {
     Started {
         stress_index: Option<StressIndex>,
         test_instance: TestInstance<'a>,
+        slot_assignment: TestSlotAssignment,
         command_line: Vec<String>,
         // The channel over which to return the unit request.
         //
@@ -107,6 +108,7 @@ pub(super) enum ExecutorEvent<'a> {
     RetryStarted {
         stress_index: Option<StressIndex>,
         test_instance: TestInstance<'a>,
+        slot_assignment: TestSlotAssignment,
         retry_data: RetryData,
         command_line: Vec<String>,
         // This is used to indicate that the dispatcher still wants to run the test.


### PR DESCRIPTION
In the future, we're going to use this information to construct Chrome traces.

This does require a major format bump for portable recordings, but that is fine in these early days.