### PR TITLE
Add link from retries.md to stress-tests.md

### DIFF
--- a/site/src/docs/features/retries.md
+++ b/site/src/docs/features/retries.md
@@ -21,14 +21,14 @@ Sometimes, tests fail nondeterministically, which can be quite annoying to devel
 
 `--retries 2` means that the test is retried twice, for a total of three attempts. In this case, the test fails on the first try but succeeds on the second try. The `TRY 2 PASS` text means that the test passed on the second try.
 
-By default, flaky tests are treated as ultimately successful. If there are no other tests that failed, the exit code for the test run is 0. <!-- md:version 0.9.131 --> To configure failure on flaky tests, see [_Failing flaky tests_](#failing-flaky-tests) below.
-
 Retries can also be:
 
 - passed in via the environment variable `NEXTEST_RETRIES`.
 - [configured in `.config/nextest.toml`](../configuration/index.md).
 
 For the order that configuration parameters are resolved in, see [_Hierarchical configuration_](../configuration/index.md#hierarchical-configuration).
+
+By default, flaky tests are treated as ultimately successful. If there are no other tests that failed, the exit code for the test run is 0. <!-- md:version 0.9.131 --> To configure failure on flaky tests, see [_Failing flaky tests_](#failing-flaky-tests) below. If you know or suspect that a test has a nondeterministic failure case and want to reproduce it by retrying on success (as opposed to retrying only on failure), you may be looking for the [stress tests](./stress-tests.md) feature.
 
 ## Delays and backoff
 


### PR DESCRIPTION
I'm not sure if the added sentence merits placement in a note box for emphasis or even having its own paragraph, so I put it with the existing paragraph that seems most closely related, about treating flaky tests as successful or failing. I also moved that sentence after the bit about retry configuration, because the retry configuration bit seems more appropriate immediately after discussing the retry CLI flag.