### PR TITLE
[nextest-filtering] add group() filterset predicate for CLI filters

### DIFF
--- a/cargo-nextest/src/dispatch/core/archive.rs
+++ b/cargo-nextest/src/dispatch/core/archive.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use camino::Utf8PathBuf;
 use clap::Args;
-use nextest_filtering::{FiltersetKind, ParseContext};
+use nextest_filtering::{FiltersetKind, KnownGroups, ParseContext};
 use nextest_runner::{
     redact::Redactor,
     reuse_build::{ArchiveReporter, PathMapper, apply_archive_filters, archive_to_file},
@@ -116,6 +116,7 @@ impl ArchiveApp {
             &pcx,
             &self.archive_filter.filterset,
             FiltersetKind::TestArchive,
+            &KnownGroups::Unavailable,
         )?;
         let binary_filter = BinaryFilter::new(filtersets);
         let ecx = profile.filterset_ecx();

--- a/cargo-nextest/src/dispatch/core/list.rs
+++ b/cargo-nextest/src/dispatch/core/list.rs
@@ -71,8 +71,13 @@ impl App {
 
         let (version_only_config, config) = self.base.load_config(&pcx, &BTreeSet::new())?;
         let profile = self.base.load_profile(&config)?;
-        let filter_exprs =
-            build_filtersets(&pcx, &self.build_filter.filterset, FiltersetKind::Test)?;
+        let known_groups = profile.known_groups();
+        let filter_exprs = build_filtersets(
+            &pcx,
+            &self.build_filter.filterset,
+            FiltersetKind::Test,
+            &known_groups,
+        )?;
         let test_filter = self
             .build_filter
             .make_test_filter(NextestRunMode::Test, filter_exprs)?;
@@ -165,8 +170,13 @@ impl App {
         };
         let settings = ShowTestGroupSettings { mode, show_default };
 
-        let filter_exprs =
-            build_filtersets(&pcx, &self.build_filter.filterset, FiltersetKind::Test)?;
+        let known_groups = profile.known_groups();
+        let filter_exprs = build_filtersets(
+            &pcx,
+            &self.build_filter.filterset,
+            FiltersetKind::Test,
+            &known_groups,
+        )?;
         let test_filter = self
             .build_filter
             .make_test_filter(NextestRunMode::Test, filter_exprs)?;

--- a/cargo-nextest/src/dispatch/core/run.rs
+++ b/cargo-nextest/src/dispatch/core/run.rs
@@ -947,8 +947,13 @@ impl App {
         );
         reporter_builder.set_verbose(self.base.output.verbose);
 
-        let filter_exprs =
-            build_filtersets(&pcx, &self.build_filter.filterset, FiltersetKind::Test)?;
+        let known_groups = profile.known_groups();
+        let filter_exprs = build_filtersets(
+            &pcx,
+            &self.build_filter.filterset,
+            FiltersetKind::Test,
+            &known_groups,
+        )?;
         let mut test_filter = self
             .build_filter
             .make_test_filter(NextestRunMode::Test, filter_exprs)?;
@@ -1231,8 +1236,13 @@ impl App {
             reporter_opts.to_builder(should_colorize, &resolved_user_config.ui);
         reporter_builder.set_verbose(self.base.output.verbose);
 
-        let filter_exprs =
-            build_filtersets(&pcx, &self.build_filter.filterset, FiltersetKind::Test)?;
+        let known_groups = profile.known_groups();
+        let filter_exprs = build_filtersets(
+            &pcx,
+            &self.build_filter.filterset,
+            FiltersetKind::Test,
+            &known_groups,
+        )?;
         let test_filter = self
             .build_filter
             .make_test_filter(NextestRunMode::Benchmark, filter_exprs)?;

--- a/cargo-nextest/src/dispatch/helpers.rs
+++ b/cargo-nextest/src/dispatch/helpers.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use camino::{Utf8Path, Utf8PathBuf};
 use itertools::Itertools;
-use nextest_filtering::{Filterset, FiltersetKind, ParseContext};
+use nextest_filtering::{Filterset, FiltersetKind, KnownGroups, ParseContext};
 use nextest_runner::{
     RustcCli,
     cargo_config::{CargoConfigs, TargetTriple},
@@ -172,10 +172,11 @@ pub(super) fn build_filtersets(
     pcx: &ParseContext<'_>,
     filter_set: &[String],
     kind: FiltersetKind,
+    known_groups: &KnownGroups,
 ) -> Result<Vec<Filterset>> {
     let (exprs, all_errors): (Vec<_>, Vec<_>) = filter_set
         .iter()
-        .map(|input| Filterset::parse(input.clone(), pcx, kind))
+        .map(|input| Filterset::parse(input.clone(), pcx, kind, known_groups))
         .partition_result();
 
     if !all_errors.is_empty() {

--- a/cargo-nextest/src/dispatch/utility/debug.rs
+++ b/cargo-nextest/src/dispatch/utility/debug.rs
@@ -10,6 +10,8 @@ use crate::{
 };
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::{Args, Subcommand, ValueEnum};
+use guppy::graph::PackageGraph;
+use nextest_filtering::{FiltersetKind, KnownGroups};
 use nextest_runner::{
     cargo_config::CargoConfigs,
     errors::{DisplayErrorChain, RecordReadError},
@@ -21,7 +23,7 @@ use nextest_runner::{
     redact::Redactor,
     user_config::elements::MAX_MAX_OUTPUT_SIZE,
 };
-use std::{fmt, fs};
+use std::{collections::HashSet, fmt, fs};
 use tracing::{error, warn};
 
 /// Debug subcommands.
@@ -69,6 +71,12 @@ pub(crate) enum DebugCommand {
 
     /// Extract metadata files from a portable recording.
     ExtractPortableRecording(ExtractPortableRecordingOpts),
+
+    /// Parse and compile a filterset expression, displaying the result or errors.
+    ///
+    /// This is useful for testing how filterset expressions are validated in
+    /// different contexts.
+    ParseFilterset(ParseFiltersetOpts),
 }
 
 impl DebugCommand {
@@ -156,6 +164,9 @@ impl DebugCommand {
                 }
             }
             DebugCommand::ExtractPortableRecording(opts) => {
+                return opts.exec();
+            }
+            DebugCommand::ParseFilterset(opts) => {
                 return opts.exec();
             }
         }
@@ -336,6 +347,103 @@ impl ExtractPortableRecordingOpts {
             })
         } else {
             Ok(0)
+        }
+    }
+}
+
+/// The empty graph JSON used when no `--cargo-metadata` is provided.
+const EMPTY_GRAPH: &str = r#"{
+    "packages": [],
+    "workspace_members": [],
+    "workspace_root": "",
+    "target_directory": "",
+    "version": 1
+}"#;
+
+/// Options for `nextest debug parse-filterset`.
+#[derive(Debug, Args)]
+pub(crate) struct ParseFiltersetOpts {
+    /// The filterset expression to parse.
+    expression: String,
+
+    /// The kind of filterset context to parse the expression in.
+    #[arg(long, value_enum)]
+    kind: FiltersetKindArg,
+
+    /// Path to a cargo metadata JSON file.
+    ///
+    /// If not provided, an empty workspace graph is used. This is sufficient for
+    /// checking banned predicates, but expressions referencing specific packages
+    /// will report no-match warnings.
+    #[arg(long)]
+    cargo_metadata: Option<Utf8PathBuf>,
+}
+
+impl ParseFiltersetOpts {
+    fn exec(self) -> Result<i32> {
+        let json = match &self.cargo_metadata {
+            Some(path) => {
+                fs::read_to_string(path).map_err(|err| ExpectedError::CargoMetadataReadError {
+                    path: path.clone(),
+                    err,
+                })?
+            }
+            None => EMPTY_GRAPH.to_string(),
+        };
+
+        let graph = PackageGraph::from_json(json).map_err(|err| {
+            ExpectedError::CargoMetadataParseError {
+                file_name: self.cargo_metadata.clone(),
+                err,
+            }
+        })?;
+
+        let kind: FiltersetKind = self.kind.into();
+        let cx = nextest_filtering::ParseContext::new(&graph);
+        // The debug command doesn't load config, so no custom groups are
+        // known. @global is always implicitly valid.
+        let known_groups = KnownGroups::Known {
+            custom_groups: HashSet::new(),
+        };
+
+        match nextest_filtering::Filterset::parse(self.expression, &cx, kind, &known_groups) {
+            Ok(expr) => {
+                println!("{expr:?}");
+                Ok(0)
+            }
+            Err(errors) => {
+                for single_error in &errors.errors {
+                    let report = miette::Report::new(single_error.clone())
+                        .with_source_code(errors.input.clone());
+                    error!(target: "cargo_nextest::no_heading", "{report:?}");
+                }
+                error!("failed to parse filterset");
+                Ok(1)
+            }
+        }
+    }
+}
+
+/// The kind of filterset context, as a CLI argument.
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub(crate) enum FiltersetKindArg {
+    /// A test filterset (used with `nextest run -E` or `nextest list -E`).
+    Test,
+    /// An override filter in a config profile.
+    OverrideFilter,
+    /// A test archive filterset (used with `nextest archive -E`).
+    ArchiveFilter,
+    /// A default-filter filterset (used in profile configuration).
+    DefaultFilter,
+}
+
+impl From<FiltersetKindArg> for FiltersetKind {
+    fn from(arg: FiltersetKindArg) -> Self {
+        match arg {
+            FiltersetKindArg::Test => FiltersetKind::Test,
+            FiltersetKindArg::OverrideFilter => FiltersetKind::OverrideFilter,
+            FiltersetKindArg::ArchiveFilter => FiltersetKind::TestArchive,
+            FiltersetKindArg::DefaultFilter => FiltersetKind::DefaultFilter,
         }
     }
 }

--- a/cargo-nextest/src/errors.rs
+++ b/cargo-nextest/src/errors.rs
@@ -190,6 +190,12 @@ pub enum ExpectedError {
         #[source]
         err: PathMapperConstructError,
     },
+    #[error("cargo metadata read error")]
+    CargoMetadataReadError {
+        path: Utf8PathBuf,
+        #[source]
+        err: std::io::Error,
+    },
     #[error("cargo metadata parse error")]
     CargoMetadataParseError {
         file_name: Option<Utf8PathBuf>,
@@ -597,6 +603,7 @@ impl ExpectedError {
             | Self::PathMapperConstructError { .. }
             | Self::TestRunnerBuildError { .. }
             | Self::ConfigureHandleInheritanceError { .. }
+            | Self::CargoMetadataReadError { .. }
             | Self::CargoMetadataParseError { .. }
             | Self::TestBinaryArgsParseError { .. }
             | Self::SignalHandlerSetupError { .. }
@@ -1001,6 +1008,13 @@ impl ExpectedError {
                     "argument {} specified `{}` that couldn't be read",
                     format!("--{arg_name}").style(styles.bold),
                     err.input().style(styles.bold)
+                );
+                Some(err as &dyn Error)
+            }
+            Self::CargoMetadataReadError { path, err } => {
+                error!(
+                    "error reading Cargo metadata from file `{}`",
+                    path.style(styles.bold),
                 );
                 Some(err as &dyn Error)
             }

--- a/integration-tests/tests/integration/main.rs
+++ b/integration-tests/tests/integration/main.rs
@@ -3011,3 +3011,40 @@ fn test_run_with_target_runner() {
         RunProperties::WITH_TARGET_RUNNER,
     );
 }
+
+// ---
+// `debug parse-filterset` banned predicate tests
+// ---
+
+/// Helper to run `debug parse-filterset` and return the output.
+fn run_parse_filterset(env_info: &TestEnvInfo, kind: &str, expression: &str) -> CargoNextestOutput {
+    CargoNextestCli::for_test(env_info)
+        .args(["debug", "parse-filterset", "--kind", kind, expression])
+        .unchecked(true)
+        .output()
+}
+
+#[test]
+fn test_banned_predicates() {
+    let env_info = set_env_vars_for_test();
+
+    // group() in override-filter: circular dependency.
+    let output = run_parse_filterset(&env_info, "override-filter", "group(serial)");
+    insta::assert_snapshot!("banned_group_in_override_filter", output.stderr_as_str());
+
+    // group() in default-filter: not available.
+    let output = run_parse_filterset(&env_info, "default-filter", "group(serial)");
+    insta::assert_snapshot!("banned_group_in_default_filter", output.stderr_as_str());
+
+    // group() in archive-filter: not supported while archiving.
+    let output = run_parse_filterset(&env_info, "archive-filter", "group(serial)");
+    insta::assert_snapshot!("banned_group_in_archive_filter", output.stderr_as_str());
+
+    // test() in archive-filter: not supported while archiving.
+    let output = run_parse_filterset(&env_info, "archive-filter", "test(foo)");
+    insta::assert_snapshot!("banned_test_in_archive_filter", output.stderr_as_str());
+
+    // default() in default-filter: infinite recursion.
+    let output = run_parse_filterset(&env_info, "default-filter", "default()");
+    insta::assert_snapshot!("banned_default_in_default_filter", output.stderr_as_str());
+}

--- a/integration-tests/tests/integration/snapshots/integration__banned_default_in_default_filter.snap
+++ b/integration-tests/tests/integration/snapshots/integration__banned_default_in_default_filter.snap
@@ -1,0 +1,12 @@
+---
+source: integration-tests/tests/integration/main.rs
+expression: output.stderr_as_str()
+---
+  error: predicate not allowed in `default-filter` expressions
+   ╭────
+ 1 │ default()
+   · ────┬────
+   ·     ╰── default() causes infinite recursion
+   ╰────
+
+error: failed to parse filterset

--- a/integration-tests/tests/integration/snapshots/integration__banned_group_in_archive_filter.snap
+++ b/integration-tests/tests/integration/snapshots/integration__banned_group_in_archive_filter.snap
@@ -1,13 +1,12 @@
 ---
 source: integration-tests/tests/integration/main.rs
-assertion_line: 1305
 expression: output.stderr_as_str()
 ---
   error: predicate not allowed in `archive-filter` expressions
    ╭────
- 1 │ test(sample_test)
-   ·      ─────┬─────
-   ·           ╰── test() predicates are not supported while archiving
+ 1 │ group(serial)
+   ·       ───┬──
+   ·          ╰── group() predicates are not supported while archiving
    ╰────
 
 error: failed to parse filterset

--- a/integration-tests/tests/integration/snapshots/integration__banned_group_in_default_filter.snap
+++ b/integration-tests/tests/integration/snapshots/integration__banned_group_in_default_filter.snap
@@ -1,0 +1,12 @@
+---
+source: integration-tests/tests/integration/main.rs
+expression: output.stderr_as_str()
+---
+  error: predicate not allowed in `default-filter` expressions
+   ╭────
+ 1 │ group(serial)
+   ·       ───┬──
+   ·          ╰── group() is not available in default-filter expressions
+   ╰────
+
+error: failed to parse filterset

--- a/integration-tests/tests/integration/snapshots/integration__banned_group_in_override_filter.snap
+++ b/integration-tests/tests/integration/snapshots/integration__banned_group_in_override_filter.snap
@@ -1,0 +1,12 @@
+---
+source: integration-tests/tests/integration/main.rs
+expression: output.stderr_as_str()
+---
+  error: predicate not allowed in `override-filter` expressions
+   ╭────
+ 1 │ group(serial)
+   ·       ───┬──
+   ·          ╰── group() creates a circular dependency with overrides
+   ╰────
+
+error: failed to parse filterset

--- a/integration-tests/tests/integration/snapshots/integration__banned_test_in_archive_filter.snap
+++ b/integration-tests/tests/integration/snapshots/integration__banned_test_in_archive_filter.snap
@@ -1,13 +1,12 @@
 ---
 source: integration-tests/tests/integration/main.rs
-assertion_line: 1305
 expression: output.stderr_as_str()
 ---
   error: predicate not allowed in `archive-filter` expressions
    ╭────
- 1 │ test(sample_test)
-   ·      ─────┬─────
-   ·           ╰── test() predicates are not supported while archiving
+ 1 │ test(foo)
+   ·      ─┬─
+   ·       ╰── test() predicates are not supported while archiving
    ╰────
 
 error: failed to parse filterset

--- a/nextest-filtering/examples/parser.rs
+++ b/nextest-filtering/examples/parser.rs
@@ -58,6 +58,9 @@ fn main() {
         args.expr,
         &cx,
         nextest_filtering::FiltersetKind::Test,
+        &nextest_filtering::KnownGroups::Known {
+            custom_groups: std::collections::HashSet::new(),
+        },
     ) {
         Ok(expr) => println!("{expr:?}"),
         Err(FiltersetParseErrors { input, errors, .. }) => {

--- a/nextest-filtering/src/compile.rs
+++ b/nextest-filtering/src/compile.rs
@@ -19,13 +19,22 @@ pub(crate) fn compile(
     expr: &ParsedExpr,
     cx: &ParseContext<'_>,
     kind: FiltersetKind,
+    known_groups: &KnownGroups,
 ) -> Result<CompiledExpr, Vec<ParseSingleError>> {
     let mut errors = vec![];
     check_banned_predicates(expr, kind, &mut errors);
 
+    // Return early if banned predicates were found. This ensures that
+    // KnownGroups::Unavailable never reaches group validation during
+    // normal operation (the ban check catches group() first), and avoids
+    // mixing ban errors with unrelated validation errors.
+    if !errors.is_empty() {
+        return Err(errors);
+    }
+
     let cx_cache = cx.make_cache();
     let mut cache = cx.graph().new_depends_cache();
-    let expr = compile_expr(expr, cx_cache, &mut cache, &mut errors);
+    let expr = compile_expr(expr, cx_cache, known_groups, &mut cache, &mut errors);
 
     if errors.is_empty() {
         Ok(expr)
@@ -41,29 +50,63 @@ fn check_banned_predicates(
 ) {
     match kind {
         FiltersetKind::Test => {}
-        FiltersetKind::TestArchive => {
-            // The `test` predicate is unsupported for a test archive since we need to
-            // package the whole binary and it may be cross-compiled.
+        FiltersetKind::OverrideFilter => {
+            // The `group` predicate is banned in override filters because group
+            // membership is determined by overrides themselves, creating a
+            // circular dependency.
             Wrapped(expr).collapse_frames(|layer: ExprFrame<&ParsedLeaf, ()>| {
-                if let ExprFrame::Set(ParsedLeaf::Test(_, span)) = layer {
+                if let ExprFrame::Set(ParsedLeaf::Group(_, span)) = layer {
                     errors.push(ParseSingleError::BannedPredicate {
                         kind,
                         span: *span,
-                        reason: BannedPredicateReason::Unsupported,
+                        reason: BannedPredicateReason::GroupCircularDependency,
                     });
                 }
             })
         }
-        FiltersetKind::DefaultFilter => {
-            // The `default` predicate is banned.
-            Wrapped(expr).collapse_frames(|layer: ExprFrame<&ParsedLeaf, ()>| {
-                if let ExprFrame::Set(ParsedLeaf::Default(span)) = layer {
+        FiltersetKind::TestArchive => {
+            // The `test` and `group` predicates are unsupported for a
+            // test archive since we need to package the whole binary
+            // and it may be cross-compiled.
+            Wrapped(expr).collapse_frames(|layer: ExprFrame<&ParsedLeaf, ()>| match layer {
+                ExprFrame::Set(ParsedLeaf::Test(_, span)) => {
                     errors.push(ParseSingleError::BannedPredicate {
                         kind,
                         span: *span,
-                        reason: BannedPredicateReason::InfiniteRecursion,
+                        reason: BannedPredicateReason::TestNotAvailableInArchive,
                     });
                 }
+                ExprFrame::Set(ParsedLeaf::Group(_, span)) => {
+                    errors.push(ParseSingleError::BannedPredicate {
+                        kind,
+                        span: *span,
+                        reason: BannedPredicateReason::GroupNotAvailableInArchive,
+                    });
+                }
+                _ => {}
+            })
+        }
+        FiltersetKind::DefaultFilter => {
+            // The `default` and `group` predicates are banned: `default`
+            // because it would cause infinite recursion, and `group`
+            // because group membership is not available in the default
+            // filter context.
+            Wrapped(expr).collapse_frames(|layer: ExprFrame<&ParsedLeaf, ()>| match layer {
+                ExprFrame::Set(ParsedLeaf::Default(span)) => {
+                    errors.push(ParseSingleError::BannedPredicate {
+                        kind,
+                        span: *span,
+                        reason: BannedPredicateReason::DefaultInfiniteRecursion,
+                    });
+                }
+                ExprFrame::Set(ParsedLeaf::Group(_, span)) => {
+                    errors.push(ParseSingleError::BannedPredicate {
+                        kind,
+                        span: *span,
+                        reason: BannedPredicateReason::GroupNotAvailableInDefaultFilter,
+                    });
+                }
+                _ => {}
             })
         }
     }
@@ -125,6 +168,7 @@ fn rdependencies_packages(
 fn compile_set_def(
     set: &ParsedLeaf,
     cx_cache: &ParseContextCache<'_>,
+    known_groups: &KnownGroups,
     cache: &mut DependsCache<'_>,
     errors: &mut Vec<ParseSingleError>,
 ) -> FiltersetLeaf {
@@ -155,6 +199,10 @@ fn compile_set_def(
         ),
         ParsedLeaf::Platform(platform, span) => FiltersetLeaf::Platform(*platform, *span),
         ParsedLeaf::Test(matcher, span) => FiltersetLeaf::Test(matcher.clone(), *span),
+        ParsedLeaf::Group(matcher, span) => FiltersetLeaf::Group(
+            expect_known_group(matcher, known_groups, *span, errors),
+            *span,
+        ),
         ParsedLeaf::Default(_) => FiltersetLeaf::Default,
         ParsedLeaf::All => FiltersetLeaf::All,
         ParsedLeaf::None => FiltersetLeaf::None,
@@ -216,16 +264,29 @@ fn expect_non_empty_binary_ids(
     matcher.clone()
 }
 
+fn expect_known_group(
+    matcher: &NameMatcher,
+    known_groups: &KnownGroups,
+    span: SourceSpan,
+    errors: &mut Vec<ParseSingleError>,
+) -> NameMatcher {
+    if !known_groups.matches(matcher) {
+        errors.push(ParseSingleError::NoGroupMatch(span));
+    }
+    matcher.clone()
+}
+
 fn compile_expr(
     expr: &ParsedExpr,
     cx_cache: &ParseContextCache<'_>,
+    known_groups: &KnownGroups,
     cache: &mut DependsCache<'_>,
     errors: &mut Vec<ParseSingleError>,
 ) -> CompiledExpr {
     use crate::expression::ExprFrame::*;
 
     Wrapped(expr).collapse_frames(|layer: ExprFrame<&ParsedLeaf, CompiledExpr>| match layer {
-        Set(set) => CompiledExpr::Set(compile_set_def(set, cx_cache, cache, errors)),
+        Set(set) => CompiledExpr::Set(compile_set_def(set, cx_cache, known_groups, cache, errors)),
         Not(expr) => CompiledExpr::Not(Box::new(expr)),
         Union(expr_1, expr_2) => CompiledExpr::Union(Box::new(expr_1), Box::new(expr_2)),
         Intersection(expr_1, expr_2) => {

--- a/nextest-filtering/src/errors.rs
+++ b/nextest-filtering/src/errors.rs
@@ -122,6 +122,10 @@ pub enum ParseSingleError {
     #[error("operator didn't match any packages")]
     NoPackageMatch(#[label("no packages matched this")] SourceSpan),
 
+    /// This matcher didn't match any test groups.
+    #[error("operator didn't match any test groups")]
+    NoGroupMatch(#[label("no test groups matched this")] SourceSpan),
+
     /// This matcher didn't match any binary IDs.
     #[error("operator didn't match any binary IDs")]
     NoBinaryIdMatch(#[label("no binary IDs matched this")] SourceSpan),
@@ -199,19 +203,39 @@ impl<'a> State<'a> {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum BannedPredicateReason {
-    /// This predicate causes infinite recursion.
-    InfiniteRecursion,
-    /// This predicate is unsupported.
-    Unsupported,
+    /// `default()` causes infinite recursion in a default filter.
+    DefaultInfiniteRecursion,
+
+    /// `group()` creates a circular dependency in override filters, because
+    /// group membership is determined by overrides themselves.
+    GroupCircularDependency,
+
+    /// `group()` is not available in default-filter expressions.
+    GroupNotAvailableInDefaultFilter,
+
+    /// `group()` predicates are not supported while archiving.
+    GroupNotAvailableInArchive,
+
+    /// `test()` predicates are not supported while archiving.
+    TestNotAvailableInArchive,
 }
 
 impl fmt::Display for BannedPredicateReason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            BannedPredicateReason::InfiniteRecursion => {
-                write!(f, "this predicate causes infinite recursion")
+            BannedPredicateReason::DefaultInfiniteRecursion => {
+                write!(f, "default() causes infinite recursion")
             }
-            BannedPredicateReason::Unsupported => {
+            BannedPredicateReason::GroupCircularDependency => {
+                write!(f, "group() creates a circular dependency with overrides")
+            }
+            BannedPredicateReason::GroupNotAvailableInDefaultFilter => {
+                write!(f, "group() is not available in default-filter expressions")
+            }
+            BannedPredicateReason::GroupNotAvailableInArchive => {
+                write!(f, "group() predicates are not supported while archiving")
+            }
+            BannedPredicateReason::TestNotAvailableInArchive => {
                 write!(f, "test() predicates are not supported while archiving")
             }
         }

--- a/nextest-filtering/src/expression.rs
+++ b/nextest-filtering/src/expression.rs
@@ -124,6 +124,8 @@ pub enum FiltersetLeaf {
     BinaryId(NameMatcher, SourceSpan),
     /// All tests matching a name
     Test(NameMatcher, SourceSpan),
+    /// All tests in the named test group.
+    Group(NameMatcher, SourceSpan),
     /// The default set of tests to run.
     Default,
     /// All tests
@@ -139,8 +141,19 @@ impl FiltersetLeaf {
     /// Currently, this also returns true (conservatively) for the `Default`
     /// leaf, which is used to represent the default set of tests to run.
     pub fn is_runtime_only(&self) -> bool {
-        matches!(self, Self::Test(_, _) | Self::Default)
+        matches!(self, Self::Test(_, _) | Self::Group(_, _) | Self::Default)
     }
+}
+
+/// Trait for looking up test group membership during filterset evaluation.
+///
+/// Implemented in `nextest-runner` and passed to
+/// [`CompiledExpr::matches_test_with_groups`] to resolve `group()`
+/// predicates.
+pub trait GroupLookup: fmt::Debug {
+    /// Returns true if the given test is a member of a group matching
+    /// the provided name matcher.
+    fn is_member_test(&self, test: &TestQuery<'_>, matcher: &NameMatcher) -> bool;
 }
 
 /// A query for a binary, passed into [`Filterset::matches_binary`].
@@ -225,10 +238,39 @@ impl CompiledExpr {
     }
 
     /// Returns true if the given test is accepted by this filterset.
+    ///
+    /// If a `group()` predicate is encountered, this method panics.
+    /// Only use this for expressions that are guaranteed group-free
+    /// (i.e. compiled with any [`FiltersetKind`] other than
+    /// [`FiltersetKind::Test`], or Test expressions where
+    /// [`has_group_matchers`](Self::has_group_matchers) returns false).
     pub fn matches_test(&self, query: &TestQuery<'_>, cx: &EvalContext<'_>) -> bool {
+        self.matches_test_impl(query, cx, &NoGroups)
+    }
+
+    /// Returns true if the given test is accepted by this filterset,
+    /// resolving `group()` predicates via the provided lookup.
+    ///
+    /// Use this for [`FiltersetKind::Test`] expressions that contain
+    /// `group()` predicates.
+    pub fn matches_test_with_groups(
+        &self,
+        query: &TestQuery<'_>,
+        cx: &EvalContext<'_>,
+        groups: &dyn GroupLookup,
+    ) -> bool {
+        self.matches_test_impl(query, cx, &WithGroups(groups))
+    }
+
+    fn matches_test_impl(
+        &self,
+        query: &TestQuery<'_>,
+        cx: &EvalContext<'_>,
+        groups: &impl GroupResolver,
+    ) -> bool {
         use ExprFrame::*;
         Wrapped(self).collapse_frames(|layer: ExprFrame<&FiltersetLeaf, bool>| match layer {
-            Set(set) => set.matches_test(query, cx),
+            Set(set) => set.matches_test_impl(query, cx, groups),
             Not(a) => !a,
             Union(a, b) => a || b,
             Intersection(a, b) => a && b,
@@ -236,10 +278,22 @@ impl CompiledExpr {
             Parens(a) => a,
         })
     }
+
+    /// Returns true if this expression contains any `group()` predicates.
+    pub fn has_group_matchers(&self) -> bool {
+        let mut found = false;
+        Wrapped(self).collapse_frames(|layer: ExprFrame<&FiltersetLeaf, ()>| {
+            if matches!(layer, ExprFrame::Set(FiltersetLeaf::Group(_, _))) {
+                found = true;
+            }
+        });
+        found
+    }
 }
 
 impl NameMatcher {
-    pub(crate) fn is_match(&self, input: &str) -> bool {
+    /// Returns true if the given input matches this name matcher.
+    pub fn is_match(&self, input: &str) -> bool {
         match self {
             Self::Equal { value, .. } => value == input,
             Self::Contains { value, .. } => input.contains(value),
@@ -250,17 +304,26 @@ impl NameMatcher {
 }
 
 impl FiltersetLeaf {
-    fn matches_test(&self, query: &TestQuery<'_>, cx: &EvalContext) -> bool {
+    fn matches_test_impl(
+        &self,
+        query: &TestQuery<'_>,
+        cx: &EvalContext,
+        groups: &impl GroupResolver,
+    ) -> bool {
         match self {
             Self::All => true,
             Self::None => false,
-            Self::Default => cx.default_filter.matches_test(query, cx),
+            // The default filter is always group-free (group() is banned
+            // in DefaultFilter), so recurse with NoGroups to enforce that
+            // invariant.
+            Self::Default => cx.default_filter.matches_test_impl(query, cx, &NoGroups),
             Self::Test(matcher, _) => matcher.is_match(query.test_name.as_str()),
             Self::Binary(matcher, _) => matcher.is_match(query.binary_query.binary_name),
             Self::BinaryId(matcher, _) => matcher.is_match(query.binary_query.binary_id.as_str()),
             Self::Platform(platform, _) => query.binary_query.platform == *platform,
             Self::Kind(matcher, _) => matcher.is_match(query.binary_query.kind.as_str()),
             Self::Packages(packages) => packages.contains(query.binary_query.package_id),
+            Self::Group(matcher, _) => groups.resolve_group(query, matcher),
         }
     }
 
@@ -275,6 +338,62 @@ impl FiltersetLeaf {
             Self::Platform(platform, _) => Some(query.platform == *platform),
             Self::Kind(matcher, _) => Some(matcher.is_match(query.kind.as_str())),
             Self::Packages(packages) => Some(packages.contains(query.package_id)),
+            // Group membership cannot be determined at the binary level.
+            Self::Group(_, _) => None,
+        }
+    }
+}
+
+/// Known test group names for validating `group()` predicates.
+///
+/// Passed to [`Filterset::parse`] to control group name validation at
+/// compile time.
+#[derive(Debug)]
+pub enum KnownGroups {
+    /// A known set of valid group names. The `group()` predicate is
+    /// validated against these names during compilation.
+    ///
+    /// `custom_groups` contains only custom (non-`@global`) group names.
+    /// `@global` is always implicitly valid and does not need to be
+    /// included.
+    Known { custom_groups: HashSet<String> },
+
+    /// Group names are not available in this context. If a `group()`
+    /// predicate reaches validation, it indicates a bug: the predicate
+    /// should have been banned during compilation for this filterset kind.
+    Unavailable,
+}
+
+impl KnownGroups {
+    /// Returns true if the given matcher matches any known group name
+    /// (including `@global`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self` is `Unavailable`, indicating a bug where `group()`
+    /// bypassed the ban check.
+    pub(crate) fn matches(&self, matcher: &NameMatcher) -> bool {
+        let custom_groups = match self {
+            KnownGroups::Known { custom_groups } => custom_groups,
+            KnownGroups::Unavailable => panic!(
+                "group() validation data is unavailable; \
+                 this is a nextest bug (group() should have been banned \
+                 during compilation for this filterset kind)"
+            ),
+        };
+
+        // Always check @global first.
+        if matcher.is_match(nextest_metadata::GLOBAL_TEST_GROUP) {
+            return true;
+        }
+
+        match matcher {
+            NameMatcher::Equal { value, .. } => custom_groups.contains(value.as_str()),
+            _ => {
+                // For anything more complex than equals, iterate over all
+                // known groups.
+                custom_groups.iter().any(|g| matcher.is_match(g))
+            }
         }
     }
 }
@@ -372,6 +491,13 @@ pub enum FiltersetKind {
     /// A test archive filterset.
     TestArchive,
 
+    /// An override filter in a config profile.
+    ///
+    /// Override filters cannot contain `group()` predicates because
+    /// group membership is determined by overrides, which would create
+    /// a circular dependency.
+    OverrideFilter,
+
     /// A default-filter filterset.
     ///
     /// To prevent recursion, default-filter expressions cannot contain `default()` themselves.
@@ -383,6 +509,7 @@ impl fmt::Display for FiltersetKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Test => write!(f, "test"),
+            Self::OverrideFilter => write!(f, "override-filter"),
             Self::TestArchive => write!(f, "archive-filter"),
             Self::DefaultFilter => write!(f, "default-filter"),
         }
@@ -396,12 +523,45 @@ pub struct EvalContext<'a> {
     pub default_filter: &'a CompiledExpr,
 }
 
+/// Internal trait for resolving `group()` predicates during expression
+/// evaluation. Not public; exposed only through the two `matches_test`
+/// variants on [`CompiledExpr`].
+trait GroupResolver {
+    fn resolve_group(&self, query: &TestQuery<'_>, matcher: &NameMatcher) -> bool;
+}
+
+/// Used by [`CompiledExpr::matches_test`]. Panics if a `group()` leaf
+/// is encountered, since the expression should have been compiled with
+/// a filterset kind that bans `group()`.
+struct NoGroups;
+
+impl GroupResolver for NoGroups {
+    fn resolve_group(&self, _query: &TestQuery<'_>, _matcher: &NameMatcher) -> bool {
+        panic!(
+            "group() predicate in expression where groups are not expected; \
+             this is a nextest bug (group() should be banned during compilation \
+             for this filterset kind)"
+        )
+    }
+}
+
+/// Used by [`CompiledExpr::matches_test_with_groups`]. Delegates to the
+/// provided [`GroupLookup`].
+struct WithGroups<'a>(&'a dyn GroupLookup);
+
+impl GroupResolver for WithGroups<'_> {
+    fn resolve_group(&self, query: &TestQuery<'_>, matcher: &NameMatcher) -> bool {
+        self.0.is_member_test(query, matcher)
+    }
+}
+
 impl Filterset {
     /// Parse a filterset.
     pub fn parse(
         input: String,
         cx: &ParseContext<'_>,
         kind: FiltersetKind,
+        known_groups: &KnownGroups,
     ) -> Result<Self, FiltersetParseErrors> {
         let mut errors = Vec::new();
         match parse(new_span(&input, &mut errors)) {
@@ -412,7 +572,7 @@ impl Filterset {
 
                 match parsed_expr {
                     ExprResult::Valid(parsed) => {
-                        let compiled = crate::compile::compile(&parsed, cx, kind)
+                        let compiled = crate::compile::compile(&parsed, cx, kind, known_groups)
                             .map_err(|errors| FiltersetParseErrors::new(input.clone(), errors))?;
                         Ok(Self {
                             input,
@@ -455,8 +615,24 @@ impl Filterset {
     }
 
     /// Returns true if the given test is accepted by this filterset.
+    ///
+    /// Panics if a `group()` predicate is encountered. See
+    /// [`CompiledExpr::matches_test`] for details.
     pub fn matches_test(&self, query: &TestQuery<'_>, cx: &EvalContext<'_>) -> bool {
         self.compiled.matches_test(query, cx)
+    }
+
+    /// Returns true if the given test is accepted by this filterset,
+    /// resolving `group()` predicates via the provided lookup.
+    ///
+    /// See [`CompiledExpr::matches_test_with_groups`] for details.
+    pub fn matches_test_with_groups(
+        &self,
+        query: &TestQuery<'_>,
+        cx: &EvalContext<'_>,
+        groups: &dyn GroupLookup,
+    ) -> bool {
+        self.compiled.matches_test_with_groups(query, cx, groups)
     }
 
     /// Returns true if the given expression needs dependencies information to work

--- a/nextest-filtering/src/lib.rs
+++ b/nextest-filtering/src/lib.rs
@@ -11,7 +11,7 @@ mod parsing;
 mod proptest_helpers;
 
 pub use expression::{
-    BinaryQuery, CompiledExpr, EvalContext, Filterset, FiltersetKind, FiltersetLeaf, NameMatcher,
-    ParseContext, TestQuery,
+    BinaryQuery, CompiledExpr, EvalContext, Filterset, FiltersetKind, FiltersetLeaf, GroupLookup,
+    KnownGroups, NameMatcher, ParseContext, TestQuery,
 };
 pub use parsing::ParsedExpr;

--- a/nextest-filtering/src/parsing.rs
+++ b/nextest-filtering/src/parsing.rs
@@ -58,6 +58,8 @@ pub enum ParsedLeaf<S = SourceSpan> {
     BinaryId(NameMatcher, S),
     Platform(BuildPlatform, S),
     Test(NameMatcher, S),
+    /// All tests in the named test group.
+    Group(NameMatcher, S),
     Default(S),
     All,
     None,
@@ -70,7 +72,10 @@ impl ParsedLeaf {
     /// Currently, this also returns true (conservatively) for the `Default`
     /// leaf, which is used to represent the default set of tests to run.
     pub fn is_runtime_only(&self) -> bool {
-        matches!(self, Self::Test(_, _) | Self::Default(_))
+        matches!(
+            self,
+            Self::Test(_, _) | Self::Group(_, _) | Self::Default(_)
+        )
     }
 
     #[cfg(test)]
@@ -84,6 +89,7 @@ impl ParsedLeaf {
             Self::BinaryId(matcher, _) => ParsedLeaf::BinaryId(matcher, ()),
             Self::Platform(platform, _) => ParsedLeaf::Platform(platform, ()),
             Self::Test(matcher, _) => ParsedLeaf::Test(matcher, ()),
+            Self::Group(matcher, _) => ParsedLeaf::Group(matcher, ()),
             Self::Default(_) => ParsedLeaf::Default(()),
             Self::All => ParsedLeaf::All,
             Self::None => ParsedLeaf::None,
@@ -102,6 +108,7 @@ impl<S> fmt::Display for ParsedLeaf<S> {
             Self::BinaryId(matcher, _) => write!(f, "binary_id({matcher})"),
             Self::Platform(platform, _) => write!(f, "platform({platform})"),
             Self::Test(matcher, _) => write!(f, "test({matcher})"),
+            Self::Group(matcher, _) => write!(f, "group({matcher})"),
             Self::Default(_) => write!(f, "default()"),
             Self::All => write!(f, "all()"),
             Self::None => write!(f, "none()"),
@@ -665,8 +672,9 @@ fn parse_set_def(input: &mut Span<'_>) -> PResult<Option<ParsedLeaf>> {
             unary_set_def("binary_id", DefaultMatcher::Glob, ParsedLeaf::BinaryId),
             unary_set_def("binary", DefaultMatcher::Glob, ParsedLeaf::Binary),
             unary_set_def("test", DefaultMatcher::Contains, ParsedLeaf::Test),
-            platform_def,
             alt((
+                unary_set_def("group", DefaultMatcher::Glob, ParsedLeaf::Group),
+                platform_def,
                 nullary_set_def("default", ParsedLeaf::Default),
                 nullary_set_def("all", |_| ParsedLeaf::All),
                 nullary_set_def("none", |_| ParsedLeaf::None),

--- a/nextest-filtering/src/proptest_helpers.rs
+++ b/nextest-filtering/src/proptest_helpers.rs
@@ -115,6 +115,7 @@ impl ParsedLeaf<()> {
             1 => NameMatcher::default_glob_strategy().prop_map(|s| Self::BinaryId(s, ())),
             1 => build_platform_strategy().prop_map(|p| Self::Platform(p, ())),
             1 => NameMatcher::default_contains_strategy().prop_map(|s| Self::Test(s, ())),
+            1 => NameMatcher::default_glob_strategy().prop_map(|s| Self::Group(s, ())),
             1 => Just(Self::All),
             1 => Just(Self::None),
         ]

--- a/nextest-filtering/tests/match.rs
+++ b/nextest-filtering/tests/match.rs
@@ -6,10 +6,12 @@ use guppy::{
     graph::{PackageGraph, cargo::BuildPlatform},
 };
 use nextest_filtering::{
-    BinaryQuery, CompiledExpr, EvalContext, Filterset, FiltersetKind, ParseContext, TestQuery,
-    errors::{FiltersetParseErrors, ParseSingleError},
+    BinaryQuery, CompiledExpr, EvalContext, Filterset, FiltersetKind, GroupLookup, KnownGroups,
+    NameMatcher, ParseContext, TestQuery,
+    errors::{BannedPredicateReason, FiltersetParseErrors, ParseSingleError},
 };
 use nextest_metadata::{RustBinaryId, RustTestBinaryKind, TestCaseName};
+use std::collections::HashSet;
 use test_case::test_case;
 
 #[track_caller]
@@ -27,9 +29,22 @@ fn mk_pid(c: char) -> PackageId {
     ))
 }
 
+/// Returns a `KnownGroups` containing the standard group names used in tests.
+fn default_known_groups() -> KnownGroups {
+    KnownGroups::Known {
+        custom_groups: HashSet::from(["serial".to_owned(), "batch".to_owned()]),
+    }
+}
+
 fn parse(input: &str, graph: &PackageGraph) -> Filterset {
     let cx = ParseContext::new(graph);
-    let expr = Filterset::parse(input.to_owned(), &cx, FiltersetKind::Test).unwrap();
+    let expr = Filterset::parse(
+        input.to_owned(),
+        &cx,
+        FiltersetKind::Test,
+        &default_known_groups(),
+    )
+    .unwrap();
     eprintln!("expression: {expr:?}");
     expr
 }
@@ -427,20 +442,42 @@ fn test_expr_with_no_matching_packages() {
     let graph = load_graph();
     let cx = ParseContext::new(&graph);
 
-    let errors =
-        Filterset::parse("deps(does-not-exist)".to_owned(), &cx, FiltersetKind::Test).unwrap_err();
+    let known_groups = default_known_groups();
+
+    let errors = Filterset::parse(
+        "deps(does-not-exist)".to_owned(),
+        &cx,
+        FiltersetKind::Test,
+        &known_groups,
+    )
+    .unwrap_err();
     assert_error(&errors);
 
-    let errors =
-        Filterset::parse("deps(=does-not-exist)".to_owned(), &cx, FiltersetKind::Test).unwrap_err();
+    let errors = Filterset::parse(
+        "deps(=does-not-exist)".to_owned(),
+        &cx,
+        FiltersetKind::Test,
+        &known_groups,
+    )
+    .unwrap_err();
     assert_error(&errors);
 
-    let errors =
-        Filterset::parse("deps(~does-not-exist)".to_owned(), &cx, FiltersetKind::Test).unwrap_err();
+    let errors = Filterset::parse(
+        "deps(~does-not-exist)".to_owned(),
+        &cx,
+        FiltersetKind::Test,
+        &known_groups,
+    )
+    .unwrap_err();
     assert_error(&errors);
 
-    let errors =
-        Filterset::parse("deps(/does-not/)".to_owned(), &cx, FiltersetKind::Test).unwrap_err();
+    let errors = Filterset::parse(
+        "deps(/does-not/)".to_owned(),
+        &cx,
+        FiltersetKind::Test,
+        &known_groups,
+    )
+    .unwrap_err();
     assert_error(&errors);
 }
 
@@ -839,5 +876,400 @@ fn test_binary_query() {
             &cx,
         ),
         Some(false)
+    );
+}
+
+// ---
+// group() predicate tests
+// ---
+
+/// Mock group lookup for testing.
+#[derive(Debug)]
+struct MockGroupLookup {
+    group_name: String,
+}
+
+impl GroupLookup for MockGroupLookup {
+    fn is_member_test(&self, _test: &TestQuery<'_>, matcher: &NameMatcher) -> bool {
+        matcher.is_match(&self.group_name)
+    }
+}
+
+#[test]
+fn test_group_parses_and_has_group_matchers() {
+    let graph = load_graph();
+    let cx = ParseContext::new(&graph);
+    let expr = Filterset::parse(
+        "group(serial)".to_owned(),
+        &cx,
+        FiltersetKind::Test,
+        &default_known_groups(),
+    )
+    .expect("group(serial) should parse");
+    assert!(expr.compiled.has_group_matchers());
+
+    // Default matcher for group() is Glob: test via mock lookups.
+    let lookup_match = MockGroupLookup {
+        group_name: "serial".to_owned(),
+    };
+    let lookup_no = MockGroupLookup {
+        group_name: "serial-extra".to_owned(),
+    };
+    let pid_a = mk_pid('a');
+    let bq = binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target);
+    let query = TestQuery {
+        binary_query: bq.to_query(),
+        test_name: &test_something(),
+    };
+    let cx = EvalContext {
+        default_filter: &CompiledExpr::ALL,
+    };
+    assert!(expr.matches_test_with_groups(&query, &cx, &lookup_match));
+    assert!(!expr.matches_test_with_groups(&query, &cx, &lookup_no));
+}
+
+#[test]
+#[should_panic(expected = "group() predicate in expression where groups are not expected")]
+fn test_group_panics_without_lookup() {
+    // matches_test without groups should panic on a group() predicate.
+    let graph = load_graph();
+    let pid_a = mk_pid('a');
+    let expr = parse("group(serial)", &graph);
+    let cx = EvalContext {
+        default_filter: &CompiledExpr::ALL,
+    };
+    let _ = expr.matches_test(
+        &TestQuery {
+            binary_query: binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target)
+                .to_query(),
+            test_name: &test_something(),
+        },
+        &cx,
+    );
+}
+
+#[test]
+fn test_group_evaluates_with_lookup() {
+    let graph = load_graph();
+    let pid_a = mk_pid('a');
+    let expr = parse("group(serial)", &graph);
+    let cx = EvalContext {
+        default_filter: &CompiledExpr::ALL,
+    };
+    let lookup = MockGroupLookup {
+        group_name: "serial".to_owned(),
+    };
+    let bq = binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target);
+    let query = TestQuery {
+        binary_query: bq.to_query(),
+        test_name: &test_something(),
+    };
+    assert!(
+        expr.matches_test_with_groups(&query, &cx, &lookup),
+        "group(serial) with matching lookup should return true"
+    );
+
+    // Non-matching group.
+    let lookup_other = MockGroupLookup {
+        group_name: "batch".to_owned(),
+    };
+    assert!(
+        !expr.matches_test_with_groups(&query, &cx, &lookup_other),
+        "group(serial) with non-matching lookup should return false"
+    );
+}
+
+#[test]
+fn test_group_binary_match_returns_none() {
+    let graph = load_graph();
+    let pid_a = mk_pid('a');
+    let expr = parse("group(serial)", &graph);
+    let cx = EvalContext {
+        default_filter: &CompiledExpr::ALL,
+    };
+    assert_eq!(
+        expr.matches_binary(
+            &binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target).to_query(),
+            &cx,
+        ),
+        None,
+        "group() at binary level should be indeterminate"
+    );
+}
+
+#[test]
+fn test_group_boolean_combinations() {
+    let graph = load_graph();
+    let pid_a = mk_pid('a');
+    let lookup = MockGroupLookup {
+        group_name: "serial".to_owned(),
+    };
+    let cx = EvalContext {
+        default_filter: &CompiledExpr::ALL,
+    };
+    let bq = binary_query(&graph, &pid_a, "lib", "my-binary", BuildPlatform::Target);
+    let query = TestQuery {
+        binary_query: bq.to_query(),
+        test_name: &test_something(),
+    };
+
+    // group(serial) & test(test_something) — both true.
+    let expr = parse("group(serial) & test(test_something)", &graph);
+    assert!(expr.matches_test_with_groups(&query, &cx, &lookup));
+
+    // group(serial) | test(nonexistent) — group true.
+    let expr = parse("group(serial) | test(nonexistent)", &graph);
+    assert!(expr.matches_test_with_groups(&query, &cx, &lookup));
+
+    // not group(serial) — false.
+    let expr = parse("not group(serial)", &graph);
+    assert!(!expr.matches_test_with_groups(&query, &cx, &lookup));
+
+    // group(batch) & test(test_something) — group false.
+    let expr = parse("group(batch) & test(test_something)", &graph);
+    assert!(!expr.matches_test_with_groups(&query, &cx, &lookup));
+}
+
+#[test]
+fn test_no_group_matchers_without_group() {
+    let graph = load_graph();
+    let expr = parse("test(foo)", &graph);
+    assert!(!expr.compiled.has_group_matchers());
+}
+
+#[test]
+fn test_group_banned_in_override_filter() {
+    let graph = load_graph();
+    let cx = ParseContext::new(&graph);
+    let err = Filterset::parse(
+        "group(serial)".to_owned(),
+        &cx,
+        FiltersetKind::OverrideFilter,
+        &KnownGroups::Unavailable,
+    )
+    .expect_err("group() should be banned in OverrideFilter");
+    assert!(
+        err.errors.iter().any(|e| matches!(
+            e,
+            ParseSingleError::BannedPredicate {
+                reason: BannedPredicateReason::GroupCircularDependency,
+                ..
+            }
+        )),
+        "should have GroupCircularDependency error: {err:?}"
+    );
+}
+
+#[test]
+fn test_group_banned_in_default_filter() {
+    let graph = load_graph();
+    let cx = ParseContext::new(&graph);
+    let err = Filterset::parse(
+        "group(serial)".to_owned(),
+        &cx,
+        FiltersetKind::DefaultFilter,
+        &KnownGroups::Unavailable,
+    )
+    .expect_err("group() should be banned in DefaultFilter");
+    assert!(
+        err.errors.iter().any(|e| matches!(
+            e,
+            ParseSingleError::BannedPredicate {
+                reason: BannedPredicateReason::GroupNotAvailableInDefaultFilter,
+                ..
+            }
+        )),
+        "should have GroupNotAvailableInDefaultFilter error: {err:?}"
+    );
+}
+
+#[test]
+fn test_group_banned_in_test_archive() {
+    let graph = load_graph();
+    let cx = ParseContext::new(&graph);
+    let err = Filterset::parse(
+        "group(serial)".to_owned(),
+        &cx,
+        FiltersetKind::TestArchive,
+        &KnownGroups::Unavailable,
+    )
+    .expect_err("group() should be banned in TestArchive");
+    assert!(
+        err.errors.iter().any(|e| matches!(
+            e,
+            ParseSingleError::BannedPredicate {
+                reason: BannedPredicateReason::GroupNotAvailableInArchive,
+                ..
+            }
+        )),
+        "should have GroupNotAvailableInArchive error: {err:?}"
+    );
+}
+
+#[test]
+fn test_test_banned_in_test_archive() {
+    let graph = load_graph();
+    let cx = ParseContext::new(&graph);
+    let err = Filterset::parse(
+        "test(foo)".to_owned(),
+        &cx,
+        FiltersetKind::TestArchive,
+        &KnownGroups::Unavailable,
+    )
+    .expect_err("test() should be banned in TestArchive");
+    assert!(
+        err.errors.iter().any(|e| matches!(
+            e,
+            ParseSingleError::BannedPredicate {
+                reason: BannedPredicateReason::TestNotAvailableInArchive,
+                ..
+            }
+        )),
+        "should have TestNotAvailableInArchive error: {err:?}"
+    );
+}
+
+#[test]
+fn test_default_banned_in_default_filter() {
+    let graph = load_graph();
+    let cx = ParseContext::new(&graph);
+    let err = Filterset::parse(
+        "default()".to_owned(),
+        &cx,
+        FiltersetKind::DefaultFilter,
+        &KnownGroups::Unavailable,
+    )
+    .expect_err("default() should be banned in DefaultFilter");
+    assert!(
+        err.errors.iter().any(|e| matches!(
+            e,
+            ParseSingleError::BannedPredicate {
+                reason: BannedPredicateReason::DefaultInfiniteRecursion,
+                ..
+            }
+        )),
+        "should have DefaultInfiniteRecursion error: {err:?}"
+    );
+}
+
+#[test]
+fn test_group_allowed_in_test_filterset() {
+    let graph = load_graph();
+    let cx = ParseContext::new(&graph);
+    assert!(
+        Filterset::parse(
+            "group(serial)".to_owned(),
+            &cx,
+            FiltersetKind::Test,
+            &default_known_groups(),
+        )
+        .is_ok(),
+        "group() should be allowed in Test filtersets"
+    );
+}
+
+// --- NoGroupMatch validation tests ---
+
+#[test]
+fn test_group_no_match_unknown_name() {
+    let graph = load_graph();
+    let cx = ParseContext::new(&graph);
+    let known = KnownGroups::Known {
+        custom_groups: HashSet::from(["serial".to_owned()]),
+    };
+    let err = Filterset::parse(
+        "group(nonexistent)".to_owned(),
+        &cx,
+        FiltersetKind::Test,
+        &known,
+    )
+    .expect_err("group(nonexistent) should fail with NoGroupMatch");
+    assert!(
+        err.errors
+            .iter()
+            .any(|e| matches!(e, ParseSingleError::NoGroupMatch(_))),
+        "should have NoGroupMatch error: {err:?}"
+    );
+}
+
+#[test]
+fn test_group_match_global() {
+    let graph = load_graph();
+    let cx = ParseContext::new(&graph);
+    let known = KnownGroups::Known {
+        custom_groups: HashSet::from(["serial".to_owned()]),
+    };
+    assert!(
+        Filterset::parse(
+            "group(@global)".to_owned(),
+            &cx,
+            FiltersetKind::Test,
+            &known
+        )
+        .is_ok(),
+        "group(@global) should succeed"
+    );
+}
+
+#[test]
+fn test_group_no_match_empty_set() {
+    let graph = load_graph();
+    let cx = ParseContext::new(&graph);
+    let known = KnownGroups::Known {
+        custom_groups: HashSet::new(),
+    };
+    let err = Filterset::parse("group(serial)".to_owned(), &cx, FiltersetKind::Test, &known)
+        .expect_err("group(serial) with empty known groups should fail");
+    assert!(
+        err.errors
+            .iter()
+            .any(|e| matches!(e, ParseSingleError::NoGroupMatch(_))),
+        "should have NoGroupMatch error: {err:?}"
+    );
+}
+
+#[test]
+fn test_group_glob_match() {
+    let graph = load_graph();
+    let cx = ParseContext::new(&graph);
+    let known = KnownGroups::Known {
+        custom_groups: HashSet::from(["serial".to_owned()]),
+    };
+    // Glob matching "serial".
+    assert!(
+        Filterset::parse("group(#ser*)".to_owned(), &cx, FiltersetKind::Test, &known).is_ok(),
+        "group(#ser*) should match 'serial'"
+    );
+    // Glob matching nothing.
+    let err = Filterset::parse("group(#zzz*)".to_owned(), &cx, FiltersetKind::Test, &known)
+        .expect_err("group(#zzz*) should fail with NoGroupMatch");
+    assert!(
+        err.errors
+            .iter()
+            .any(|e| matches!(e, ParseSingleError::NoGroupMatch(_))),
+        "should have NoGroupMatch error: {err:?}"
+    );
+}
+
+#[test]
+fn test_group_regex_match() {
+    let graph = load_graph();
+    let cx = ParseContext::new(&graph);
+    let known = KnownGroups::Known {
+        custom_groups: HashSet::from(["serial".to_owned()]),
+    };
+    // Regex matching "serial".
+    assert!(
+        Filterset::parse("group(/^ser/)".to_owned(), &cx, FiltersetKind::Test, &known).is_ok(),
+        "group(/^ser/) should match 'serial'"
+    );
+    // Regex matching nothing.
+    let err = Filterset::parse("group(/^zzz/)".to_owned(), &cx, FiltersetKind::Test, &known)
+        .expect_err("group(/^zzz/) should fail with NoGroupMatch");
+    assert!(
+        err.errors
+            .iter()
+            .any(|e| matches!(e, ParseSingleError::NoGroupMatch(_))),
+        "should have NoGroupMatch error: {err:?}"
     );
 }

--- a/nextest-metadata/src/test_list.rs
+++ b/nextest-metadata/src/test_list.rs
@@ -15,6 +15,12 @@ use std::{
 };
 use target_spec::summaries::PlatformSummary;
 
+/// The string `"@global"`, representing the implicit global test group.
+///
+/// All tests belong to `@global` unless assigned to a custom group by
+/// a per-test override.
+pub const GLOBAL_TEST_GROUP: &str = "@global";
+
 /// Command builder for `cargo nextest list`.
 #[derive(Clone, Debug, Default)]
 pub struct ListCommand {

--- a/nextest-runner/src/config/core/imp.rs
+++ b/nextest-runner/src/config/core/imp.rs
@@ -15,6 +15,7 @@ use crate::{
         overrides::{
             CompiledByProfile, CompiledData, CompiledDefaultFilter, DeserializedOverride,
             ListSettings, SettingSource, TestSettings,
+            group_membership::PrecomputedGroupMembership,
         },
         scripts::{
             DeserializedProfileScriptConfig, ProfileScriptType, ScriptConfig, ScriptId, ScriptInfo,
@@ -28,7 +29,7 @@ use crate::{
         provided_by_tool,
     },
     helpers::plural,
-    list::TestList,
+    list::{TestInstanceId, TestList},
     platform::BuildPlatforms,
     reporter::{FinalStatusLevel, StatusLevel, TestOutputDisplay},
     run_mode::NextestRunMode,
@@ -39,7 +40,9 @@ use config::{
 };
 use iddqd::IdOrdMap;
 use indexmap::IndexMap;
-use nextest_filtering::{BinaryQuery, EvalContext, Filterset, ParseContext, TestQuery};
+use nextest_filtering::{
+    BinaryQuery, EvalContext, Filterset, KnownGroups, ParseContext, TestQuery,
+};
 use petgraph::{Directed, Graph, algo::scc::kosaraju_scc, graph::NodeIndex};
 use serde::Deserialize;
 use std::{
@@ -986,6 +989,19 @@ impl<'cfg> EarlyProfile<'cfg> {
         self.test_groups
     }
 
+    /// Returns the known test groups for filterset validation.
+    ///
+    /// Only custom group names are included; `@global` is always
+    /// implicitly valid and handled by `KnownGroups` itself.
+    pub fn known_groups(&self) -> KnownGroups {
+        let custom_groups = self
+            .test_group_config()
+            .keys()
+            .map(|g| g.to_string())
+            .collect();
+        KnownGroups::Known { custom_groups }
+    }
+
     /// Applies build platforms to make the profile ready for evaluation.
     ///
     /// This is a separate step from parsing the config and reading a profile so that cargo-nextest
@@ -1063,6 +1079,35 @@ impl<'cfg> EvaluatableProfile<'cfg> {
         EvalContext {
             default_filter: &self.default_filter().expr,
         }
+    }
+
+    /// Precomputes test group memberships for the given tests.
+    ///
+    /// Uses [`settings_for`](Self::settings_for) to determine each
+    /// test's group, keeping the override resolution logic in one
+    /// place. The result implements [`nextest_filtering::GroupLookup`]
+    /// and should be passed into an [`EvalContext`] for CLI filterset
+    /// evaluation.
+    pub fn precompute_group_memberships<'a>(
+        &self,
+        tests: impl Iterator<Item = TestQuery<'a>>,
+    ) -> PrecomputedGroupMembership {
+        // test_group is not mode-dependent, so the choice of run mode
+        // doesn't matter here.
+        let run_mode = NextestRunMode::Test;
+
+        let mut membership = PrecomputedGroupMembership::empty();
+        for test in tests {
+            let group = self.settings_for(run_mode, &test).test_group().clone();
+            if group != TestGroup::Global {
+                let id = TestInstanceId {
+                    binary_id: test.binary_query.binary_id,
+                    test_name: test.test_name,
+                };
+                membership.insert(id.to_owned(), group);
+            }
+        }
+        membership
     }
 
     /// Returns the default set of tests to run.

--- a/nextest-runner/src/config/elements/test_group.rs
+++ b/nextest-runner/src/config/elements/test_group.rs
@@ -20,9 +20,6 @@ pub enum TestGroup {
 }
 
 impl TestGroup {
-    /// The string `"@global"`, indicating the global test group.
-    pub const GLOBAL_STR: &'static str = "@global";
-
     /// Returns the custom group name if this is a custom group, or None if this is the global group.
     pub fn custom_name(&self) -> Option<&str> {
         match self {
@@ -61,7 +58,7 @@ impl<'de> Deserialize<'de> for TestGroup {
         // Try and deserialize the group as a string. (Note: we don't deserialize a
         // `CustomTestGroup` directly because that errors out on None.)
         let group = SmolStr::deserialize(deserializer)?;
-        if group == Self::GLOBAL_STR {
+        if group == nextest_metadata::GLOBAL_TEST_GROUP {
             Ok(TestGroup::Global)
         } else {
             Ok(TestGroup::Custom(
@@ -75,7 +72,7 @@ impl FromStr for TestGroup {
     type Err = InvalidCustomTestGroupName;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == Self::GLOBAL_STR {
+        if s == nextest_metadata::GLOBAL_TEST_GROUP {
             Ok(TestGroup::Global)
         } else {
             Ok(TestGroup::Custom(CustomTestGroup::new(s.into())?))

--- a/nextest-runner/src/config/overrides/group_membership.rs
+++ b/nextest-runner/src/config/overrides/group_membership.rs
@@ -1,0 +1,254 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Precomputation of test group memberships for `group()` filterset
+//! evaluation.
+//!
+//! Group membership is determined entirely by config overrides that set
+//! `test-group`. Since `group()` is banned in override filters, the
+//! membership is a pure function of the config and can be computed in a
+//! single pass.
+
+use crate::{
+    config::elements::TestGroup,
+    list::{OwnedTestInstanceId, TestInstanceId, TestInstanceIdKey},
+};
+use nextest_filtering::{GroupLookup, NameMatcher, TestQuery};
+use std::{collections::HashMap, fmt};
+
+/// Precomputed test group memberships.
+///
+/// Built by [`EvaluatableProfile::precompute_group_memberships`] and
+/// implements [`GroupLookup`] to resolve `group()` predicates in CLI
+/// filtersets.
+///
+/// [`EvaluatableProfile::precompute_group_memberships`]: crate::config::EvaluatableProfile::precompute_group_memberships
+pub struct PrecomputedGroupMembership {
+    /// Map from test identity to the assigned test group. Tests not
+    /// present in this map are implicitly in `@global`.
+    assignments: HashMap<OwnedTestInstanceId, TestGroup>,
+}
+
+impl PrecomputedGroupMembership {
+    /// Creates an empty membership with no custom group assignments.
+    pub fn empty() -> Self {
+        Self {
+            assignments: HashMap::new(),
+        }
+    }
+
+    /// Inserts a group assignment for the given test. Only custom
+    /// (non-`@global`) groups need to be inserted; `@global` is the
+    /// implicit default.
+    pub(crate) fn insert(&mut self, id: OwnedTestInstanceId, group: TestGroup) {
+        self.assignments.insert(id, group);
+    }
+}
+
+impl fmt::Debug for PrecomputedGroupMembership {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PrecomputedGroupMembership")
+            .field("num_assignments", &self.assignments.len())
+            .finish()
+    }
+}
+
+impl GroupLookup for PrecomputedGroupMembership {
+    fn is_member_test(&self, test: &TestQuery<'_>, matcher: &NameMatcher) -> bool {
+        let key = TestInstanceId {
+            binary_id: test.binary_query.binary_id,
+            test_name: test.test_name,
+        };
+        // Look up via the borrow-complex-key pattern, avoiding a clone.
+        match self.assignments.get(&key as &dyn TestInstanceIdKey) {
+            Some(TestGroup::Custom(group)) => matcher.is_match(group.as_str()),
+            Some(TestGroup::Global) | None => matcher.is_match(nextest_metadata::GLOBAL_TEST_GROUP),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        config::{
+            core::{EvaluatableProfile, NextestConfig},
+            elements::TestGroup,
+            overrides::TestSettings,
+            utils::test_helpers::*,
+        },
+        run_mode::NextestRunMode,
+    };
+    use camino_tempfile::tempdir;
+    use guppy::graph::{PackageGraph, cargo::BuildPlatform};
+    use indoc::indoc;
+    use nextest_filtering::{
+        EvalContext, Filterset, FiltersetKind, KnownGroups, ParseContext, TestQuery,
+    };
+    use nextest_metadata::TestCaseName;
+    use std::collections::HashSet;
+
+    /// Parses a config and returns the evaluatable profile along with
+    /// the graph and package ID needed for constructing queries.
+    fn setup_profile(config_contents: &str) -> (EvaluatableProfile<'static>, SetupContext) {
+        let workspace_dir = tempdir().unwrap();
+        let graph = temp_workspace(&workspace_dir, config_contents);
+        let package_id = graph.workspace().iter().next().unwrap().id().clone();
+        let pcx = ParseContext::new(&graph);
+        let config = NextestConfig::from_sources(
+            graph.workspace().root(),
+            &pcx,
+            None,
+            &[][..],
+            &Default::default(),
+        )
+        .expect("config is valid");
+        // Leak to avoid lifetime issues in tests.
+        let config = Box::leak(Box::new(config));
+        let graph = Box::leak(Box::new(graph));
+        let profile = config
+            .profile("default")
+            .expect("default profile")
+            .apply_build_platforms(&build_platforms());
+        (profile, SetupContext { graph, package_id })
+    }
+
+    struct SetupContext {
+        graph: &'static PackageGraph,
+        package_id: guppy::PackageId,
+    }
+
+    /// Precomputes group membership for a single test and returns its
+    /// settings.
+    fn settings_for_test<'a>(
+        profile: &'a EvaluatableProfile<'_>,
+        cx: &'a SetupContext,
+        test_name: &'a str,
+    ) -> TestSettings<'a> {
+        let bq = binary_query(
+            cx.graph,
+            &cx.package_id,
+            "lib",
+            "my-binary",
+            BuildPlatform::Target,
+        );
+        let test_name = TestCaseName::new(test_name);
+        let query = TestQuery {
+            binary_query: bq.to_query(),
+            test_name: &test_name,
+        };
+        profile.settings_for(NextestRunMode::Test, &query)
+    }
+
+    #[test]
+    fn base_override_assigns_group() {
+        let (profile, cx) = setup_profile(indoc! {r#"
+            [[profile.default.overrides]]
+            filter = "test(my_test)"
+            test-group = "serial"
+
+            [test-groups.serial]
+            max-threads = 1
+        "#});
+        let settings = settings_for_test(&profile, &cx, "my_test");
+        assert_eq!(settings.test_group(), &test_group("serial"));
+    }
+
+    #[test]
+    fn non_matching_test_stays_global() {
+        let (profile, cx) = setup_profile(indoc! {r#"
+            [[profile.default.overrides]]
+            filter = "test(my_test)"
+            test-group = "serial"
+
+            [test-groups.serial]
+            max-threads = 1
+        "#});
+        let settings = settings_for_test(&profile, &cx, "other_test");
+        assert_eq!(settings.test_group(), &TestGroup::Global);
+    }
+
+    #[test]
+    fn first_override_wins() {
+        let (profile, cx) = setup_profile(indoc! {r#"
+            [[profile.default.overrides]]
+            filter = "test(my_test)"
+            test-group = "serial"
+
+            [[profile.default.overrides]]
+            filter = "test(my_test)"
+            test-group = "batch"
+
+            [test-groups.serial]
+            max-threads = 1
+
+            [test-groups.batch]
+            max-threads = 4
+        "#});
+        let settings = settings_for_test(&profile, &cx, "my_test");
+        assert_eq!(settings.test_group(), &test_group("serial"));
+    }
+
+    #[test]
+    fn group_lookup_resolves_membership() {
+        // This test exercises the full pipeline: precompute group
+        // memberships from config overrides, then use the result as
+        // a GroupLookup to evaluate a group() filterset.
+        let (profile, cx) = setup_profile(indoc! {r#"
+            [[profile.default.overrides]]
+            filter = "test(my_test)"
+            test-group = "serial"
+
+            [test-groups.serial]
+            max-threads = 1
+        "#});
+
+        let bq = binary_query(
+            cx.graph,
+            &cx.package_id,
+            "lib",
+            "my-binary",
+            BuildPlatform::Target,
+        );
+        let test_name = TestCaseName::new("my_test");
+        let query = TestQuery {
+            binary_query: bq.to_query(),
+            test_name: &test_name,
+        };
+
+        // Precompute group membership.
+        let membership = profile.precompute_group_memberships(std::iter::once(query));
+
+        // Parse a group() filterset and evaluate with the membership.
+        let pcx = ParseContext::new(cx.graph);
+        let filterset = Filterset::parse(
+            "group(serial)".to_owned(),
+            &pcx,
+            FiltersetKind::Test,
+            &KnownGroups::Known {
+                custom_groups: HashSet::from(["serial".to_owned()]),
+            },
+        )
+        .expect("group(serial) parses");
+
+        let ecx = EvalContext {
+            default_filter: &profile.default_filter().expr,
+        };
+
+        // my_test is in the serial group, so group(serial) should match.
+        assert!(
+            filterset.matches_test_with_groups(&query, &ecx, &membership),
+            "group(serial) should match my_test (in serial group)"
+        );
+
+        // other_test is not in any custom group.
+        let other_name = TestCaseName::new("other_test");
+        let other_query = TestQuery {
+            binary_query: bq.to_query(),
+            test_name: &other_name,
+        };
+        assert!(
+            !filterset.matches_test_with_groups(&other_query, &ecx, &membership),
+            "group(serial) should not match other_test (not in serial group)"
+        );
+    }
+}

--- a/nextest-runner/src/config/overrides/imp.rs
+++ b/nextest-runner/src/config/overrides/imp.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 use guppy::graph::cargo::BuildPlatform;
 use nextest_filtering::{
-    BinaryQuery, CompiledExpr, Filterset, FiltersetKind, ParseContext, TestQuery,
+    BinaryQuery, CompiledExpr, Filterset, FiltersetKind, KnownGroups, ParseContext, TestQuery,
 };
 use owo_colors::{OwoColorize, Style};
 use serde::{Deserialize, Deserializer};
@@ -277,24 +277,9 @@ impl<'p, Source: Copy> TestSettings<'p, Source> {
         let mut junit_flaky_fail_status = None;
 
         for override_ in &profile.compiled_data.overrides {
-            if !override_.state.host_eval {
+            if !override_.matches_test_query(query, &ecx) {
                 continue;
             }
-            if query.binary_query.platform == BuildPlatform::Host && !override_.state.host_test_eval
-            {
-                continue;
-            }
-            if query.binary_query.platform == BuildPlatform::Target && !override_.state.target_eval
-            {
-                continue;
-            }
-
-            if let Some(expr) = &override_.filter()
-                && !expr.matches_test(query, &ecx)
-            {
-                continue;
-            }
-            // If no expression is present, it's equivalent to "all()".
 
             if priority.is_none()
                 && let Some(p) = override_.data.priority
@@ -625,7 +610,12 @@ impl CompiledData<PreBuildPlatform> {
     ) -> Self {
         let profile_default_filter =
             profile_default_filter.and_then(|filter| {
-                match Filterset::parse(filter.to_owned(), pcx, FiltersetKind::DefaultFilter) {
+                match Filterset::parse(
+                    filter.to_owned(),
+                    pcx,
+                    FiltersetKind::DefaultFilter,
+                    &KnownGroups::Unavailable,
+                ) {
                     Ok(expr) => Some(CompiledDefaultFilter {
                         expr: expr.compiled,
                         profile: profile_name.to_owned(),
@@ -781,13 +771,20 @@ impl CompiledOverride<PreBuildPlatform> {
         let host_spec = MaybeTargetSpec::new(source.platform.host.as_deref());
         let target_spec = MaybeTargetSpec::new(source.platform.target.as_deref());
         let filter = source.filter.as_ref().map_or(Ok(None), |filter| {
-            Some(Filterset::parse(filter.clone(), pcx, FiltersetKind::Test)).transpose()
+            Some(Filterset::parse(
+                filter.clone(),
+                pcx,
+                FiltersetKind::OverrideFilter,
+                &KnownGroups::Unavailable,
+            ))
+            .transpose()
         });
         let default_filter = source.default_filter.as_ref().map_or(Ok(None), |filter| {
             Some(Filterset::parse(
                 filter.clone(),
                 pcx,
                 FiltersetKind::DefaultFilter,
+                &KnownGroups::Unavailable,
             ))
             .transpose()
         });
@@ -901,6 +898,31 @@ impl CompiledOverride<FinalConfig> {
             Some(FilterOrDefaultFilter::Filter(filter)) => Some(filter),
             _ => None,
         }
+    }
+
+    /// Returns true if this override's platform and filter constraints
+    /// match the given test query.
+    pub(in crate::config) fn matches_test_query(
+        &self,
+        query: &TestQuery<'_>,
+        ecx: &nextest_filtering::EvalContext<'_>,
+    ) -> bool {
+        if !self.state.host_eval {
+            return false;
+        }
+        if query.binary_query.platform == BuildPlatform::Host && !self.state.host_test_eval {
+            return false;
+        }
+        if query.binary_query.platform == BuildPlatform::Target && !self.state.target_eval {
+            return false;
+        }
+        // If no expression is present, it's equivalent to "all()".
+        if let Some(expr) = self.filter()
+            && !expr.matches_test(query, ecx)
+        {
+            return false;
+        }
+        true
     }
 
     /// Returns the default filter if it matches the platform.
@@ -1456,7 +1478,7 @@ mod tests {
             message: "predicate not allowed in `default-filter` expressions".to_owned(),
             labels: vec![
                 MietteJsonLabel {
-                    label: "this predicate causes infinite recursion".to_owned(),
+                    label: "default() causes infinite recursion".to_owned(),
                     span: MietteJsonSpan { offset: 4, length: 9 },
                 },
             ],
@@ -1551,7 +1573,7 @@ mod tests {
         &[MietteJsonReport {
             message: "predicate not allowed in `default-filter` expressions".to_owned(),
             labels: vec![
-                MietteJsonLabel { label: "this predicate causes infinite recursion".to_owned(), span: MietteJsonSpan { offset: 13, length: 9 } }
+                MietteJsonLabel { label: "default() causes infinite recursion".to_owned(), span: MietteJsonSpan { offset: 13, length: 9 } }
             ]
         }]
 

--- a/nextest-runner/src/config/overrides/mod.rs
+++ b/nextest-runner/src/config/overrides/mod.rs
@@ -3,6 +3,7 @@
 
 //! Support for per-test settings and overrides.
 
+pub(crate) mod group_membership;
 mod imp;
 
 pub use imp::*;

--- a/nextest-runner/src/config/scripts/imp.rs
+++ b/nextest-runner/src/config/scripts/imp.rs
@@ -27,7 +27,7 @@ use guppy::graph::cargo::BuildPlatform;
 use iddqd::{IdOrdItem, id_upcast};
 use indexmap::IndexMap;
 use nextest_filtering::{
-    BinaryQuery, EvalContext, Filterset, FiltersetKind, ParseContext, TestQuery,
+    BinaryQuery, EvalContext, Filterset, FiltersetKind, KnownGroups, ParseContext, TestQuery,
 };
 use quick_junit::ReportUuid;
 use serde::{Deserialize, de::Error};
@@ -429,6 +429,7 @@ impl CompiledProfileScripts<PreBuildPlatform> {
                 filter.clone(),
                 pcx,
                 FiltersetKind::DefaultFilter,
+                &KnownGroups::Unavailable,
             ))
             .transpose()
         });

--- a/nextest-runner/src/list/test_list.rs
+++ b/nextest-runner/src/list/test_list.rs
@@ -6,7 +6,7 @@ use crate::{
     cargo_config::EnvironmentMap,
     config::{
         core::EvaluatableProfile,
-        overrides::{ListSettings, TestSettings},
+        overrides::{ListSettings, TestSettings, group_membership::PrecomputedGroupMembership},
         scripts::{ScriptCommandEnvMap, WrapperScriptConfig, WrapperScriptTargetRunner},
     },
     double_spawn::DoubleSpawnInfo,
@@ -33,7 +33,7 @@ use guppy::{
     graph::{PackageGraph, PackageMetadata},
 };
 use iddqd::{IdOrdItem, IdOrdMap, id_upcast};
-use nextest_filtering::{BinaryQuery, EvalContext, TestQuery};
+use nextest_filtering::{BinaryQuery, EvalContext, GroupLookup, TestQuery};
 use nextest_metadata::{
     BuildPlatform, FilterMatch, MismatchReason, RustBinaryId, RustNonTestBinaryKind,
     RustTestBinaryKind, RustTestBinarySummary, RustTestCaseSummary, RustTestKind,
@@ -330,8 +330,19 @@ impl<'g> TestList<'g> {
         runtime.shutdown_background();
 
         // Phase 2: apply test-level filters and build suites.
-        let mut rust_suites = Self::build_suites(parsed_binaries, filter, &ecx, bound);
+        //
+        // If the CLI filter uses group() predicates, precompute group
+        // memberships first so that group() evaluates correctly in a
+        // single pass (no re-evaluation needed).
+        let group_membership = if filter.has_group_predicates() {
+            let test_queries = Self::collect_test_queries_from_parsed(&parsed_binaries);
+            Some(profile.precompute_group_memberships(test_queries.into_iter()))
+        } else {
+            None
+        };
+        let groups = group_membership.as_ref().map(|g| g as &dyn GroupLookup);
 
+        let mut rust_suites = Self::build_suites(parsed_binaries, filter, &ecx, bound, groups);
         Self::apply_partitioning(&mut rust_suites, partitioner_builder);
 
         let test_count = rust_suites
@@ -390,7 +401,7 @@ impl<'g> TestList<'g> {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let mut rust_suites = Self::build_suites(parsed_binaries, filter, ecx, bound);
+        let mut rust_suites = Self::build_suites(parsed_binaries, filter, ecx, bound, None);
 
         Self::apply_partitioning(&mut rust_suites, partitioner_builder);
 
@@ -784,12 +795,19 @@ impl<'g> TestList<'g> {
     /// Converts parsed binaries into filtered test suites.
     ///
     /// This is separated from [`Self::parse_output`] so that callers can
-    /// insert processing between parsing and filtering.
+    /// insert processing between parsing and filtering (e.g. precomputing
+    /// group memberships).
+    ///
+    /// `groups` should be `Some` when the CLI filter contains `group()`
+    /// predicates (see [`TestFilter::has_group_predicates`]), and `None`
+    /// otherwise. When `None`, encountering a `group()` predicate in the
+    /// expression panics.
     fn build_suites(
         parsed: impl IntoIterator<Item = ParsedTestBinary<'g>>,
         filter: &TestFilter,
         ecx: &EvalContext<'_>,
         bound: FilterBound,
+        groups: Option<&dyn GroupLookup>,
     ) -> IdOrdMap<RustTestSuite<'g>> {
         parsed
             .into_iter()
@@ -802,8 +820,9 @@ impl<'g> TestList<'g> {
                         let query = artifact.to_binary_query();
                         let mut map = IdOrdMap::new();
                         for tc in test_cases {
-                            let filter_match = filter
-                                .filter_match(query, &tc.name, &tc.kind, ecx, bound, tc.ignored);
+                            let filter_match = filter.filter_match(
+                                query, &tc.name, &tc.kind, ecx, bound, tc.ignored, groups,
+                            );
                             // Use insert_overwrite so that ignored entries
                             // (appended after non-ignored by parse_output)
                             // take precedence when a test name appears in
@@ -838,6 +857,34 @@ impl<'g> TestList<'g> {
             artifact: test_binary,
             reason,
         }
+    }
+
+    /// Collects test queries from parsed (but not yet filtered) binaries.
+    ///
+    /// Used to precompute group memberships before building suites.
+    /// Override filters that assign `test-group` are group-free
+    /// (group() is banned in override filters), so this evaluation
+    /// only needs a base `EvalContext` without group lookup.
+    fn collect_test_queries_from_parsed<'a>(
+        parsed_binaries: &'a [ParsedTestBinary<'g>],
+    ) -> Vec<TestQuery<'a>> {
+        parsed_binaries
+            .iter()
+            .filter_map(|binary| match binary {
+                ParsedTestBinary::Listed {
+                    artifact,
+                    test_cases,
+                } => Some((artifact, test_cases)),
+                ParsedTestBinary::Skipped { .. } => None,
+            })
+            .flat_map(|(artifact, test_cases)| {
+                let binary_query = artifact.to_binary_query();
+                test_cases.iter().map(move |tc| TestQuery {
+                    binary_query,
+                    test_name: &tc.name,
+                })
+            })
+            .collect()
     }
 
     /// Applies partitioning to the test suites as a post-filtering step.
@@ -1153,6 +1200,12 @@ pub trait ListProfile {
 
     /// Returns list-time settings for a test binary.
     fn list_settings_for(&self, query: &BinaryQuery<'_>) -> ListSettings<'_>;
+
+    /// Precomputes group memberships for the given tests.
+    fn precompute_group_memberships<'a>(
+        &self,
+        _tests: impl Iterator<Item = TestQuery<'a>>,
+    ) -> PrecomputedGroupMembership;
 }
 
 impl<'g> ListProfile for EvaluatableProfile<'g> {
@@ -1162,6 +1215,13 @@ impl<'g> ListProfile for EvaluatableProfile<'g> {
 
     fn list_settings_for(&self, query: &BinaryQuery<'_>) -> ListSettings<'_> {
         self.list_settings_for(query)
+    }
+
+    fn precompute_group_memberships<'a>(
+        &self,
+        tests: impl Iterator<Item = TestQuery<'a>>,
+    ) -> PrecomputedGroupMembership {
+        EvaluatableProfile::precompute_group_memberships(self, tests)
     }
 }
 
@@ -1869,10 +1929,13 @@ mod tests {
     };
     use iddqd::id_ord_map;
     use indoc::indoc;
-    use nextest_filtering::{CompiledExpr, Filterset, FiltersetKind, ParseContext};
+    use nextest_filtering::{CompiledExpr, Filterset, FiltersetKind, KnownGroups, ParseContext};
     use nextest_metadata::{FilterMatch, MismatchReason, PlatformLibdirUnavailable, RustTestKind};
     use pretty_assertions::assert_eq;
-    use std::{collections::BTreeMap, hash::DefaultHasher};
+    use std::{
+        collections::{BTreeMap, HashSet},
+        hash::DefaultHasher,
+    };
     use target_spec::Platform;
     use test_strategy::proptest;
 
@@ -1898,7 +1961,15 @@ mod tests {
             TestFilterPatterns::default(),
             // Test against the platform() predicate because this is the most important one here.
             vec![
-                Filterset::parse("platform(target)".to_owned(), &cx, FiltersetKind::Test).unwrap(),
+                Filterset::parse(
+                    "platform(target)".to_owned(),
+                    &cx,
+                    FiltersetKind::Test,
+                    &KnownGroups::Known {
+                        custom_groups: HashSet::new(),
+                    },
+                )
+                .unwrap(),
             ],
         )
         .unwrap();
@@ -2800,5 +2871,133 @@ mod tests {
             hash_value(&borrowed2),
             "Hash must be consistent for owned2 and its borrowed form"
         );
+    }
+
+    /// A mock group lookup that reports all tests as members of a
+    /// single named group.
+    #[derive(Debug)]
+    struct MockGroupLookup {
+        group_name: String,
+    }
+
+    impl GroupLookup for MockGroupLookup {
+        fn is_member_test(
+            &self,
+            _test: &nextest_filtering::TestQuery<'_>,
+            matcher: &nextest_filtering::NameMatcher,
+        ) -> bool {
+            matcher.is_match(&self.group_name)
+        }
+    }
+
+    /// Tests that `build_suites` correctly resolves `group()` predicates
+    /// when a group lookup is provided.
+    #[test]
+    fn test_build_suites_with_group_filter() {
+        let cx = ParseContext::new(&PACKAGE_GRAPH_FIXTURE);
+
+        // Create a filter with group(serial) — only tests in the
+        // "serial" group should match.
+        let test_filter = TestFilter::new(
+            NextestRunMode::Test,
+            RunIgnored::Default,
+            TestFilterPatterns::default(),
+            vec![
+                Filterset::parse(
+                    "group(serial)".to_owned(),
+                    &cx,
+                    FiltersetKind::Test,
+                    &KnownGroups::Known {
+                        custom_groups: HashSet::from(["serial".to_owned()]),
+                    },
+                )
+                .unwrap(),
+            ],
+        )
+        .unwrap();
+
+        assert!(
+            test_filter.has_group_predicates(),
+            "filter with group() must report has_group_predicates"
+        );
+
+        let fake_binary_id = RustBinaryId::new("fake-package::fake-binary");
+
+        let make_parsed = || {
+            vec![ParsedTestBinary::Listed {
+                artifact: RustTestArtifact {
+                    binary_path: "/fake/binary".into(),
+                    cwd: "/fake/cwd".into(),
+                    package: package_metadata(),
+                    binary_name: "fake-binary".to_owned(),
+                    binary_id: fake_binary_id.clone(),
+                    kind: RustTestBinaryKind::LIB,
+                    non_test_binaries: BTreeSet::new(),
+                    build_platform: BuildPlatform::Target,
+                },
+                test_cases: vec![
+                    ParsedTestCase {
+                        name: TestCaseName::new("serial_test"),
+                        kind: RustTestKind::TEST,
+                        ignored: false,
+                    },
+                    ParsedTestCase {
+                        name: TestCaseName::new("parallel_test"),
+                        kind: RustTestKind::TEST,
+                        ignored: false,
+                    },
+                ],
+            }]
+        };
+
+        let ecx = EvalContext {
+            default_filter: &CompiledExpr::ALL,
+        };
+
+        // Mock: all tests report as members of the "serial" group.
+        let lookup = MockGroupLookup {
+            group_name: "serial".to_owned(),
+        };
+        let suites = TestList::build_suites(
+            make_parsed(),
+            &test_filter,
+            &ecx,
+            FilterBound::All,
+            Some(&lookup),
+        );
+        let suite = suites.get(&fake_binary_id).expect("suite exists");
+        // Both tests should match because the mock says all are in "serial".
+        for case in suite.status.test_cases() {
+            assert_eq!(
+                case.test_info.filter_match,
+                FilterMatch::Matches,
+                "{} should match with serial group lookup",
+                case.name,
+            );
+        }
+
+        // Mock: all tests report as members of "batch", not "serial".
+        let lookup_other = MockGroupLookup {
+            group_name: "batch".to_owned(),
+        };
+        let suites = TestList::build_suites(
+            make_parsed(),
+            &test_filter,
+            &ecx,
+            FilterBound::All,
+            Some(&lookup_other),
+        );
+        let suite = suites.get(&fake_binary_id).expect("suite exists");
+        // No tests should match because the group is "batch", not "serial".
+        for case in suite.status.test_cases() {
+            assert_eq!(
+                case.test_info.filter_match,
+                FilterMatch::Mismatch {
+                    reason: MismatchReason::Expression,
+                },
+                "{} should not match with batch group lookup",
+                case.name,
+            );
+        }
     }
 }

--- a/nextest-runner/src/runner/executor.rs
+++ b/nextest-runner/src/runner/executor.rs
@@ -796,7 +796,7 @@ impl<'a> ExecutorContext<'a> {
                     test.cx.group_slot().is_none(),
                     "test_group being unset implies group_slot is unset"
                 );
-                command_mut.env("NEXTEST_TEST_GROUP", TestGroup::GLOBAL_STR);
+                command_mut.env("NEXTEST_TEST_GROUP", nextest_metadata::GLOBAL_TEST_GROUP);
             }
         }
         if let Some(group_slot) = test.cx.group_slot() {

--- a/nextest-runner/src/test_filter.rs
+++ b/nextest-runner/src/test_filter.rs
@@ -7,7 +7,7 @@
 
 use crate::{errors::TestFilterBuildError, record::ComputedRerunInfo, run_mode::NextestRunMode};
 use aho_corasick::AhoCorasick;
-use nextest_filtering::{BinaryQuery, EvalContext, Filterset, TestQuery};
+use nextest_filtering::{BinaryQuery, EvalContext, Filterset, GroupLookup, TestQuery};
 use nextest_metadata::{FilterMatch, MismatchReason, RustBinaryId, RustTestKind, TestCaseName};
 use std::{collections::HashSet, fmt, mem};
 
@@ -477,12 +477,50 @@ impl TestFilter {
         self.patterns == other.patterns
     }
 
+    /// Returns true if the filter expressions contain any `group()` predicates.
+    /// When true, test list creation must precompute group memberships.
+    pub fn has_group_predicates(&self) -> bool {
+        match &self.binary_filter.exprs {
+            TestFilterExprs::All => false,
+            TestFilterExprs::Sets(exprs) => {
+                exprs.iter().any(|expr| expr.compiled.has_group_matchers())
+            }
+        }
+    }
+
+    /// Returns true if the given test matches the expression filters
+    /// with the given evaluation context (or there are no expression
+    /// filters).
+    ///
+    /// This evaluates only expression filters (`-E` arguments), not
+    /// name patterns or the default filter.
+    fn matches_expression(
+        &self,
+        query: &TestQuery<'_>,
+        ecx: &EvalContext<'_>,
+        groups: Option<&dyn GroupLookup>,
+    ) -> bool {
+        match &self.binary_filter.exprs {
+            TestFilterExprs::All => true,
+            TestFilterExprs::Sets(exprs) => exprs.iter().any(|expr| match groups {
+                Some(groups) => expr.matches_test_with_groups(query, ecx, groups),
+                None => expr.matches_test(query, ecx),
+            }),
+        }
+    }
+
     /// Consumes self, returning the underlying [`ComputedRerunInfo`] if any.
     pub fn into_rerun_info(self) -> Option<ComputedRerunInfo> {
         self.rerun_info
     }
 
     /// Returns an enum describing the match status of this filter.
+    ///
+    /// `groups` should be `Some` when the CLI filter contains `group()`
+    /// predicates, and `None` otherwise. When `None`, encountering a
+    /// `group()` predicate panics (it indicates a bug in filterset
+    /// compilation).
+    #[expect(clippy::too_many_arguments)]
     pub fn filter_match(
         &self,
         binary_query: BinaryQuery<'_>,
@@ -491,6 +529,7 @@ impl TestFilter {
         ecx: &EvalContext<'_>,
         bound: FilterBound,
         ignored: bool,
+        groups: Option<&dyn GroupLookup>,
     ) -> FilterMatch {
         // Handle benchmark mismatches first.
         if let Some(mismatch) = self.filter_benchmark_mismatch(test_kind) {
@@ -504,7 +543,7 @@ impl TestFilter {
             };
         }
 
-        self.filter_match_base(binary_query, test_name, ecx, bound, ignored)
+        self.filter_match_base(binary_query, test_name, ecx, bound, ignored, groups)
     }
 
     /// Core filter matching logic, used by `filter_match`.
@@ -515,6 +554,7 @@ impl TestFilter {
         ecx: &EvalContext<'_>,
         bound: FilterBound,
         ignored: bool,
+        groups: Option<&dyn GroupLookup>,
     ) -> FilterMatch {
         if let Some(mismatch) = self.filter_ignored_mismatch(ignored) {
             return mismatch;
@@ -544,7 +584,7 @@ impl TestFilter {
             use FilterNameMatch::*;
             match (
                 self.filter_name_match(test_name),
-                self.filter_expression_match(binary_query, test_name, ecx, bound),
+                self.filter_expression_match(binary_query, test_name, ecx, bound, groups),
             ) {
                 // Tests must be accepted by both expressions and filters.
                 (
@@ -606,26 +646,27 @@ impl TestFilter {
         test_name: &TestCaseName,
         ecx: &EvalContext<'_>,
         bound: FilterBound,
+        groups: Option<&dyn GroupLookup>,
     ) -> FilterNameMatch {
         let query = TestQuery {
             binary_query,
             test_name,
         };
 
-        let expr_result = match &self.binary_filter.exprs {
-            TestFilterExprs::All => FilterNameMatch::MatchEmptyPatterns,
-            TestFilterExprs::Sets(exprs) => {
-                if exprs.iter().any(|expr| expr.matches_test(&query, ecx)) {
-                    FilterNameMatch::MatchWithPatterns
-                } else {
-                    return FilterNameMatch::Mismatch(MismatchReason::Expression);
-                }
+        let expr_result = if self.matches_expression(&query, ecx, groups) {
+            match &self.binary_filter.exprs {
+                TestFilterExprs::All => FilterNameMatch::MatchEmptyPatterns,
+                TestFilterExprs::Sets(_) => FilterNameMatch::MatchWithPatterns,
             }
+        } else {
+            return FilterNameMatch::Mismatch(MismatchReason::Expression);
         };
 
         match bound {
             FilterBound::All => expr_result,
             FilterBound::DefaultSet => {
+                // The default filter is always group-free (group() is
+                // banned in DefaultFilter filtersets).
                 if ecx.default_filter.matches_test(&query, ecx) {
                     expr_result
                 } else {


### PR DESCRIPTION
Add a new filterset predicate, `group()`, to list tests by test group.