### PR TITLE
[nextest-runner] add support for --nocapture after --

### DIFF
--- a/cargo-nextest/src/dispatch/core/filter.rs
+++ b/cargo-nextest/src/dispatch/core/filter.rs
@@ -68,12 +68,24 @@ pub(crate) struct TestBuildFilter {
 
     /// Test name filters and emulated test binary arguments.
     ///
+    /// These arguments emulate the flags accepted by libtest (the standard Rust
+    /// test harness), so that `cargo nextest run -- <args>` works similarly to
+    /// `cargo test -- <args>`.
+    ///
     /// Supported arguments:
     ///
-    /// - --ignored:         Only run ignored tests
-    /// - --include-ignored: Run both ignored and non-ignored tests
-    /// - --skip PATTERN:    Skip tests that match the pattern
-    /// - --exact:           Run tests that exactly match patterns after `--`
+    /// `--ignored`: Only run ignored tests (equivalent to `--run-ignored ignored-only`).
+    ///
+    /// `--include-ignored`: Run both ignored and non-ignored tests (equivalent to `--run-ignored all`).
+    ///
+    /// `--skip PATTERN`: Skip tests matching PATTERN. May be specified multiple
+    /// times.
+    ///
+    /// `--exact`: Require that filters after -- match test names exactly, rather
+    /// than as substrings.
+    ///
+    /// `--nocapture` (or `--no-capture`): Run tests serially and do not capture
+    /// output. Equivalent to the `--no-capture` flag before --.
     #[arg(help_heading = None, value_name = "FILTERS_AND_ARGS", last = true)]
     filters: Vec<String>,
 }
@@ -138,24 +150,29 @@ impl TestBuildFilter {
         &self,
         mode: NextestRunMode,
         filter_exprs: Vec<nextest_filtering::Filterset>,
-    ) -> Result<TestFilter> {
+    ) -> Result<TestFilterWithCaptureOpts> {
         // Merge the test binary args into the patterns.
         let mut run_ignored = self.run_ignored.map(Into::into);
         let mut patterns = TestFilterPatterns::new(self.pre_double_dash_filters.clone());
-        self.merge_test_binary_args(&mut run_ignored, &mut patterns)?;
+        let mut no_capture = false;
+        self.merge_test_binary_args(&mut run_ignored, &mut patterns, &mut no_capture)?;
 
-        Ok(TestFilter::new(
-            mode,
-            run_ignored.unwrap_or_default(),
-            patterns,
-            filter_exprs,
-        )?)
+        Ok(TestFilterWithCaptureOpts {
+            test_filter: TestFilter::new(
+                mode,
+                run_ignored.unwrap_or_default(),
+                patterns,
+                filter_exprs,
+            )?,
+            no_capture,
+        })
     }
 
     fn merge_test_binary_args(
         &self,
         run_ignored: &mut Option<RunIgnored>,
         patterns: &mut TestFilterPatterns,
+        no_capture: &mut bool,
     ) -> Result<()> {
         // First scan to see if `--exact` is specified. If so, then everything here will be added to
         // `--exact`.
@@ -177,6 +194,7 @@ impl TestBuildFilter {
 
         let mut ignore_filters = Vec::new();
         let mut read_trailing_filters = false;
+        let mut seen_nocapture = false;
 
         let mut unsupported_args = Vec::new();
 
@@ -209,6 +227,15 @@ impl TestBuildFilter {
                 }
             } else if arg == "--exact" {
                 // Already handled above.
+            } else if arg == "--nocapture" || arg == "--no-capture" {
+                if seen_nocapture {
+                    return Err(ExpectedError::test_binary_args_parse_error(
+                        "duplicated",
+                        vec![arg.clone()],
+                    ));
+                }
+                seen_nocapture = true;
+                *no_capture = true;
             } else {
                 unsupported_args.push(arg.clone());
             }
@@ -241,6 +268,16 @@ impl TestBuildFilter {
 
         Ok(())
     }
+}
+
+/// The result of parsing test filters, including emulated test binary arguments
+/// that affect runner behavior (not just filtering).
+pub(crate) struct TestFilterWithCaptureOpts {
+    /// The constructed test filter.
+    pub(crate) test_filter: TestFilter,
+
+    /// Whether `--nocapture` or `--no-capture` was specified after `--`.
+    pub(crate) no_capture: bool,
 }
 
 /// Archive build filtering options.

--- a/cargo-nextest/src/dispatch/core/list.rs
+++ b/cargo-nextest/src/dispatch/core/list.rs
@@ -78,9 +78,11 @@ impl App {
             FiltersetKind::Test,
             &known_groups,
         )?;
+        // no_capture is ignored for list commands.
         let test_filter = self
             .build_filter
-            .make_test_filter(NextestRunMode::Test, filter_exprs)?;
+            .make_test_filter(NextestRunMode::Test, filter_exprs)?
+            .test_filter;
 
         let binary_list = self.base.build_binary_list("test")?;
 
@@ -177,9 +179,11 @@ impl App {
             FiltersetKind::Test,
             &known_groups,
         )?;
+        // no_capture is ignored for list commands.
         let test_filter = self
             .build_filter
-            .make_test_filter(NextestRunMode::Test, filter_exprs)?;
+            .make_test_filter(NextestRunMode::Test, filter_exprs)?
+            .test_filter;
 
         let binary_list = self.base.build_binary_list("test")?;
         let build_platforms = binary_list.rust_build_meta.build_platforms.clone();

--- a/cargo-nextest/src/dispatch/core/run.rs
+++ b/cargo-nextest/src/dispatch/core/run.rs
@@ -906,6 +906,29 @@ impl App {
             }
         };
 
+        // Parse test filters and emulated test binary args. This must happen
+        // before computing cap_strat, since `-- --nocapture` affects capture.
+        let known_groups = profile.known_groups();
+        let filter_exprs = build_filtersets(
+            &pcx,
+            &self.build_filter.filterset,
+            FiltersetKind::Test,
+            &known_groups,
+        )?;
+        let filter_result = self
+            .build_filter
+            .make_test_filter(NextestRunMode::Test, filter_exprs)?;
+        let mut test_filter = filter_result.test_filter;
+
+        // Merge no_capture from the CLI flag and the emulated `-- --nocapture`.
+        if no_capture && filter_result.no_capture {
+            return Err(ExpectedError::test_binary_args_parse_error(
+                "duplicated",
+                vec!["--no-capture".to_owned()],
+            ));
+        }
+        let no_capture = no_capture || filter_result.no_capture;
+
         let cap_strat = if no_capture || runner_opts.interceptor.is_active() {
             CaptureStrategy::None
         } else if matches!(message_format, MessageFormat::Human) {
@@ -946,17 +969,6 @@ impl App {
             &resolved_user_config.ui,
         );
         reporter_builder.set_verbose(self.base.output.verbose);
-
-        let known_groups = profile.known_groups();
-        let filter_exprs = build_filtersets(
-            &pcx,
-            &self.build_filter.filterset,
-            FiltersetKind::Test,
-            &known_groups,
-        )?;
-        let mut test_filter = self
-            .build_filter
-            .make_test_filter(NextestRunMode::Test, filter_exprs)?;
         let (rerun_state, expected_outstanding) = match rerun {
             Some(RunIdOrRecordingSelector::RunId(selector)) => {
                 let (rerun_state, outstanding_tests) = self.resolve_rerun(selector)?;
@@ -1243,9 +1255,11 @@ impl App {
             FiltersetKind::Test,
             &known_groups,
         )?;
+        // no_capture is ignored for benchmarks: they always run without capture.
         let test_filter = self
             .build_filter
-            .make_test_filter(NextestRunMode::Benchmark, filter_exprs)?;
+            .make_test_filter(NextestRunMode::Benchmark, filter_exprs)?
+            .test_filter;
 
         let binary_list = self.base.build_binary_list("bench")?;
         let build_platforms = &binary_list.rust_build_meta.build_platforms.clone();

--- a/cargo-nextest/src/dispatch/core/tests.rs
+++ b/cargo-nextest/src/dispatch/core/tests.rs
@@ -495,14 +495,19 @@ struct TestCli {
 
 #[test]
 fn test_test_binary_argument_parsing() {
+    use super::filter::TestFilterWithCaptureOpts;
     use crate::{ExpectedError, Result};
     use nextest_runner::test_filter::{RunIgnored, TestFilter, TestFilterPatterns};
 
-    fn get_test_filter(cmd: &str) -> Result<TestFilter> {
+    fn get_filter_result(cmd: &str) -> Result<TestFilterWithCaptureOpts> {
         let app = TestCli::try_parse_from(shell_words::split(cmd).expect("valid command line"))
             .unwrap_or_else(|_| panic!("{cmd} should have successfully parsed"));
         app.build_filter
             .make_test_filter(NextestRunMode::Test, vec![])
+    }
+
+    fn get_test_filter(cmd: &str) -> Result<TestFilter> {
+        Ok(get_filter_result(cmd)?.test_filter)
     }
 
     let valid = &[
@@ -565,6 +570,9 @@ fn test_test_binary_argument_parsing() {
         ("foo -- --include-ignored --include-ignored", "duplicated"),
         ("foo -- --ignored --ignored", "duplicated"),
         ("foo -- --exact --exact", "duplicated"),
+        ("foo -- --nocapture --nocapture", "duplicated"),
+        ("foo -- --no-capture --no-capture", "duplicated"),
+        ("foo -- --nocapture --no-capture", "duplicated"),
         // ---
         // mutually exclusive
         // ---
@@ -618,6 +626,69 @@ fn test_test_binary_argument_parsing() {
         } else {
             panic!("{s} should have errored out with TestBinaryArgsParseError, actual: {res:?}",);
         }
+    }
+
+    // ---
+    // nocapture
+    // ---
+
+    // Commands where no_capture should be true.
+    let nocapture_true = &[
+        "foo -- --nocapture",
+        "foo -- --no-capture",
+        "foo -- --nocapture --ignored",
+        "foo -- pattern --nocapture",
+    ];
+    for cmd in nocapture_true {
+        let result = get_filter_result(cmd).unwrap_or_else(|_| panic!("failed to parse {cmd}"));
+        assert!(result.no_capture, "{cmd} should set no_capture = true");
+    }
+
+    // Commands where no_capture should be false.
+    let nocapture_false = &[
+        "foo -- pattern",
+        "foo -- --ignored",
+        "foo -- --exact pattern",
+    ];
+    for cmd in nocapture_false {
+        let result = get_filter_result(cmd).unwrap_or_else(|_| panic!("failed to parse {cmd}"));
+        assert!(!result.no_capture, "{cmd} should set no_capture = false");
+    }
+
+    // --skip consumes --nocapture as its pattern argument (matching libtest
+    // behavior), so no_capture should be false.
+    {
+        let result =
+            get_filter_result("foo -- --skip --nocapture").expect("should parse successfully");
+        assert!(
+            !result.no_capture,
+            "-- --skip --nocapture should not set no_capture",
+        );
+        let expected = {
+            let mut patterns = TestFilterPatterns::default();
+            patterns.add_skip_pattern("--nocapture".to_owned());
+            patterns
+        };
+        let expected_filter = TestFilter::new(
+            NextestRunMode::Test,
+            RunIgnored::Default,
+            expected,
+            Vec::new(),
+        )
+        .expect("failed to build expected TestFilter");
+        assert!(
+            result.test_filter.patterns_eq(&expected_filter),
+            "-- --skip --nocapture should produce a skip pattern of --nocapture",
+        );
+    }
+
+    // After a second `--`, --nocapture is treated as a filter pattern, not a flag.
+    {
+        let result = get_filter_result("foo -- -- --nocapture").expect("should parse successfully");
+        assert!(
+            !result.no_capture,
+            "-- -- --nocapture should not set no_capture",
+        );
     }
 }
 


### PR DESCRIPTION
Some cases like rust-analyzer integration benefit from uniformity between `cargo test` and nextest.