### PR TITLE
[nextest-runner] for user config platform overrides, always use build platform

### DIFF
--- a/cargo-nextest/src/dispatch/app.rs
+++ b/cargo-nextest/src/dispatch/app.rs
@@ -10,12 +10,11 @@ use super::{
         App, ArchiveApp, ArchiveOpts, BaseApp, BenchOpts, ListOpts, ReplayOpts, RunOpts,
         exec_replay,
     },
+    helpers::resolve_user_config,
     utility::{DebugCommand, SelfCommand, ShowConfigCommand, StoreCommand},
 };
-use crate::{ExpectedError, Result, output::OutputContext, reuse_build::ReuseBuildOpts};
+use crate::{Result, output::OutputContext, reuse_build::ReuseBuildOpts};
 use clap::{Args, Subcommand};
-use guppy::platform::Platform;
-use nextest_runner::user_config::UserConfig;
 
 /// A next-generation test runner for Rust.
 ///
@@ -200,13 +199,7 @@ impl AppOpts {
                 exec_replay(&early_args, *replay_opts, self.common.manifest_path, output)
             }
             Command::Store { command } => {
-                let host_platform =
-                    Platform::build_target().expect("nextest is built for a supported platform");
-                let user_config = UserConfig::for_host_platform(
-                    &host_platform,
-                    early_args.user_config_location(),
-                )
-                .map_err(|e| ExpectedError::UserConfigError { err: Box::new(e) })?;
+                let user_config = resolve_user_config(early_args.user_config_location())?;
                 command.exec(&early_args, self.common.manifest_path, &user_config, output)
             }
         }

--- a/cargo-nextest/src/dispatch/clap_error.rs
+++ b/cargo-nextest/src/dispatch/clap_error.rs
@@ -13,7 +13,6 @@ use crate::output::Color;
 use clap::{ArgAction, Args, Command};
 use nextest_runner::{
     pager::PagedOutput,
-    platform::Platform,
     user_config::{
         EarlyUserConfig, UserConfigLocation,
         elements::{PagerSetting, PaginateSetting, UiConfig},
@@ -22,42 +21,6 @@ use nextest_runner::{
 };
 use std::io::{IsTerminal, Write};
 use tracing::debug;
-
-/// Early setup information needed before full CLI parsing.
-///
-/// This contains the build-time host platform and early arguments extracted
-/// from the command line. This is used for help output and other early
-/// decisions where we don't want to run `rustc -vV`.
-#[derive(Debug)]
-pub struct EarlySetup {
-    /// The build-time host platform.
-    ///
-    /// This uses `Platform::build_target()` rather than runtime detection via
-    /// `rustc -vV`. For help output and early config, this is sufficient and
-    /// avoids potential failures from missing/broken rustc.
-    build_target_platform: Platform,
-    /// Early arguments extracted before full parsing.
-    pub early_args: EarlyArgs,
-}
-
-impl EarlySetup {
-    /// Performs early setup: gets build target platform and extracts early args.
-    ///
-    /// This should be called once at startup, before CLI parsing. To avoid
-    /// complex error handling, this uses `Platform::build_target()`, which is
-    /// compile-time detection, not runtime `rustc -vV` detection.
-    pub fn new(cli_args: &[String], app: &Command) -> Self {
-        // Use the build target platform for early setup. This is compile-time
-        // detection and essentially infallible for supported platforms.
-        let build_target_platform =
-            Platform::build_target().expect("nextest is built for a supported platform");
-        let early_args = extract_early_args(cli_args, app);
-        Self {
-            build_target_platform,
-            early_args,
-        }
-    }
-}
 
 /// Early arguments extracted before full CLI parsing.
 ///
@@ -97,6 +60,75 @@ pub struct EarlyArgs {
 }
 
 impl EarlyArgs {
+    /// Extracts early arguments from CLI args using clap's parsing.
+    ///
+    /// This should be called once at startup, before full CLI parsing.
+    ///
+    /// This approach uses clap's own argument parsing with `ignore_errors(true)`
+    /// to properly handle the `--` separator and other edge cases.
+    ///
+    /// The technique is inspired by Jujutsu, which uses a similar approach for
+    /// early argument extraction.
+    pub fn extract(args: &[String], app: &Command) -> Self {
+        // Clone the command and configure it for early parsing:
+        //
+        // - disable_version_flag: Don't stop at --version
+        // - disable_help_flag: Don't stop at -h/--help (we add a dummy instead)
+        // - ignore_errors: Continue parsing even with errors
+        //
+        // We add a dummy help flag that counts occurrences instead of triggering
+        // the DisplayHelp error. This allows early parsing to complete and extract
+        // our global options.
+        let early_cmd = app
+            .clone()
+            .disable_version_flag(true)
+            .disable_help_flag(true)
+            // Add a dummy help arg that doesn't stop parsing.
+            .arg(
+                clap::Arg::new("help")
+                    .short('h')
+                    .long("help")
+                    .global(true)
+                    .action(ArgAction::Count),
+            )
+            .ignore_errors(true);
+
+        // Try to parse. With ignore_errors, this should always succeed.
+        match early_cmd.try_get_matches_from(args) {
+            Ok(matches) => {
+                // Extract early args manually from matches.
+                // We use try_get_one to handle cases where the arg might not be
+                // present (e.g., if parsing failed partway through).
+                let no_pager = matches
+                    .try_get_one::<bool>("no_pager")
+                    .ok()
+                    .flatten()
+                    .copied()
+                    .unwrap_or(false);
+                let color = matches
+                    .try_get_one::<Color>("color")
+                    .ok()
+                    .flatten()
+                    .copied()
+                    .unwrap_or_default();
+                let user_config_file = matches
+                    .try_get_one::<String>("user_config_file")
+                    .ok()
+                    .flatten()
+                    .cloned();
+                EarlyArgs {
+                    color,
+                    no_pager,
+                    user_config_file,
+                }
+            }
+            Err(_) => {
+                // This shouldn't happen with ignore_errors, but fall back to defaults.
+                EarlyArgs::default()
+            }
+        }
+    }
+
     /// Returns the user config location.
     pub fn user_config_location(&self) -> UserConfigLocation<'_> {
         UserConfigLocation::from_cli_or_env(self.user_config_file.as_deref())
@@ -118,86 +150,15 @@ impl EarlyArgs {
     }
 }
 
-/// Extracts early arguments from CLI args using clap's parsing.
-///
-/// This approach uses clap's own argument parsing with `ignore_errors(true)`
-/// to properly handle the `--` separator and other edge cases.
-///
-/// The technique is inspired by Jujutsu, which uses a similar approach for
-/// early argument extraction.
-fn extract_early_args(args: &[String], app: &Command) -> EarlyArgs {
-    // Clone the command and configure it for early parsing:
-    //
-    // - disable_version_flag: Don't stop at --version
-    // - disable_help_flag: Don't stop at -h/--help (we add a dummy instead)
-    // - ignore_errors: Continue parsing even with errors
-    //
-    // We add a dummy help flag that counts occurrences instead of triggering
-    // the DisplayHelp error. This allows early parsing to complete and extract
-    // our global options.
-    let early_cmd = app
-        .clone()
-        .disable_version_flag(true)
-        .disable_help_flag(true)
-        // Add a dummy help arg that doesn't stop parsing.
-        .arg(
-            clap::Arg::new("help")
-                .short('h')
-                .long("help")
-                .global(true)
-                .action(ArgAction::Count),
-        )
-        .ignore_errors(true);
-
-    // Try to parse. With ignore_errors, this should always succeed.
-    match early_cmd.try_get_matches_from(args) {
-        Ok(matches) => {
-            // Extract early args manually from matches.
-            // We use try_get_one to handle cases where the arg might not be
-            // present (e.g., if parsing failed partway through).
-            let no_pager = matches
-                .try_get_one::<bool>("no_pager")
-                .ok()
-                .flatten()
-                .copied()
-                .unwrap_or(false);
-            let color = matches
-                .try_get_one::<Color>("color")
-                .ok()
-                .flatten()
-                .copied()
-                .unwrap_or_default();
-            let user_config_file = matches
-                .try_get_one::<String>("user_config_file")
-                .ok()
-                .flatten()
-                .cloned();
-            EarlyArgs {
-                color,
-                no_pager,
-                user_config_file,
-            }
-        }
-        Err(_) => {
-            // This shouldn't happen with ignore_errors, but fall back to defaults.
-            EarlyArgs::default()
-        }
-    }
-}
-
 /// Handles a clap error, potentially paging help output.
 ///
 /// Returns the exit code to use.
-pub fn handle_clap_error(err: clap::Error, early_setup: &EarlySetup) -> i32 {
+pub fn handle_clap_error(err: clap::Error, early_args: &EarlyArgs) -> i32 {
     use clap::error::ErrorKind;
 
     match err.kind() {
         ErrorKind::DisplayHelp | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand => {
-            handle_help_output(
-                err,
-                &early_setup.early_args,
-                &early_setup.build_target_platform,
-            );
+            handle_help_output(err, early_args);
             0
         }
         ErrorKind::DisplayVersion => {
@@ -214,7 +175,7 @@ pub fn handle_clap_error(err: clap::Error, early_setup: &EarlySetup) -> i32 {
 }
 
 /// Handles help output, potentially through a pager.
-fn handle_help_output(err: clap::Error, early_args: &EarlyArgs, host_platform: &Platform) {
+fn handle_help_output(err: clap::Error, early_args: &EarlyArgs) {
     let should_colorize = early_args
         .color
         .should_colorize(supports_color::Stream::Stdout);
@@ -234,8 +195,7 @@ fn handle_help_output(err: clap::Error, early_args: &EarlyArgs, host_platform: &
         return;
     }
 
-    let early_config =
-        EarlyUserConfig::for_platform(host_platform, early_args.user_config_location());
+    let early_config = EarlyUserConfig::load(early_args.user_config_location());
     if early_config.paginate == PaginateSetting::Never {
         let _ = std::io::stdout().write_all(help_text.as_bytes());
         return;
@@ -278,7 +238,7 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_early_args() {
+    fn test_extract() {
         // Remove this env var (which is set in CI) so that without arguments,
         // color is auto.
         unsafe {
@@ -286,41 +246,41 @@ mod tests {
         }
 
         // Empty args.
-        let early = extract_early_args(&[], &cmd());
+        let early = EarlyArgs::extract(&[], &cmd());
         assert!(!early.no_pager);
         assert!(matches!(early.color, Color::Auto));
 
         // --no-pager before subcommand.
-        let early = extract_early_args(&args("cargo nextest --no-pager run"), &cmd());
+        let early = EarlyArgs::extract(&args("cargo nextest --no-pager run"), &cmd());
         assert!(early.no_pager);
 
         // --color=always (equals syntax).
-        let early = extract_early_args(&args("cargo nextest --color=always"), &cmd());
+        let early = EarlyArgs::extract(&args("cargo nextest --color=always"), &cmd());
         assert!(matches!(early.color, Color::Always));
 
         // --color=never (equals syntax).
-        let early = extract_early_args(&args("cargo nextest --color=never"), &cmd());
+        let early = EarlyArgs::extract(&args("cargo nextest --color=never"), &cmd());
         assert!(matches!(early.color, Color::Never));
 
         // --color always (space syntax).
-        let early = extract_early_args(&args("cargo nextest --color always"), &cmd());
+        let early = EarlyArgs::extract(&args("cargo nextest --color always"), &cmd());
         assert!(matches!(early.color, Color::Always));
 
         // Combined --no-pager and --color.
-        let early = extract_early_args(&args("cargo nextest --no-pager --color=never run"), &cmd());
+        let early = EarlyArgs::extract(&args("cargo nextest --no-pager --color=never run"), &cmd());
         assert!(early.no_pager);
         assert!(matches!(early.color, Color::Never));
 
         // --no-pager after -- should be ignored.
-        let early = extract_early_args(&args("cargo nextest run -- --no-pager"), &cmd());
+        let early = EarlyArgs::extract(&args("cargo nextest run -- --no-pager"), &cmd());
         assert!(!early.no_pager, "--no-pager after -- should be ignored");
 
         // --no-pager before -- should work.
-        let early = extract_early_args(&args("cargo nextest --no-pager run -- test_name"), &cmd());
+        let early = EarlyArgs::extract(&args("cargo nextest --no-pager run -- test_name"), &cmd());
         assert!(early.no_pager, "--no-pager before -- should work");
 
         // --color after -- should be ignored.
-        let early = extract_early_args(&args("cargo nextest run -- --color=never"), &cmd());
+        let early = EarlyArgs::extract(&args("cargo nextest run -- --color=never"), &cmd());
         assert!(
             matches!(early.color, Color::Auto),
             "--color after -- should be ignored"

--- a/cargo-nextest/src/dispatch/core/list.rs
+++ b/cargo-nextest/src/dispatch/core/list.rs
@@ -86,10 +86,8 @@ impl App {
 
         let binary_list = self.base.build_binary_list("test")?;
 
-        let resolved_user_config = resolve_user_config(
-            &self.base.build_platforms.host.platform,
-            self.base.early_args.user_config_location(),
-        )?;
+        let resolved_user_config =
+            resolve_user_config(self.base.early_args.user_config_location())?;
         let (pager_setting, paginate) =
             self.base.early_args.resolve_pager(&resolved_user_config.ui);
 
@@ -199,10 +197,8 @@ impl App {
 
         let test_list = self.build_test_list(&ctx, binary_list, &test_filter, &profile)?;
 
-        let resolved_user_config = resolve_user_config(
-            &self.base.build_platforms.host.platform,
-            self.base.early_args.user_config_location(),
-        )?;
+        let resolved_user_config =
+            resolve_user_config(self.base.early_args.user_config_location())?;
         let (pager_setting, paginate) =
             self.base.early_args.resolve_pager(&resolved_user_config.ui);
 

--- a/cargo-nextest/src/dispatch/core/replay.rs
+++ b/cargo-nextest/src/dispatch/core/replay.rs
@@ -6,12 +6,16 @@
 use super::run::ReporterCommonOpts;
 use crate::{
     ExpectedError, Result,
-    dispatch::{EarlyArgs, common::CommonOpts, helpers::locate_workspace_root},
+    dispatch::{
+        EarlyArgs,
+        common::CommonOpts,
+        helpers::{locate_workspace_root, resolve_user_config},
+    },
     output::OutputContext,
 };
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::Args;
-use guppy::{graph::PackageGraph, platform::Platform};
+use guppy::graph::PackageGraph;
 use nextest_metadata::NextestExitCode;
 use nextest_runner::{
     errors::{DisplayErrorChain, RecordReadError},
@@ -86,11 +90,7 @@ pub(crate) fn exec_replay(
     output: OutputContext,
 ) -> Result<i32> {
     // Load user config and check the experimental feature early.
-    let host_platform =
-        Platform::build_target().expect("nextest is built for a supported platform");
-    let user_config =
-        UserConfig::for_host_platform(&host_platform, early_args.user_config_location())
-            .map_err(|e| ExpectedError::UserConfigError { err: Box::new(e) })?;
+    let user_config = resolve_user_config(early_args.user_config_location())?;
 
     // The replay command requires the record experimental feature to be enabled.
     if !user_config.is_experimental_enabled(UserConfigExperimental::Record) {

--- a/cargo-nextest/src/dispatch/core/run.rs
+++ b/cargo-nextest/src/dispatch/core/run.rs
@@ -944,10 +944,8 @@ impl App {
             .should_colorize(supports_color::Stream::Stderr);
 
         // Load and resolve user config with platform-specific overrides.
-        let resolved_user_config = resolve_user_config(
-            &self.base.build_platforms.host.platform,
-            self.base.early_args.user_config_location(),
-        )?;
+        let resolved_user_config =
+            resolve_user_config(self.base.early_args.user_config_location())?;
 
         // The -R/--rerun option requires the record experimental feature to be enabled.
         if rerun.is_some()
@@ -1236,10 +1234,8 @@ impl App {
             .should_colorize(supports_color::Stream::Stderr);
 
         // Load and resolve user config with platform-specific overrides.
-        let resolved_user_config = resolve_user_config(
-            &self.base.build_platforms.host.platform,
-            self.base.early_args.user_config_location(),
-        )?;
+        let resolved_user_config =
+            resolve_user_config(self.base.early_args.user_config_location())?;
 
         // Make the runner and reporter builders. Do them now so warnings are
         // emitted before we start doing the build.

--- a/cargo-nextest/src/dispatch/helpers.rs
+++ b/cargo-nextest/src/dispatch/helpers.rs
@@ -91,11 +91,9 @@ pub(super) fn detect_build_platforms(
 
 /// Loads and resolves user configuration with platform-specific overrides.
 pub(super) fn resolve_user_config(
-    host_platform: &Platform,
     location: UserConfigLocation<'_>,
 ) -> Result<UserConfig, ExpectedError> {
-    UserConfig::for_host_platform(host_platform, location)
-        .map_err(|e| ExpectedError::UserConfigError { err: Box::new(e) })
+    UserConfig::load(location).map_err(|e| ExpectedError::UserConfigError { err: Box::new(e) })
 }
 
 pub(super) fn discover_target_triple(

--- a/cargo-nextest/src/dispatch/imp.rs
+++ b/cargo-nextest/src/dispatch/imp.rs
@@ -5,22 +5,22 @@
 
 use super::{
     app::CargoNextestApp,
-    clap_error::{EarlySetup, handle_clap_error},
+    clap_error::{EarlyArgs, handle_clap_error},
 };
 use clap::{CommandFactory, Parser};
 
 /// Main entry point for cargo-nextest.
 ///
-/// This function handles CLI parsing, early setup (for paged help), and
-/// dispatches to the appropriate command. Both the main binary and the
-/// integration test duplicate use this.
+/// This function handles CLI parsing, early argument extraction (for paged
+/// help), and dispatches to the appropriate command. Both the main binary and
+/// the integration test duplicate use this.
 pub fn main_impl() -> ! {
     let cli_args: Vec<_> = std::env::args_os()
         .map(|arg| arg.to_string_lossy().into_owned())
         .collect();
 
     let app = CargoNextestApp::command();
-    let early_setup = EarlySetup::new(&cli_args, &app);
+    let early_args = EarlyArgs::extract(&cli_args, &app);
 
     match CargoNextestApp::try_parse() {
         Ok(opts) => {
@@ -34,7 +34,7 @@ pub fn main_impl() -> ! {
             }
         }
         Err(err) => {
-            let code = handle_clap_error(err, &early_setup);
+            let code = handle_clap_error(err, &early_args);
             std::process::exit(code);
         }
     }

--- a/nextest-runner/src/platform.rs
+++ b/nextest-runner/src/platform.rs
@@ -486,21 +486,6 @@ impl PlatformLibdir {
     }
 }
 
-/// Detects the host platform for use in tests.
-///
-/// Prefer this over `Platform::build_target()` in tests to ensure we're testing
-/// with the same platform detection logic used in production.
-#[cfg(test)]
-pub(crate) fn detect_host_platform_for_tests() -> Platform {
-    use crate::RustcCli;
-
-    HostPlatform::detect(PlatformLibdir::from_rustc_stdout(
-        RustcCli::print_host_libdir().read(),
-    ))
-    .expect("host platform detection should succeed in tests")
-    .platform
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/nextest-runner/src/user_config/early.rs
+++ b/nextest-runner/src/user_config/early.rs
@@ -31,8 +31,8 @@ use tracing::{debug, warn};
 /// parsing completes. It contains only the settings needed to decide whether
 /// and how to page help output.
 ///
-/// Use [`Self::for_platform`] to load from the default location. If an error
-/// occurs, defaults are used and a warning is logged.
+/// Use [`Self::load`] to load from the default location. If an error occurs,
+/// defaults are used and a warning is logged.
 #[derive(Clone, Debug)]
 pub struct EarlyUserConfig {
     /// Which pager to use.
@@ -44,35 +44,41 @@ pub struct EarlyUserConfig {
 }
 
 impl EarlyUserConfig {
-    /// Loads early user configuration for the given host platform.
+    /// Loads early user configuration.
     ///
     /// This attempts to load user config from the specified location and resolve
     /// pager settings. On any error, returns defaults and logs a warning.
     ///
     /// This is intentionally fault-tolerant: help paging is a nice-to-have
     /// feature, so we prefer degraded behavior over failing to show help.
-    pub fn for_platform(host_platform: &Platform, location: UserConfigLocation<'_>) -> Self {
-        match Self::try_load(host_platform, location) {
+    ///
+    /// Platform overrides in the user config are evaluated against the build
+    /// target of the nextest binary (via [`Platform::build_target`]). See
+    /// [`super::UserConfig::load`] for the rationale.
+    pub fn load(location: UserConfigLocation<'_>) -> Self {
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        match Self::try_load(&build_target, location) {
             Ok(config) => config,
             Err(error) => {
                 warn!(
                     "failed to load user config for pager settings, using defaults: {}",
                     error
                 );
-                Self::defaults(host_platform)
+                Self::defaults(&build_target)
             }
         }
     }
 
-    /// Returns the default pager configuration for the host platform.
-    fn defaults(host_platform: &Platform) -> Self {
+    /// Returns the default pager configuration for the build target.
+    fn defaults(build_target: &Platform) -> Self {
         let default_config = DefaultUserConfig::from_embedded();
-        Self::resolve_from_defaults(&default_config, host_platform)
+        Self::resolve_from_defaults(&default_config, build_target)
     }
 
     /// Attempts to load early user configuration from the specified location.
     fn try_load(
-        host_platform: &Platform,
+        build_target: &Platform,
         location: UserConfigLocation<'_>,
     ) -> Result<Self, EarlyConfigError> {
         let default_config = DefaultUserConfig::from_embedded();
@@ -80,7 +86,7 @@ impl EarlyUserConfig {
         match location {
             UserConfigLocation::Isolated => {
                 debug!("early user config: skipping (isolated)");
-                Ok(Self::resolve_from_defaults(&default_config, host_platform))
+                Ok(Self::resolve_from_defaults(&default_config, build_target))
             }
             UserConfigLocation::Explicit(path) => {
                 debug!("early user config: loading from explicit path {path}");
@@ -90,7 +96,7 @@ impl EarlyUserConfig {
                         Ok(Self::resolve(
                             &default_config,
                             Some(&user_config),
-                            host_platform,
+                            build_target,
                         ))
                     }
                     Ok(None) => Err(EarlyConfigError::FileNotFound(path.to_owned())),
@@ -98,7 +104,7 @@ impl EarlyUserConfig {
                 }
             }
             UserConfigLocation::Default => {
-                Self::try_load_from_default_locations(&default_config, host_platform)
+                Self::try_load_from_default_locations(&default_config, build_target)
             }
         }
     }
@@ -106,13 +112,13 @@ impl EarlyUserConfig {
     /// Attempts to load early user configuration from default locations.
     fn try_load_from_default_locations(
         default_config: &DefaultUserConfig,
-        host_platform: &Platform,
+        build_target: &Platform,
     ) -> Result<Self, EarlyConfigError> {
         let paths = user_config_paths().map_err(EarlyConfigError::Discovery)?;
 
         if paths.is_empty() {
             debug!("early user config: no config directory found, using defaults");
-            return Ok(Self::resolve_from_defaults(default_config, host_platform));
+            return Ok(Self::resolve_from_defaults(default_config, build_target));
         }
 
         // Try each candidate path.
@@ -123,7 +129,7 @@ impl EarlyUserConfig {
                     return Ok(Self::resolve(
                         default_config,
                         Some(&user_config),
-                        host_platform,
+                        build_target,
                     ));
                 }
                 Ok(None) => {
@@ -139,19 +145,19 @@ impl EarlyUserConfig {
         }
 
         debug!("early user config: no config file found, using defaults");
-        Ok(Self::resolve_from_defaults(default_config, host_platform))
+        Ok(Self::resolve_from_defaults(default_config, build_target))
     }
 
     /// Resolves configuration from defaults.
-    fn resolve_from_defaults(default_config: &DefaultUserConfig, host_platform: &Platform) -> Self {
-        Self::resolve(default_config, None, host_platform)
+    fn resolve_from_defaults(default_config: &DefaultUserConfig, build_target: &Platform) -> Self {
+        Self::resolve(default_config, None, build_target)
     }
 
     /// Resolves configuration from defaults and optional user config.
     fn resolve(
         default_config: &DefaultUserConfig,
         user_config: Option<&EarlyDeserializedConfig>,
-        host_platform: &Platform,
+        build_target: &Platform,
     ) -> Self {
         // Compile user overrides.
         let user_overrides: Vec<CompiledUiOverride> = user_config
@@ -181,7 +187,7 @@ impl EarlyUserConfig {
             &default_config.ui_overrides,
             user_config.and_then(|c| c.ui.pager.as_ref()),
             &user_overrides,
-            host_platform,
+            build_target,
             |data| data.pager(),
         );
 
@@ -190,7 +196,7 @@ impl EarlyUserConfig {
             &default_config.ui_overrides,
             user_config.and_then(|c| c.ui.paginate.as_ref()),
             &user_overrides,
-            host_platform,
+            build_target,
             |data| data.paginate(),
         );
 
@@ -200,7 +206,7 @@ impl EarlyUserConfig {
                 &default_config.ui_overrides,
                 user_config.and_then(|c| c.ui.streampager_interface()),
                 &user_overrides,
-                host_platform,
+                build_target,
                 |data| data.streampager_interface(),
             ),
             wrapping: resolve_ui_setting(
@@ -208,7 +214,7 @@ impl EarlyUserConfig {
                 &default_config.ui_overrides,
                 user_config.and_then(|c| c.ui.streampager_wrapping()),
                 &user_overrides,
-                host_platform,
+                build_target,
                 |data| data.streampager_wrapping(),
             ),
             show_ruler: resolve_ui_setting(
@@ -216,7 +222,7 @@ impl EarlyUserConfig {
                 &default_config.ui_overrides,
                 user_config.and_then(|c| c.ui.streampager_show_ruler()),
                 &user_overrides,
-                host_platform,
+                build_target,
                 |data| data.streampager_show_ruler(),
             ),
         };
@@ -332,12 +338,12 @@ struct EarlyDeserializedOverride {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::platform::detect_host_platform_for_tests;
 
     #[test]
     fn test_early_user_config_defaults() {
-        let host = detect_host_platform_for_tests();
-        let config = EarlyUserConfig::defaults(&host);
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        let config = EarlyUserConfig::defaults(&build_target);
 
         // This should have a configured pager.
         match &config.pager {
@@ -352,11 +358,9 @@ mod tests {
     }
 
     #[test]
-    fn test_early_user_config_from_host_platform() {
-        let host = detect_host_platform_for_tests();
-
+    fn test_early_user_config_load() {
         // This should not panic, even if no config file exists.
-        let config = EarlyUserConfig::for_platform(&host, UserConfigLocation::Default);
+        let config = EarlyUserConfig::load(UserConfigLocation::Default);
 
         // Should return a valid config.
         match &config.pager {

--- a/nextest-runner/src/user_config/elements/record.rs
+++ b/nextest-runner/src/user_config/elements/record.rs
@@ -133,13 +133,13 @@ impl CompiledRecordOverride {
         }
     }
 
-    /// Checks if this override matches the host platform.
+    /// Checks if this override matches the given platform.
     ///
     /// Unknown results (e.g., unrecognized target features) are treated as
     /// non-matching to be conservative.
-    pub(in crate::user_config) fn matches(&self, host_platform: &Platform) -> bool {
+    pub(in crate::user_config) fn matches(&self, build_target: &Platform) -> bool {
         self.platform_spec
-            .eval(host_platform)
+            .eval(build_target)
             .unwrap_or(/* unknown results are mapped to false */ false)
     }
 
@@ -209,8 +209,8 @@ pub struct RecordConfig {
 }
 
 impl RecordConfig {
-    /// Resolves record configuration from user configs, defaults, and the host
-    /// platform.
+    /// Resolves record configuration from user configs, defaults, and the
+    /// build target of the nextest binary.
     ///
     /// Resolution order (highest to lowest priority):
     ///
@@ -228,14 +228,14 @@ impl RecordConfig {
         default_overrides: &[CompiledRecordOverride],
         user_config: Option<&DeserializedRecordConfig>,
         user_overrides: &[CompiledRecordOverride],
-        host_platform: &Platform,
+        build_target: &Platform,
     ) -> Self {
         let mut max_output_size = resolve_record_setting(
             &default_config.max_output_size,
             default_overrides,
             user_config.and_then(|c| c.max_output_size.as_ref()),
             user_overrides,
-            host_platform,
+            build_target,
             |data| data.max_output_size(),
         );
 
@@ -262,7 +262,7 @@ impl RecordConfig {
                 default_overrides,
                 user_config.and_then(|c| c.enabled.as_ref()),
                 user_overrides,
-                host_platform,
+                build_target,
                 |data| data.enabled(),
             ),
             max_records: resolve_record_setting(
@@ -270,7 +270,7 @@ impl RecordConfig {
                 default_overrides,
                 user_config.and_then(|c| c.max_records.as_ref()),
                 user_overrides,
-                host_platform,
+                build_target,
                 |data| data.max_records(),
             ),
             max_total_size: resolve_record_setting(
@@ -278,7 +278,7 @@ impl RecordConfig {
                 default_overrides,
                 user_config.and_then(|c| c.max_total_size.as_ref()),
                 user_overrides,
-                host_platform,
+                build_target,
                 |data| data.max_total_size(),
             ),
             max_age: resolve_record_setting(
@@ -286,7 +286,7 @@ impl RecordConfig {
                 default_overrides,
                 user_config.and_then(|c| c.max_age.as_ref()),
                 user_overrides,
-                host_platform,
+                build_target,
                 |data| data.max_age(),
             ),
             max_output_size,
@@ -297,7 +297,6 @@ impl RecordConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::platform::detect_host_platform_for_tests;
 
     #[test]
     fn test_deserialized_record_config_parsing() {
@@ -372,8 +371,9 @@ mod tests {
             max_output_size: ByteSize::mb(10),
         };
 
-        let host = detect_host_platform_for_tests();
-        let resolved = RecordConfig::resolve(&defaults, &[], None, &[], &host);
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        let resolved = RecordConfig::resolve(&defaults, &[], None, &[], &build_target);
 
         assert!(!resolved.enabled);
         assert_eq!(resolved.max_records, 100);
@@ -400,8 +400,10 @@ mod tests {
             max_output_size: Some(ByteSize::mb(5)),
         };
 
-        let host = detect_host_platform_for_tests();
-        let resolved = RecordConfig::resolve(&defaults, &[], Some(&user_config), &[], &host);
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        let resolved =
+            RecordConfig::resolve(&defaults, &[], Some(&user_config), &[], &build_target);
 
         assert!(resolved.enabled); // From user.
         assert_eq!(resolved.max_records, 50); // From user.
@@ -429,8 +431,10 @@ mod tests {
             max_output_size: Some(ByteSize::b(100)), // Way below minimum.
         };
 
-        let host = detect_host_platform_for_tests();
-        let resolved = RecordConfig::resolve(&defaults, &[], Some(&user_config), &[], &host);
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        let resolved =
+            RecordConfig::resolve(&defaults, &[], Some(&user_config), &[], &build_target);
 
         // Should be clamped to the minimum.
         assert_eq!(resolved.max_output_size, MIN_MAX_OUTPUT_SIZE);
@@ -455,8 +459,10 @@ mod tests {
             max_output_size: Some(MIN_MAX_OUTPUT_SIZE),
         };
 
-        let host = detect_host_platform_for_tests();
-        let resolved = RecordConfig::resolve(&defaults, &[], Some(&user_config), &[], &host);
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        let resolved =
+            RecordConfig::resolve(&defaults, &[], Some(&user_config), &[], &build_target);
 
         // Should be accepted as-is.
         assert_eq!(resolved.max_output_size, MIN_MAX_OUTPUT_SIZE);
@@ -481,8 +487,10 @@ mod tests {
             max_output_size: Some(ByteSize::gib(1)), // Way above maximum.
         };
 
-        let host = detect_host_platform_for_tests();
-        let resolved = RecordConfig::resolve(&defaults, &[], Some(&user_config), &[], &host);
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        let resolved =
+            RecordConfig::resolve(&defaults, &[], Some(&user_config), &[], &build_target);
 
         // Should be clamped to the maximum.
         assert_eq!(resolved.max_output_size, MAX_MAX_OUTPUT_SIZE);
@@ -507,8 +515,10 @@ mod tests {
             max_output_size: Some(MAX_MAX_OUTPUT_SIZE),
         };
 
-        let host = detect_host_platform_for_tests();
-        let resolved = RecordConfig::resolve(&defaults, &[], Some(&user_config), &[], &host);
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        let resolved =
+            RecordConfig::resolve(&defaults, &[], Some(&user_config), &[], &build_target);
 
         // Should be accepted as-is.
         assert_eq!(resolved.max_output_size, MAX_MAX_OUTPUT_SIZE);
@@ -544,8 +554,9 @@ mod tests {
             },
         );
 
-        let host = detect_host_platform_for_tests();
-        let resolved = RecordConfig::resolve(&defaults, &[], None, &[override_], &host);
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        let resolved = RecordConfig::resolve(&defaults, &[], None, &[override_], &build_target);
 
         assert!(resolved.enabled);
         assert_eq!(resolved.max_records, 50);
@@ -574,8 +585,9 @@ mod tests {
             },
         );
 
-        let host = detect_host_platform_for_tests();
-        let resolved = RecordConfig::resolve(&defaults, &[override_], None, &[], &host);
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        let resolved = RecordConfig::resolve(&defaults, &[override_], None, &[], &build_target);
 
         assert!(resolved.enabled);
         assert_eq!(resolved.max_records, 50);
@@ -605,8 +617,9 @@ mod tests {
             },
         );
 
-        let host = detect_host_platform_for_tests();
-        let resolved = RecordConfig::resolve(&defaults, &[], None, &[override_], &host);
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        let resolved = RecordConfig::resolve(&defaults, &[], None, &[override_], &build_target);
 
         // Nothing should be overridden - all values should match defaults.
         assert!(!resolved.enabled);
@@ -644,8 +657,10 @@ mod tests {
             },
         );
 
-        let host = detect_host_platform_for_tests();
-        let resolved = RecordConfig::resolve(&defaults, &[], None, &[override1, override2], &host);
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        let resolved =
+            RecordConfig::resolve(&defaults, &[], None, &[override1, override2], &build_target);
 
         // First override wins for enabled.
         assert!(resolved.enabled);
@@ -682,13 +697,14 @@ mod tests {
             },
         );
 
-        let host = detect_host_platform_for_tests();
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
         let resolved = RecordConfig::resolve(
             &defaults,
             &[default_override],
             None,
             &[user_override],
-            &host,
+            &build_target,
         );
 
         // User override wins for enabled.
@@ -723,13 +739,14 @@ mod tests {
             },
         );
 
-        let host = detect_host_platform_for_tests();
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
         let resolved = RecordConfig::resolve(
             &defaults,
             &[default_override],
             Some(&user_config),
             &[],
-            &host,
+            &build_target,
         );
 
         // Default override is chosen over user base for enabled.
@@ -757,8 +774,9 @@ mod tests {
             },
         );
 
-        let host = detect_host_platform_for_tests();
-        let resolved = RecordConfig::resolve(&defaults, &[], None, &[override_], &host);
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        let resolved = RecordConfig::resolve(&defaults, &[], None, &[override_], &build_target);
 
         // Should be clamped to the minimum.
         assert_eq!(resolved.max_output_size, MIN_MAX_OUTPUT_SIZE);

--- a/nextest-runner/src/user_config/elements/ui.rs
+++ b/nextest-runner/src/user_config/elements/ui.rs
@@ -146,13 +146,13 @@ impl CompiledUiOverride {
         }
     }
 
-    /// Checks if this override matches the host platform.
+    /// Checks if this override matches the given platform.
     ///
     /// Unknown results (e.g., unrecognized target features) are treated as
     /// non-matching to be conservative.
-    pub(in crate::user_config) fn matches(&self, host_platform: &Platform) -> bool {
+    pub(in crate::user_config) fn matches(&self, build_target: &Platform) -> bool {
         self.platform_spec
-            .eval(host_platform)
+            .eval(build_target)
             .unwrap_or(/* unknown results are mapped to false */ false)
     }
 
@@ -226,8 +226,8 @@ pub struct UiConfig {
 }
 
 impl UiConfig {
-    /// Resolves UI configuration from user configs, defaults, and the host
-    /// platform.
+    /// Resolves UI configuration from user configs, defaults, and the build
+    /// target of the nextest binary.
     ///
     /// Resolution order (highest to lowest priority):
     ///
@@ -242,7 +242,7 @@ impl UiConfig {
         default_overrides: &[CompiledUiOverride],
         user_config: Option<&DeserializedUiConfig>,
         user_overrides: &[CompiledUiOverride],
-        host_platform: &Platform,
+        build_target: &Platform,
     ) -> Self {
         Self {
             show_progress: resolve_ui_setting(
@@ -250,7 +250,7 @@ impl UiConfig {
                 default_overrides,
                 user_config.and_then(|c| c.show_progress.as_ref()),
                 user_overrides,
-                host_platform,
+                build_target,
                 |data| data.show_progress.as_ref(),
             ),
             max_progress_running: resolve_ui_setting(
@@ -258,7 +258,7 @@ impl UiConfig {
                 default_overrides,
                 user_config.and_then(|c| c.max_progress_running.as_ref()),
                 user_overrides,
-                host_platform,
+                build_target,
                 |data| data.max_progress_running.as_ref(),
             ),
             input_handler: resolve_ui_setting(
@@ -266,7 +266,7 @@ impl UiConfig {
                 default_overrides,
                 user_config.and_then(|c| c.input_handler.as_ref()),
                 user_overrides,
-                host_platform,
+                build_target,
                 |data| data.input_handler.as_ref(),
             ),
             output_indent: resolve_ui_setting(
@@ -274,7 +274,7 @@ impl UiConfig {
                 default_overrides,
                 user_config.and_then(|c| c.output_indent.as_ref()),
                 user_overrides,
-                host_platform,
+                build_target,
                 |data| data.output_indent.as_ref(),
             ),
             pager: resolve_ui_setting(
@@ -282,7 +282,7 @@ impl UiConfig {
                 default_overrides,
                 user_config.and_then(|c| c.pager.as_ref()),
                 user_overrides,
-                host_platform,
+                build_target,
                 |data| data.pager.as_ref(),
             ),
             paginate: resolve_ui_setting(
@@ -290,7 +290,7 @@ impl UiConfig {
                 default_overrides,
                 user_config.and_then(|c| c.paginate.as_ref()),
                 user_overrides,
-                host_platform,
+                build_target,
                 |data| data.paginate.as_ref(),
             ),
             streampager: StreampagerConfig {
@@ -299,7 +299,7 @@ impl UiConfig {
                     default_overrides,
                     user_config.and_then(|c| c.streampager.interface.as_ref()),
                     user_overrides,
-                    host_platform,
+                    build_target,
                     |data| data.streampager_interface.as_ref(),
                 ),
                 wrapping: resolve_ui_setting(
@@ -307,7 +307,7 @@ impl UiConfig {
                     default_overrides,
                     user_config.and_then(|c| c.streampager.wrapping.as_ref()),
                     user_overrides,
-                    host_platform,
+                    build_target,
                     |data| data.streampager_wrapping.as_ref(),
                 ),
                 show_ruler: resolve_ui_setting(
@@ -315,7 +315,7 @@ impl UiConfig {
                     default_overrides,
                     user_config.and_then(|c| c.streampager.show_ruler.as_ref()),
                     user_overrides,
-                    host_platform,
+                    build_target,
                     |data| data.streampager_show_ruler.as_ref(),
                 ),
             },
@@ -715,7 +715,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{platform::detect_host_platform_for_tests, user_config::DefaultUserConfig};
+    use crate::user_config::DefaultUserConfig;
 
     /// Helper to create a CompiledUiOverride for tests.
     fn make_override(platform: &str, data: DeserializedUiOverrideData) -> CompiledUiOverride {
@@ -839,8 +839,9 @@ mod tests {
     fn test_resolved_ui_config_defaults_only() {
         let defaults = DefaultUserConfig::from_embedded().ui;
 
-        let host = detect_host_platform_for_tests();
-        let resolved = UiConfig::resolve(&defaults, &[], None, &[], &host);
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        let resolved = UiConfig::resolve(&defaults, &[], None, &[], &build_target);
 
         // Resolved values should match the embedded defaults.
         assert_eq!(resolved.show_progress, defaults.show_progress);
@@ -860,8 +861,9 @@ mod tests {
             ..Default::default()
         };
 
-        let host = detect_host_platform_for_tests();
-        let resolved = UiConfig::resolve(&defaults, &[], Some(&user_config), &[], &host);
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        let resolved = UiConfig::resolve(&defaults, &[], Some(&user_config), &[], &build_target);
 
         assert_eq!(resolved.show_progress, UiShowProgress::Bar);
         assert_eq!(resolved.max_progress_running, MaxProgressRunning::Count(4));
@@ -883,8 +885,9 @@ mod tests {
             },
         );
 
-        let host = detect_host_platform_for_tests();
-        let resolved = UiConfig::resolve(&defaults, &[], None, &[override_], &host);
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        let resolved = UiConfig::resolve(&defaults, &[], None, &[override_], &build_target);
 
         assert_eq!(resolved.show_progress, UiShowProgress::Counter);
         assert_eq!(resolved.max_progress_running, defaults.max_progress_running); // From defaults.
@@ -906,8 +909,9 @@ mod tests {
             },
         );
 
-        let host = detect_host_platform_for_tests();
-        let resolved = UiConfig::resolve(&defaults, &[override_], None, &[], &host);
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        let resolved = UiConfig::resolve(&defaults, &[override_], None, &[], &build_target);
 
         assert_eq!(resolved.show_progress, UiShowProgress::Counter);
         assert_eq!(resolved.max_progress_running, defaults.max_progress_running); // From defaults.
@@ -934,8 +938,9 @@ mod tests {
             },
         );
 
-        let host = detect_host_platform_for_tests();
-        let resolved = UiConfig::resolve(&defaults, &[], None, &[override_], &host);
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        let resolved = UiConfig::resolve(&defaults, &[], None, &[override_], &build_target);
 
         // Nothing should be overridden - all values should match defaults.
         assert_eq!(resolved.show_progress, defaults.show_progress);
@@ -966,8 +971,10 @@ mod tests {
             },
         );
 
-        let host = detect_host_platform_for_tests();
-        let resolved = UiConfig::resolve(&defaults, &[], None, &[override1, override2], &host);
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        let resolved =
+            UiConfig::resolve(&defaults, &[], None, &[override1, override2], &build_target);
 
         // First override wins for show_progress.
         assert_eq!(resolved.show_progress, UiShowProgress::Bar);
@@ -998,13 +1005,14 @@ mod tests {
             },
         );
 
-        let host = detect_host_platform_for_tests();
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
         let resolved = UiConfig::resolve(
             &defaults,
             &[default_override],
             None,
             &[user_override],
-            &host,
+            &build_target,
         );
 
         // User override wins for show_progress.
@@ -1033,13 +1041,14 @@ mod tests {
             },
         );
 
-        let host = detect_host_platform_for_tests();
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
         let resolved = UiConfig::resolve(
             &defaults,
             &[default_override],
             Some(&user_config),
             &[],
-            &host,
+            &build_target,
         );
 
         // Default override is chosen over user base for show_progress.
@@ -1309,8 +1318,9 @@ mod tests {
     fn test_resolved_ui_config_pager_defaults() {
         let defaults = DefaultUserConfig::from_embedded().ui;
 
-        let host = detect_host_platform_for_tests();
-        let resolved = UiConfig::resolve(&defaults, &[], None, &[], &host);
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        let resolved = UiConfig::resolve(&defaults, &[], None, &[], &build_target);
 
         // Resolved values should match the embedded defaults.
         assert_eq!(resolved.pager, defaults.pager);
@@ -1334,8 +1344,9 @@ mod tests {
             },
         );
 
-        let host = detect_host_platform_for_tests();
-        let resolved = UiConfig::resolve(&defaults, &[], None, &[override_], &host);
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        let resolved = UiConfig::resolve(&defaults, &[], None, &[override_], &build_target);
 
         assert_eq!(resolved.pager, custom_pager);
         // paginate should still be from defaults.
@@ -1355,8 +1366,9 @@ mod tests {
             },
         );
 
-        let host = detect_host_platform_for_tests();
-        let resolved = UiConfig::resolve(&defaults, &[], None, &[override_], &host);
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        let resolved = UiConfig::resolve(&defaults, &[], None, &[override_], &build_target);
 
         assert_eq!(resolved.paginate, PaginateSetting::Never);
         // pager should still be from defaults.
@@ -1431,8 +1443,9 @@ mod tests {
             },
         );
 
-        let host = detect_host_platform_for_tests();
-        let resolved = UiConfig::resolve(&defaults, &[], None, &[override_], &host);
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+        let resolved = UiConfig::resolve(&defaults, &[], None, &[override_], &build_target);
 
         // Interface should be overridden.
         assert_eq!(

--- a/nextest-runner/src/user_config/helpers.rs
+++ b/nextest-runner/src/user_config/helpers.rs
@@ -14,12 +14,12 @@ pub(crate) fn resolve_ui_setting<T: Clone>(
     default_overrides: &[CompiledUiOverride],
     user_value: Option<&T>,
     user_overrides: &[CompiledUiOverride],
-    host_platform: &Platform,
+    build_target: &Platform,
     get_override: impl Fn(&UiOverrideData) -> Option<&T>,
 ) -> T {
     // 1. User overrides (first match).
     for override_ in user_overrides {
-        if override_.matches(host_platform)
+        if override_.matches(build_target)
             && let Some(v) = get_override(override_.data())
         {
             return v.clone();
@@ -28,7 +28,7 @@ pub(crate) fn resolve_ui_setting<T: Clone>(
 
     // 2. Default overrides (first match).
     for override_ in default_overrides {
-        if override_.matches(host_platform)
+        if override_.matches(build_target)
             && let Some(v) = get_override(override_.data())
         {
             return v.clone();
@@ -50,12 +50,12 @@ pub(crate) fn resolve_record_setting<T: Clone>(
     default_overrides: &[CompiledRecordOverride],
     user_value: Option<&T>,
     user_overrides: &[CompiledRecordOverride],
-    host_platform: &Platform,
+    build_target: &Platform,
     get_override: impl Fn(&RecordOverrideData) -> Option<&T>,
 ) -> T {
     // 1. User overrides (first match).
     for override_ in user_overrides {
-        if override_.matches(host_platform)
+        if override_.matches(build_target)
             && let Some(v) = get_override(override_.data())
         {
             return v.clone();
@@ -64,7 +64,7 @@ pub(crate) fn resolve_record_setting<T: Clone>(
 
     // 2. Default overrides (first match).
     for override_ in default_overrides {
-        if override_.matches(host_platform)
+        if override_.matches(build_target)
             && let Some(v) = get_override(override_.data())
         {
             return v.clone();

--- a/nextest-runner/src/user_config/imp.rs
+++ b/nextest-runner/src/user_config/imp.rs
@@ -67,11 +67,19 @@ pub struct UserConfig {
 }
 
 impl UserConfig {
-    /// Loads and resolves user configuration for the given host platform.
-    pub fn for_host_platform(
-        host_platform: &Platform,
-        location: UserConfigLocation<'_>,
-    ) -> Result<Self, UserConfigError> {
+    /// Loads and resolves user configuration.
+    ///
+    /// Platform overrides in the user config are evaluated against the build
+    /// target of the nextest binary (via [`Platform::build_target`]), not
+    /// against the host platform reported by `rustc -vV`. User config expresses
+    /// per-user preferences for the running nextest binary, so the binary's
+    /// build target is the right thing to match against — and this keeps
+    /// resolution consistent across normal runs, archive replay, and commands
+    /// that don't otherwise need to detect a host platform.
+    pub fn load(location: UserConfigLocation<'_>) -> Result<Self, UserConfigError> {
+        let build_target =
+            Platform::build_target().expect("nextest is built for a supported platform");
+
         let user_config = CompiledUserConfig::from_location(location)?;
         let default_user_config = DefaultUserConfig::from_embedded();
 
@@ -89,7 +97,7 @@ impl UserConfig {
                 .as_ref()
                 .map(|c| &c.ui_overrides[..])
                 .unwrap_or(&[]),
-            host_platform,
+            &build_target,
         );
 
         let resolved_record = RecordConfig::resolve(
@@ -100,7 +108,7 @@ impl UserConfig {
                 .as_ref()
                 .map(|c| &c.record_overrides[..])
                 .unwrap_or(&[]),
-            host_platform,
+            &build_target,
         );
 
         Ok(Self {

--- a/site/src/docs/user-config/index.md
+++ b/site/src/docs/user-config/index.md
@@ -54,7 +54,7 @@ ui.max-progress-running = 4
 
 !!! note "User config vs. per-test overrides"
 
-    <!-- md:version 0.9.134 --> The `platform` spec is matched against nextest's build target. In most cases, this is the same as the host platform. But it can sometimes differ, for example with using nextest's musl binaries against gnu build targets. In this case, the build target is `x86_64-unknown-linux-musl` or `aarch64-unknown-linux-musl`, while the host platform is the corresponding `-gnu` platform.
+    <!-- md:version 0.9.134 --> The `platform` spec is matched against nextest's build target. In most cases, this is the same as the host platform. But it can sometimes differ, for example when running a musl-targeted nextest binary on a glibc (`-gnu`) host. In this case, the build target is `x86_64-unknown-linux-musl` or `aarch64-unknown-linux-musl`, while the host platform is the corresponding `-gnu` platform.
     
     This is distinct from the `platform` field in [per-test overrides](../configuration/per-test-overrides.md#selecting-tests), which is matched against the host or target platform of the tests being run.
 

--- a/site/src/docs/user-config/index.md
+++ b/site/src/docs/user-config/index.md
@@ -50,7 +50,13 @@ platform = "cfg(windows)"
 ui.max-progress-running = 4
 ```
 
-Overrides are evaluated against the *host* platform (where nextest is running). For each setting, the first matching override provides the value. See the [user config reference](reference.md#platform-specific-overrides) for details.
+<!-- md:version 0.9.134 --> Overrides are evaluated against the _build target_: the platform nextest was compiled for. In earlier versions, the build target was used in some cases and the host platform in others. See the [user config reference](reference.md#platform-specific-overrides) for details.
+
+!!! note "User config vs. per-test overrides"
+
+    <!-- md:version 0.9.134 --> The `platform` spec is matched against nextest's build target. In most cases, this is the same as the host platform. But it can sometimes differ, for example with using nextest's musl binaries against gnu build targets. In this case, the build target is `x86_64-unknown-linux-musl` or `aarch64-unknown-linux-musl`, while the host platform is the corresponding `-gnu` platform.
+    
+    This is distinct from the `platform` field in [per-test overrides](../configuration/per-test-overrides.md#selecting-tests), which is matched against the host or target platform of the tests being run.
 
 !!! note "User config versus repository config"
 

--- a/site/src/docs/user-config/reference.md
+++ b/site/src/docs/user-config/reference.md
@@ -288,7 +288,7 @@ Each override has a required `platform` filter and optional settings in the `ui`
 #### `overrides.platform`
 
 - **Type**: String (target spec expression)
-- **Description**: Platform specification for when this override applies. The expression is evaluated against the *host* platform (where nextest is running).
+- **Description**: Platform specification for when this override applies. The expression is evaluated against the _build target_: the platform nextest was compiled for. This is distinct from the `platform` field in [per-test overrides](../configuration/per-test-overrides.md#selecting-tests), which is matched against the host or target platform of the tests being run.
 - **Required**: Yes
 - **Documentation**: [_Specifying platforms_](../configuration/specifying-platforms.md)
 - **Valid formats**:


### PR DESCRIPTION
We currently use the build target platform in some cases and the host platform in others. This is pretty janky.

Always use the build target platform. For user config that makes the most sense.