### PR TITLE
[cargo-nextest] check store format version at export time

### DIFF
--- a/cargo-nextest/src/dispatch/utility/store.rs
+++ b/cargo-nextest/src/dispatch/utility/store.rs
@@ -17,8 +17,9 @@ use nextest_runner::{
     record::{
         ChromeTraceGroupBy, ChromeTraceMessageFormat, DisplayRunList, PortableRecording,
         PortableRecordingWriter, PruneKind, RecordReader, RecordRetentionPolicy, RecordedRunStatus,
-        RunIdIndex, RunIdOrRecordingSelector, RunIdSelector, RunStore, SnapshotWithReplayability,
-        Styles as RecordStyles, convert_to_chrome_trace, has_zip_extension, records_state_dir,
+        RunIdIndex, RunIdOrRecordingSelector, RunIdSelector, RunStore, STORE_FORMAT_VERSION,
+        SnapshotWithReplayability, Styles as RecordStyles, convert_to_chrome_trace,
+        has_zip_extension, records_state_dir,
     },
     redact::Redactor,
     user_config::{UserConfig, elements::RecordConfig},
@@ -286,10 +287,23 @@ impl ExportChromeTraceOpts {
             .map_err(|err| ExpectedError::RunIdResolutionError { err })?;
         let run_id = resolved.run_id;
 
-        // Warn if the run is incomplete.
         let run = snapshot
             .get_run(run_id)
             .expect("run ID was just resolved, so the run should exist");
+
+        // Check the store format version before opening the archive. Otherwise,
+        // an incompatible run would fail partway through event deserialization
+        // with a confusing error.
+        if let Err(incompatibility) = run
+            .store_format_version
+            .check_readable_by(STORE_FORMAT_VERSION)
+        {
+            return Err(ExpectedError::StoreVersionIncompatible {
+                run_id,
+                incompatibility,
+            });
+        }
+
         if matches!(
             run.status,
             RecordedRunStatus::Incomplete | RecordedRunStatus::Unknown
@@ -401,7 +415,18 @@ impl ExportOpts {
             .get_run(run_id)
             .expect("run ID was just resolved, so the run should exist");
 
-        // Warn if the run is incomplete.
+        // Check the store format version. If the current nextest can't read
+        // the run, don't let it produce a portable recording from it.
+        if let Err(incompatibility) = run
+            .store_format_version
+            .check_readable_by(STORE_FORMAT_VERSION)
+        {
+            return Err(ExpectedError::StoreVersionIncompatible {
+                run_id,
+                incompatibility,
+            });
+        }
+
         if matches!(
             run.status,
             RecordedRunStatus::Incomplete | RecordedRunStatus::Unknown

--- a/integration-tests/tests/integration/record_replay.rs
+++ b/integration-tests/tests/integration/record_replay.rs
@@ -53,6 +53,13 @@ const NEXTEST_STATE_DIR_ENV: &str = "NEXTEST_STATE_DIR";
 /// This is the same constant as in `nextest_runner::runner::imp`.
 const FORCE_RUN_ID_ENV: &str = "__NEXTEST_FORCE_RUN_ID";
 
+/// Environment variable to force a specific store format version in the
+/// per-run metadata written to `runs.json.zst` (for testing).
+///
+/// This is the same constant as `FORCE_STORE_FORMAT_VERSION_ENV` in
+/// `nextest_runner::record::format`.
+const FORCE_STORE_FORMAT_VERSION_ENV: &str = "__NEXTEST_FORCE_STORE_FORMAT_VERSION";
+
 /// Environment variable to enable redaction of dynamic fields (timestamps, durations, sizes).
 ///
 /// When set to "1", nextest produces fixed-width placeholders for these fields,
@@ -2186,6 +2193,66 @@ fn test_replayability_all_runs_non_replayable() {
         stderr.contains("error opening archive at"),
         "replay error should mention opening archive: {stderr}"
     );
+}
+
+/// Replayability: store format version incompatible with current nextest.
+///
+/// Coverage: Verifies that replay, `run --rerun`, `store export`, and
+/// `store export-chrome-trace` all reject a run whose per-run
+/// `store_format_version` metadata is unreadable by the current nextest,
+/// before attempting to open the archive or event log. Uses the testing-only
+/// `__NEXTEST_FORCE_STORE_FORMAT_VERSION` knob to synthesize a run whose
+/// metadata claims a future major version.
+#[test]
+fn test_replayability_store_version_too_new() {
+    let env_info = set_env_vars_for_test();
+    let p = TempProject::new(&env_info).unwrap();
+    let cache_dir = create_cache_dir(&p);
+    let temp_root = p.temp_root();
+    let (_user_config_dir, user_config_path) = create_record_user_config();
+
+    // Deterministic so the run ID appears stably in error snapshots.
+    const RUN_ID: &str = "84000001-0000-0000-0000-000000000001";
+
+    // Record a run with the per-run store format version forced to a future
+    // major version. The store.zip and run.log.zst payloads still use the real
+    // current format, which is fine: every dependent command checks the
+    // metadata version before opening either one.
+    let recording = cli_with_recording(&env_info, &p, &cache_dir, &user_config_path, Some(RUN_ID))
+        .env(FORCE_STORE_FORMAT_VERSION_ENV, "9999.0")
+        .args(["run", "-E", "test(=test_success)"])
+        .output();
+    assert!(
+        recording.exit_status.success(),
+        "recording with forced store format version should succeed: {recording}"
+    );
+
+    // Each dependent command should exit with SETUP_ERROR and surface the
+    // StoreVersionIncompatible diagnostic.
+    let cases: [(&str, &[&str]); 4] = [
+        ("replay", &["replay", "--run-id", RUN_ID]),
+        ("run_rerun", &["run", "--rerun", RUN_ID]),
+        ("store_export", &["store", "export", RUN_ID]),
+        (
+            "store_export_chrome_trace",
+            &["store", "export-chrome-trace", RUN_ID],
+        ),
+    ];
+    for (command_label, args) in cases {
+        let out = cli_with_recording(&env_info, &p, &cache_dir, &user_config_path, None)
+            .args(args.iter().copied())
+            .unchecked(true)
+            .output();
+        assert_eq!(
+            out.exit_status.code(),
+            Some(NextestExitCode::SETUP_ERROR),
+            "{command_label} should fail with SETUP_ERROR: {out}"
+        );
+        insta::assert_snapshot!(
+            format!("version_incompat_too_new_major__{command_label}"),
+            redact_dynamic_fields(&out.stderr_as_str(), temp_root)
+        );
+    }
 }
 
 // --- Rerun tests ---

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__version_incompat_too_new_major__replay.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__version_incompat_too_new_major__replay.snap
@@ -1,0 +1,5 @@
+---
+source: integration-tests/tests/integration/record_replay.rs
+expression: "redact_dynamic_fields(&out.stderr_as_str(), temp_root)"
+---
+error: run 84000001-0000-0000-0000-000000000001 has incompatible store format: recording has major version 9999, but this nextest only supports version 2 (upgrade nextest to replay this recording)

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__version_incompat_too_new_major__run_rerun.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__version_incompat_too_new_major__run_rerun.snap
@@ -1,0 +1,6 @@
+---
+source: integration-tests/tests/integration/record_replay.rs
+expression: "redact_dynamic_fields(&out.stderr_as_str(), temp_root)"
+---
+info: experimental features enabled: setup-scripts, wrapper-scripts, benchmarks
+error: run 84000001-0000-0000-0000-000000000001 has incompatible store format: recording has major version 9999, but this nextest only supports version 2 (upgrade nextest to replay this recording)

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__version_incompat_too_new_major__store_export.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__version_incompat_too_new_major__store_export.snap
@@ -1,0 +1,5 @@
+---
+source: integration-tests/tests/integration/record_replay.rs
+expression: "redact_dynamic_fields(&out.stderr_as_str(), temp_root)"
+---
+error: run 84000001-0000-0000-0000-000000000001 has incompatible store format: recording has major version 9999, but this nextest only supports version 2 (upgrade nextest to replay this recording)

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__version_incompat_too_new_major__store_export_chrome_trace.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__version_incompat_too_new_major__store_export_chrome_trace.snap
@@ -1,0 +1,5 @@
+---
+source: integration-tests/tests/integration/record_replay.rs
+expression: "redact_dynamic_fields(&out.stderr_as_str(), temp_root)"
+---
+error: run 84000001-0000-0000-0000-000000000001 has incompatible store format: recording has major version 9999, but this nextest only supports version 2 (upgrade nextest to replay this recording)

--- a/nextest-runner/src/record/format.rs
+++ b/nextest-runner/src/record/format.rs
@@ -256,6 +256,43 @@ pub const STORE_FORMAT_VERSION: StoreFormatVersion = StoreFormatVersion::new(
     StoreFormatMinorVersion::new(0),
 );
 
+/// Testing-only environment variable to force a specific store format version
+/// in the per-run metadata written to `runs.json.zst`.
+///
+/// Integration tests use this to synthesize runs that exercise version mismatch
+/// error paths. The override only affects the version reported in the metadata.
+/// The `store.zip` and `run.log.zst` payloads are still written in the real
+/// current format.
+///
+/// Format: `MAJOR.MINOR` (e.g. `9999.0`). Unset in normal use.
+pub(super) const FORCE_STORE_FORMAT_VERSION_ENV: &str = "__NEXTEST_FORCE_STORE_FORMAT_VERSION";
+
+/// Returns the store format version to record for a new run.
+pub(super) fn store_format_version_for_new_run() -> StoreFormatVersion {
+    let Some(raw) = std::env::var_os(FORCE_STORE_FORMAT_VERSION_ENV) else {
+        return STORE_FORMAT_VERSION;
+    };
+    let raw = raw.to_str().unwrap_or_else(|| {
+        panic!("{FORCE_STORE_FORMAT_VERSION_ENV} contains non-UTF-8 bytes");
+    });
+    let (major, minor) = raw.split_once('.').unwrap_or_else(|| {
+        panic!(
+            "{FORCE_STORE_FORMAT_VERSION_ENV}={raw:?} is malformed \
+             (expected MAJOR.MINOR, e.g. 9999.0)"
+        )
+    });
+    let major: u32 = major.parse().unwrap_or_else(|err| {
+        panic!("{FORCE_STORE_FORMAT_VERSION_ENV}={raw:?} has invalid major version: {err}")
+    });
+    let minor: u32 = minor.parse().unwrap_or_else(|err| {
+        panic!("{FORCE_STORE_FORMAT_VERSION_ENV}={raw:?} has invalid minor version: {err}")
+    });
+    StoreFormatVersion::new(
+        StoreFormatMajorVersion::new(major),
+        StoreFormatMinorVersion::new(minor),
+    )
+}
+
 /// Whether a runs.json.zst file can be written to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RunsJsonWritePermission {

--- a/nextest-runner/src/record/store.rs
+++ b/nextest-runner/src/record/store.rs
@@ -14,6 +14,7 @@ use super::{
     format::{
         RUN_LOG_FILE_NAME, RecordedRunList, RunsJsonWritePermission, STORE_FORMAT_VERSION,
         STORE_ZIP_FILE_NAME, StoreFormatVersion, StoreVersionIncompatibility,
+        store_format_version_for_new_run,
     },
     recorder::{RunRecorder, StoreSizes},
     retention::{
@@ -425,7 +426,7 @@ impl<'store> ExclusiveLockedRunStore<'store> {
         let now = Local::now().fixed_offset();
         let run = RecordedRunInfo {
             run_id,
-            store_format_version: STORE_FORMAT_VERSION,
+            store_format_version: store_format_version_for_new_run(),
             nextest_version,
             started_at,
             last_written_at: now,


### PR DESCRIPTION
Realized that these code paths were missing store format version checking.