### PR TITLE
[nextest-metadata] bump target-spec to 3.6.0, MSRV to 1.86

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        rust-version: ["1.78"]
+        rust-version: ["1.86"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ supports-color = "3.0.2"
 supports-unicode = "3.0.0"
 swrite = "0.1.0"
 tar = "0.4.45"
-target-spec = { version = "3.4.2", features = ["custom", "summaries"] }
+target-spec = { version = "3.6.0", features = ["custom", "summaries"] }
 target-spec-miette = "0.4.6"
 test-case = "3.3.1"
 test-strategy = "0.4.5"

--- a/fixtures/nextest-metadata-msrv/Cargo.toml
+++ b/fixtures/nextest-metadata-msrv/Cargo.toml
@@ -5,7 +5,7 @@ members = ["."]
 name = "nextest-metadata-msrv-test"
 edition = "2021"
 # Same as nextest-metadata's MSRV.
-rust-version = "1.78"
+rust-version = "1.86"
 
 [dependencies]
 nextest-metadata = { path = "../../nextest-metadata" }

--- a/nextest-metadata/CHANGELOG.md
+++ b/nextest-metadata/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- MSRV updated to Rust 1.86.
+
 ## [0.14.1] - 2026-04-14
 
 ### Added

--- a/nextest-metadata/README.md
+++ b/nextest-metadata/README.md
@@ -32,7 +32,7 @@ println!("{:?}", test_list);
 
 ## Minimum supported Rust version (MSRV)
 
-The minimum supported Rust version is **Rust 1.78.**
+The minimum supported Rust version is **Rust 1.86.**
 
 While this crate is a pre-release (0.x.x) it may have its MSRV bumped in a patch release. Once a
 crate has reached 1.x, any MSRV bump will be accompanied with a new minor version.

--- a/nextest-metadata/src/lib.rs
+++ b/nextest-metadata/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! # Minimum supported Rust version (MSRV)
 //!
-//! The minimum supported Rust version is **Rust 1.78.**
+//! The minimum supported Rust version is **Rust 1.86.**
 //!
 //! While this crate is a pre-release (0.x.x) it may have its MSRV bumped in a patch release. Once a
 //! crate has reached 1.x, any MSRV bump will be accompanied with a new minor version.


### PR DESCRIPTION
Prerequisite for #3331.