### PR TITLE
[meta] align docs/config references/schemas, improve language

### DIFF
--- a/cargo-nextest/src/dispatch/core/run.rs
+++ b/cargo-nextest/src/dispatch/core/run.rs
@@ -151,17 +151,21 @@ pub struct TestRunnerOpts {
     test_threads: Option<TestThreads>,
 
     /// Number of retries for failing tests [default: from profile].
+    ///
+    /// For more advanced retry policies (jitter, exponential backoff, max
+    /// delay), configure `retries` in `.config/nextest.toml`.
     #[arg(long, env = "NEXTEST_RETRIES", value_name = "N")]
     retries: Option<u32>,
 
-    /// Flaky test result behavior [default: from profile].
+    /// Whether to treat flaky tests as passing or failing [default: from
+    /// profile].
     ///
-    /// Controls whether tests that pass on retry are treated as passing or
-    /// failing.
+    /// "pass" treats tests that pass on retry as passing; "fail" treats them
+    /// as failing.
     #[arg(long, env = "NEXTEST_FLAKY_RESULT", value_name = "RESULT", value_enum)]
     flaky_result: Option<FlakyResultOpt>,
 
-    /// Cancel test run on the first failure.
+    /// Stop running tests after the first failure.
     #[arg(
         long,
         visible_alias = "ff",
@@ -185,11 +189,11 @@ pub struct TestRunnerOpts {
     )]
     no_fail_fast: bool,
 
-    /// Number of tests that can fail before exiting test run.
+    /// Number of failures after which to stop running tests.
     ///
     /// To control whether currently running tests are waited for or terminated
     /// immediately, append ':wait' (default) or ':immediate' to the number
-    /// (e.g., '5:immediate').
+    /// (e.g. '5:immediate').
     ///
     /// [possible values: integer, "all", "N:wait", "N:immediate"]
     #[arg(
@@ -283,7 +287,7 @@ pub(crate) struct BenchRunnerOpts {
     #[arg(long, name = "no-run")]
     pub(crate) no_run: bool,
 
-    /// Cancel benchmark run on the first failure.
+    /// Stop running benchmarks after the first failure.
     #[arg(
         long,
         visible_alias = "ff",
@@ -307,7 +311,7 @@ pub(crate) struct BenchRunnerOpts {
     )]
     no_fail_fast: bool,
 
-    /// Number of benchmarks that can fail before exiting run [possible
+    /// Number of failures after which to stop running benchmarks [possible
     /// values: integer or "all"].
     #[arg(
         long,
@@ -477,7 +481,7 @@ fn no_run_no_capture_reasons(no_run: bool, no_capture: bool) -> Option<&'static 
 /// during live test runs and when replaying recorded runs.
 #[derive(Debug, Default, Args)]
 pub(crate) struct ReporterCommonOpts {
-    /// Output stdout and stderr on failure.
+    /// When to display output for failed tests.
     #[arg(
         long,
         value_enum,
@@ -487,7 +491,7 @@ pub(crate) struct ReporterCommonOpts {
     )]
     pub(crate) failure_output: Option<TestOutputDisplayOpt>,
 
-    /// Output stdout and stderr on success.
+    /// When to display output for successful tests.
     #[arg(
         long,
         value_enum,
@@ -498,7 +502,7 @@ pub(crate) struct ReporterCommonOpts {
     pub(crate) success_output: Option<TestOutputDisplayOpt>,
 
     // status_level does not conflict with --no-capture because pass vs skip still makes sense.
-    /// Test statuses to output.
+    /// Level of status information to display during test runs.
     #[arg(
         long,
         value_enum,
@@ -508,7 +512,7 @@ pub(crate) struct ReporterCommonOpts {
     )]
     pub(crate) status_level: Option<StatusLevelOpt>,
 
-    /// Test statuses to output at the end of the run.
+    /// Level of status information to display in the final summary.
     #[arg(
         long,
         value_enum,
@@ -628,12 +632,11 @@ pub(crate) struct ReporterOpts {
     #[arg(long, env = "NEXTEST_NO_INPUT_HANDLER", value_parser = BoolishValueParser::new())]
     pub(crate) no_input_handler: bool,
 
-    /// Maximum number of running tests to display progress for.
+    /// Maximum number of running tests to list in the progress bar.
     ///
-    /// When more tests are running than this limit, the progress bar will show
-    /// the first N tests and a summary of remaining tests (e.g. "... and 24
-    /// more tests running"). Set to **0** to hide running tests, or
-    /// **infinite** for unlimited. This applies when using
+    /// Excess running tests are collapsed into a summary line (e.g. "... and
+    /// 24 more tests running"). Set to **0** to hide running tests, or
+    /// **infinite** for no limit. This applies when using
     /// `--show-progress=bar` or `--show-progress=only`.
     ///
     /// This can also be set via user config at `~/.config/nextest/config.toml`.

--- a/cargo-nextest/src/dispatch/core/value_enums.rs
+++ b/cargo-nextest/src/dispatch/core/value_enums.rs
@@ -247,13 +247,13 @@ impl From<ShowProgressOpt> for ShowProgress {
     }
 }
 
-/// Flaky test result behavior.
+/// Whether to treat flaky tests as passing or failing.
 #[derive(Clone, Copy, Debug, ValueEnum)]
 pub(crate) enum FlakyResultOpt {
-    /// Flaky tests are treated as passing.
+    /// Treat flaky tests as passing.
     Pass,
 
-    /// Flaky tests are treated as failing.
+    /// Treat flaky tests as failing.
     Fail,
 }
 

--- a/nextest-runner/default-config.toml
+++ b/nextest-runner/default-config.toml
@@ -12,76 +12,83 @@ dir = "target/nextest"
 # The set of tests run by `cargo nextest run` by default.
 default-filter = "all()"
 
-# "retries" defines the number of times a test should be retried. If set to a
-# non-zero value, tests that succeed on a subsequent attempt will be marked as
-# flaky. Can be overridden through the `--retries` option.
-# Examples
+# Retry policy for failed tests. A non-zero value causes tests that pass on a
+# subsequent attempt to be marked as flaky. Can be overridden through the
+# `--retries` option.
+# Examples:
 # * retries = 3
 # * retries = { backoff = "fixed", count = 2, delay = "1s" }
 # * retries = { backoff = "exponential", count = 10, delay = "1s", jitter = true, max-delay = "10s" }
 retries = 0
 
-# Controls whether a flaky test is treated as passing or failing.
+# Whether to treat flaky tests as passing or failing.
 flaky-result = "pass"
 
-# The number of threads to run tests with. Supported values are either an integer or
-# the string "num-cpus". Can be overridden through the `--test-threads` option.
+# Number of threads to run tests with. Either an integer or "num-cpus". Can be
+# overridden through the `--test-threads` option.
 test-threads = "num-cpus"
 
-# The number of threads required for each test. This is generally used in overrides to
-# mark certain tests as heavier than others. However, it can also be set as a global parameter.
+# Number of threads (slots) each test reserves from the pool. Generally used in
+# overrides to mark certain tests as heavier than others; can also be set as a
+# global default.
 threads-required = 1
 
-# Extra arguments to pass in to the test binary at runtime. Intended primarily for
+# Extra arguments to pass to test binaries at runtime. Intended primarily for
 # communication with custom test harnesses -- use with caution!
 run-extra-args = []
 
-# Show these test statuses in the output.
+# Level of status information to display during test runs.
 #
-# The possible values this can take are:
-# * none: no output
-# * fail: show failed (including exec-failed) tests
-# * retry: show flaky and retried tests
-# * slow: show slow tests
-# * pass: show passed tests
-# * skip: show skipped tests (most useful for CI)
-# * all: all of the above
+# Status levels are incremental: each level includes all levels above it. For
+# example, "slow" implies "retry" and "fail".
 #
-# Each value includes all the values above it; for example, "slow" includes
-# failed and retried tests.
+# Valid values:
+# * "none": no output.
+# * "fail": only output test failures.
+# * "retry": output test retries; includes "fail".
+# * "slow": output slow tests; includes "retry".
+# * "leak": output leaky tests; includes "slow".
+# * "pass": output passing tests; includes "leak".
+# * "skip": output skipped tests; includes "pass".
+# * "all": equivalent to "skip" today; reserved for future expansion.
 #
 # Can be overridden through the `--status-level` flag.
 status-level = "pass"
 
-# Similar to status-level, show these test statuses at the end of the run.
+# Level of status information to display in the final summary. Differs from
+# status-level in that it has a separate "flaky" indicator distinct from
+# "retry" (though "retry" works as an alias), and in that "skip" is prioritized
+# over "pass".
 final-status-level = "flaky"
 
-# "failure-output" defines when standard output and standard error for failing tests are produced.
-# Accepted values are
-# * "immediate": output failures as soon as they happen
-# * "final": output failures at the end of the test run
-# * "immediate-final": output failures as soon as they happen and at the end of
-#   the test run; combination of "immediate" and "final"
-# * "never": don't output failures at all
+# When to display output for failed tests.
+#
+# Valid values:
+# * "immediate": show captured output as soon as the test completes.
+# * "final": show captured output only at the end of the run.
+# * "immediate-final": show captured output when the test completes and again
+#   at the end of the run.
+# * "never": never show captured output.
 #
 # For large test suites and CI it is generally useful to use "immediate-final".
 #
 # Can be overridden through the `--failure-output` option.
 failure-output = "immediate"
 
-# "success-output" controls production of standard output and standard error on success. This should
-# generally be set to "never".
+# When to display output for successful tests. Generally best left as "never".
 success-output = "never"
 
-# Cancel the test run on the first failure. For CI runs, consider setting this
-# to false.
-# Accepted values are
-# * true: cancel the test run on the first failure (waits for running tests to complete)
-# * false: continue running tests even after a failure
-# * { max-fail = 10 }: cancel the test run after 10 failures (waits for running tests)
-# * { max-fail = 10, terminate = "wait" }: same as above (explicit)
-# * { max-fail = 10, terminate = "immediate" }: cancel and terminate running tests immediately
-# * { max-fail = "all" }: continue running tests even after a failure
+# Failure handling for the test run. Accepted values:
+# * true: stop running tests after the first failure (waits for running tests
+#   to complete).
+# * false: run all tests regardless of failures.
+# * { max-fail = 10 }: stop after 10 failures (waits for running tests).
+# * { max-fail = 10, terminate = "wait" }: same as above (explicit).
+# * { max-fail = 10, terminate = "immediate" }: stop and terminate running
+#   tests immediately.
+# * { max-fail = "all" }: run all tests regardless of failures.
+#
+# For CI runs, consider setting this to false.
 fail-fast = true
 
 # Treat a test that takes longer than the configured 'period' as slow, and print a message.
@@ -97,7 +104,8 @@ fail-fast = true
 # Example: slow-timeout = { period = "60s", on-timeout = "pass" }
 slow-timeout = { period = "60s", on-timeout = "fail" }
 
-# Treat a benchmark that takes longer than the configured 'period' as slow, and print a message.
+# Time after which benchmarks are considered slow, plus optional termination
+# policy. Replaces `slow-timeout` when running `cargo nextest bench`.
 # See <https://nexte.st/docs/features/slow-tests> for more information.
 #
 # Optional: specify the parameter 'terminate-after' with a non-zero integer,
@@ -105,20 +113,17 @@ slow-timeout = { period = "60s", on-timeout = "fail" }
 # periods have passed.
 # Example: bench.slow-timeout = { period = "60s", terminate-after = 2 }
 #
-# This is a separate configuration for benchmarks, because benchmarks are often
-# expected to take longer than tests.
-#
-# Defaults to 30 years, which is a large enough value to feel "infinite" without
-# running into overflows on various platforms.
+# Benchmarks have a separate configuration because they are often expected to
+# take longer than tests. Defaults to 30 years, which is a large enough value
+# to feel "infinite" without running into overflows on various platforms.
 bench.slow-timeout = { period = "30y" }
 
-# Stop all benchmarks after the configured global timeout.
+# Global timeout for the entire benchmark run. Replaces `global-timeout` when
+# running `cargo nextest bench`.
 #
-# This is a separate configuration for benchmarks, because benchmarks are often
-# expected to take longer than tests.
-#
-# Defaults to 30 years, which is a large enough value to feel "infinite" without
-# running into overflows on various platforms.
+# Benchmarks have a separate configuration because they are often expected to
+# take longer than tests. Defaults to 30 years, which is a large enough value
+# to feel "infinite" without running into overflows on various platforms.
 bench.global-timeout = "30y"
 
 # Treat a test as leaky if after the process is shut down, standard output and standard error
@@ -136,9 +141,9 @@ leak-timeout = "200ms"
 # running into overflows on various platforms.
 global-timeout = "30y"
 
-# `nextest archive` automatically includes any build output required by a standard build.
-# However sometimes extra non-standard files are required.
-# To address this, "archive.include" specifies additional paths that will be included in the archive.
+# Extra paths to include in `nextest archive`. The standard build output is
+# included automatically; use this to add any non-standard files the tests
+# need at runtime.
 archive.include = [
     # Examples:
     #
@@ -146,35 +151,38 @@ archive.include = [
     # { path = "data-from-some-dependency/file.txt", relative-to = "target" },
     #
     # In the above example:
-    # * the directory and its contents at "target/application-data" will be included recursively in the archive.
-    # * the file "target/data-from-some-dependency/file.txt" will be included in the archive.
+    # * the directory and its contents at "target/application-data" are
+    #   included recursively in the archive.
+    # * the file "target/data-from-some-dependency/file.txt" is included in
+    #   the archive.
 ]
 
 [profile.default.junit]
-# Output a JUnit report into the given file inside 'store.dir/<profile-name>'.
-# If unspecified, JUnit is not written out.
+# Path to write the JUnit XML report to, relative to 'store.dir/<profile-name>'.
+# If unset, JUnit reporting is disabled.
 
 # path = "junit.xml"
 
-# The name of the top-level "report" element in JUnit report. If aggregating
-# reports across different test runs, it may be useful to provide separate names
-# for each report.
+# Name for the JUnit XML report. When aggregating reports across different test
+# runs, it may be useful to provide separate names for each report.
 report-name = "nextest-run"
 
-# Whether standard output and standard error for passing tests should be stored in the JUnit report.
-# Output is stored in the <system-out> and <system-err> elements of the <testcase> element.
+# Whether to store successful test output in the JUnit XML report. When true,
+# output is stored in the <system-out> and <system-err> elements of the
+# <testcase> element.
 store-success-output = false
 
-# Whether standard output and standard error for failing tests should be stored in the JUnit report.
-# Output is stored in the <system-out> and <system-err> elements of the <testcase> element.
+# Whether to store failed test output in the JUnit XML report. When true,
+# output is stored in the <system-out> and <system-err> elements of the
+# <testcase> element.
 #
-# Note that if a description can be extracted from the output, it is always stored in the
-# <description> element.
+# Note that if a description can be extracted from the output, it is always
+# stored in the <description> element.
 store-failure-output = true
 
-# Controls how flaky-fail tests are reported in the JUnit report. "failure" reports
-# them as failures with <failure> and <flakyFailure> elements; "success" reports them
-# as successes, identical to flaky-pass tests.
+# How flaky-fail tests are reported in the JUnit XML report. "failure" reports
+# them as failures with <failure> and <flakyFailure> elements; "success"
+# reports them as successes, identical to flaky-pass tests.
 flaky-fail-status = "failure"
 
 # This profile is activated if MIRI_SYSROOT is set.

--- a/nextest-runner/default-user-config.toml
+++ b/nextest-runner/default-user-config.toml
@@ -5,55 +5,55 @@
 # https://nexte.st/docs/user-config/reference
 
 [ui]
-# How to show progress during test runs.
+# Style of progress display shown during test runs.
 # Valid values: "auto", "none", "bar", "counter", "only"
 show-progress = "auto"
 
-# Maximum running tests to display in the progress bar.
-# Valid values: an integer, or "infinite" for unlimited.
+# Maximum number of running tests to list in the progress bar. Excess running
+# tests are collapsed into a summary line.
+# Valid values: a non-negative integer, or "infinite" for no limit.
 max-progress-running = 8
 
-# Whether to enable the input handler for keyboard shortcuts during test runs.
+# Enables the interactive keyboard input handler (e.g. `t` to dump test status,
+# `Enter` to print a summary line).
 input-handler = true
 
-# Whether to indent captured test output for visual clarity.
+# Indents captured test output for visual clarity.
 output-indent = true
 
-# Pager for supported command output.
+# Pager command for output that benefits from scrolling.
 #
 # Accepts a command string ("less -FRX"), an array (["less", "-FRX"]),
 # a table ({ command = ["less", "-FRX"], env = { LESSCHARSET = "utf-8" } }),
 # or ":builtin" to use the builtin pager.
 pager = { command = ["less", "-FRX"], env = { LESSCHARSET = "utf-8" } }
 
-# When to paginate output.
+# When to send output through the pager.
 # Valid values: "auto", "never"
 paginate = "auto"
 
-# Configuration for the builtin streampager (used when pager = ":builtin").
+# Settings for the builtin pager (active when pager = ":builtin").
 [ui.streampager]
-# Interface mode controlling alternate screen behavior.
+# How the builtin pager uses the alternate screen and when it exits.
 # Valid values: "quit-if-one-page", "full-screen-clear-output", "quit-quickly-or-clear-output"
 interface = "quit-if-one-page"
-# Text wrapping mode.
+# How the builtin pager wraps long lines.
 # Valid values: "none", "word", "anywhere"
 wrapping = "word"
-# Whether to show a ruler at the bottom.
+# Whether to show a ruler at the bottom of the builtin pager.
 show-ruler = true
 
-# Record retention settings (for experimental record-replay feature).
+# Retention settings for the record-replay-rerun feature.
 [record]
-# Whether recording is enabled.
-# Recording only occurs when the `record` experimental feature is enabled AND
-# this is set to true.
+# Whether to record test runs. Has no effect unless [experimental] record = true.
 enabled = false
-# Maximum number of recorded runs to keep.
+# Maximum number of recorded runs to retain before eviction.
 max-records = 100
-# Maximum total size of all recorded runs.
+# Maximum combined size of all retained recordings before eviction.
 max-total-size = "1GB"
-# Maximum age of recorded runs.
+# Maximum age of a recorded run before eviction.
 max-age = "30d"
-# Maximum size of a single output (stdout/stderr) before truncation.
+# Maximum size of a single captured stdout or stderr stream before truncation.
 max-output-size = "10MB"
 
 # Windows uses the builtin pager by default because external pagers are

--- a/nextest-runner/jsonschemas/repo-config.json
+++ b/nextest-runner/jsonschemas/repo-config.json
@@ -4,11 +4,11 @@
   "type": "object",
   "properties": {
     "experimental": {
-      "description": "Enables experimental nextest features.",
+      "description": "Enables experimental, non-stable features.",
       "$ref": "#/$defs/ExperimentalDeserialize"
     },
     "nextest-version": {
-      "description": "The minimum required and recommended versions of nextest for this\nconfiguration.",
+      "description": "The minimum required (and optionally recommended) version of nextest\nfor this configuration.",
       "anyOf": [
         {
           "$ref": "#/$defs/NextestVersionDeserialize"
@@ -19,7 +19,7 @@
       ]
     },
     "profile": {
-      "description": "Test profiles.",
+      "description": "Test profiles, keyed by profile name.",
       "type": [
         "object",
         "null"
@@ -36,7 +36,7 @@
       }
     },
     "scripts": {
-      "description": "Setup and wrapper scripts.",
+      "description": "Setup and wrapper scripts, keyed by script name.",
       "$ref": "#/$defs/ScriptConfig"
     },
     "store": {
@@ -51,7 +51,7 @@
       ]
     },
     "test-groups": {
-      "description": "Custom test groups for mutual exclusion and resource management.",
+      "description": "Custom test groups for mutual exclusion and resource management, keyed\nby group name.",
       "type": "object",
       "additionalProperties": {
         "$ref": "#/$defs/TestGroupConfig"
@@ -62,11 +62,11 @@
   "x-tombi-toml-version": "v1.1.0",
   "$defs": {
     "ArchiveConfig": {
-      "description": "Configuration for archives.",
+      "description": "Archive configuration for this profile.",
       "type": "object",
       "properties": {
         "include": {
-          "description": "Files to include in the archive.",
+          "description": "Extra paths to include in the archive.",
           "type": [
             "array",
             "null"
@@ -79,11 +79,11 @@
       "additionalProperties": false
     },
     "ArchiveInclude": {
-      "description": "Type for the archive-include key.\n\n# Notes\n\nThis is `deny_unknown_fields` because if we take additional arguments in the future, they're\nlikely to change semantics in an incompatible way.",
+      "description": "A single entry under `archive.include`.",
       "type": "object",
       "properties": {
         "depth": {
-          "description": "Maximum recursion depth.",
+          "description": "Maximum recursion depth: a non-negative integer, or `\"infinite\"`.",
           "oneOf": [
             {
               "type": "integer",
@@ -98,15 +98,15 @@
           ]
         },
         "on-missing": {
-          "description": "What to do if the path is missing.",
+          "description": "What to do if `path` is missing: `\"ignore\"`, `\"warn\"`, or `\"error\"`.",
           "$ref": "#/$defs/ArchiveIncludeOnMissing"
         },
         "path": {
-          "description": "Relative path to include.",
+          "description": "Path to include, relative to `relative-to`.",
           "type": "string"
         },
         "relative-to": {
-          "description": "Base directory that `path` is relative to.",
+          "description": "Base directory `path` is interpreted relative to.",
           "$ref": "#/$defs/ArchiveRelativeTo"
         }
       },
@@ -117,48 +117,48 @@
       ]
     },
     "ArchiveIncludeOnMissing": {
-      "description": "What to do when an archive-include path is missing.",
+      "description": "What to do when an `archive.include` path is missing.",
       "oneOf": [
         {
-          "description": "Ignore and continue.",
+          "description": "Skip the missing path (printed in verbose mode).",
           "type": "string",
           "const": "ignore"
         },
         {
-          "description": "Warn and continue.",
+          "description": "Print a warning and continue.",
           "type": "string",
           "const": "warn"
         },
         {
-          "description": "Produce an error.",
+          "description": "Produce an error and abort the archive operation.",
           "type": "string",
           "const": "error"
         }
       ]
     },
     "ArchiveRelativeTo": {
-      "description": "Defines the base of the path",
+      "description": "Base directory `path` is interpreted relative to.",
       "oneOf": [
         {
-          "description": "Path starts at the target directory",
+          "description": "Resolve `path` against the target directory.",
           "type": "string",
           "const": "target"
         }
       ]
     },
     "BenchConfig": {
-      "description": "Benchmark-specific configuration (deserialized form with optional fields).",
+      "description": "Benchmark-specific timeout overrides used when running\n`cargo nextest bench`.\n\nEach field, if set, replaces its non-`bench` counterpart for benchmark\nruns only.",
       "type": "object",
       "properties": {
         "global-timeout": {
-          "description": "Global timeout for benchmarks.",
+          "description": "Global timeout for the entire benchmark run. Replaces `global-timeout`\nwhen running `cargo nextest bench`.",
           "type": [
             "string",
             "null"
           ]
         },
         "slow-timeout": {
-          "description": "Slow timeout for benchmarks.",
+          "description": "Time after which benchmarks are considered slow, plus optional\ntermination policy. Replaces `slow-timeout` when running\n`cargo nextest bench`.",
           "anyOf": [
             {
               "$ref": "#/$defs/SlowTimeout"
@@ -201,7 +201,7 @@
           ]
         },
         "default-filter": {
-          "description": "The default set of tests run by `cargo nextest run`.",
+          "description": "The default set of tests run by `cargo nextest run`, as a filterset\nexpression.",
           "type": [
             "string",
             "null"
@@ -255,14 +255,14 @@
           "default": null
         },
         "global-timeout": {
-          "description": "A global timeout for test execution.",
+          "description": "A global timeout for the entire test run.",
           "type": [
             "string",
             "null"
           ]
         },
         "inherits": {
-          "description": "The profile to inherit configuration settings from.",
+          "description": "The profile to inherit settings from.",
           "type": [
             "string",
             "null"
@@ -270,7 +270,7 @@
           "default": null
         },
         "junit": {
-          "description": "JUnit output configuration.",
+          "description": "JUnit XML output configuration.",
           "$ref": "#/$defs/JunitImpl"
         },
         "leak-timeout": {
@@ -285,7 +285,7 @@
           ]
         },
         "overrides": {
-          "description": "Per-test setting overrides.",
+          "description": "Per-test setting overrides, evaluated in order.",
           "type": "array",
           "items": {
             "$ref": "#/$defs/DeserializedOverride"
@@ -314,14 +314,14 @@
           }
         },
         "scripts": {
-          "description": "Profile-specific script configuration.",
+          "description": "Profile-specific script bindings (setup and wrapper).",
           "type": "array",
           "items": {
             "$ref": "#/$defs/DeserializedProfileScriptConfig"
           }
         },
         "slow-timeout": {
-          "description": "Time after which tests are considered slow, and timeout configuration.",
+          "description": "Time after which tests are considered slow, plus optional termination\npolicy.",
           "anyOf": [
             {
               "$ref": "#/$defs/SlowTimeout"
@@ -366,7 +366,7 @@
           ]
         },
         "threads-required": {
-          "description": "Number of threads each test requires.",
+          "description": "Number of threads (slots) each test reserves from the pool.",
           "anyOf": [
             {
               "$ref": "#/$defs/ThreadsRequired"
@@ -398,14 +398,14 @@
           ]
         },
         "store-failure-output": {
-          "description": "Whether to store failed test output in the JUnit XML report.",
+          "description": "Whether to store failed output for matching tests in the JUnit XML\nreport.",
           "type": [
             "boolean",
             "null"
           ]
         },
         "store-success-output": {
-          "description": "Whether to store successful test output in the JUnit XML report.",
+          "description": "Whether to store successful output for matching tests in the JUnit XML\nreport.",
           "type": [
             "boolean",
             "null"
@@ -419,11 +419,11 @@
       "type": "object",
       "properties": {
         "bench": {
-          "description": "Benchmark-specific overrides.",
+          "description": "Benchmark-specific overrides for matching tests.",
           "$ref": "#/$defs/DeserializedOverrideBench"
         },
         "default-filter": {
-          "description": "The default filter for tests. Only supported if platform is specified\nbut filter is not.",
+          "description": "Replaces `default-filter` for matching platforms. Requires `platform`\nand must not be combined with `filter`.",
           "type": [
             "string",
             "null"
@@ -431,7 +431,7 @@
           "default": null
         },
         "failure-output": {
-          "description": "Failure output display for matching tests.",
+          "description": "When to display output for matching failed tests.",
           "anyOf": [
             {
               "$ref": "#/$defs/TestOutputDisplay"
@@ -443,7 +443,7 @@
           "default": null
         },
         "filter": {
-          "description": "The filterset to match against.",
+          "description": "Filterset expression selecting tests this override applies to.",
           "type": [
             "string",
             "null"
@@ -451,7 +451,7 @@
           "default": null
         },
         "flaky-result": {
-          "description": "Whether to treat flaky tests as passing or failing.",
+          "description": "Whether to treat matching flaky tests as passing or failing.",
           "anyOf": [
             {
               "$ref": "#/$defs/FlakyResult"
@@ -463,7 +463,7 @@
           "default": null
         },
         "junit": {
-          "description": "JUnit output configuration for matching tests.",
+          "description": "JUnit XML output settings for matching tests.",
           "$ref": "#/$defs/DeserializedJunitOutput"
         },
         "leak-timeout": {
@@ -478,11 +478,11 @@
           ]
         },
         "platform": {
-          "description": "The host and/or target platforms to match against.",
+          "description": "Host and/or target platforms this override applies to.",
           "$ref": "#/$defs/PlatformStrings"
         },
         "priority": {
-          "description": "Test priority.",
+          "description": "Priority for matching tests; higher values run sooner.",
           "anyOf": [
             {
               "$ref": "#/$defs/TestPriority"
@@ -504,7 +504,7 @@
           ]
         },
         "run-extra-args": {
-          "description": "Extra arguments to pass to the test runner.",
+          "description": "Extra arguments to pass to matching test binaries.",
           "type": [
             "array",
             "null"
@@ -526,7 +526,7 @@
           ]
         },
         "success-output": {
-          "description": "Success output display for matching tests.",
+          "description": "When to display output for matching successful tests.",
           "anyOf": [
             {
               "$ref": "#/$defs/TestOutputDisplay"
@@ -550,7 +550,7 @@
           "default": null
         },
         "threads-required": {
-          "description": "The number of threads required for matching tests.",
+          "description": "Number of threads each matching test reserves from the pool.",
           "anyOf": [
             {
               "$ref": "#/$defs/ThreadsRequired"
@@ -586,7 +586,7 @@
       "type": "object",
       "properties": {
         "filter": {
-          "description": "The filterset to match against.",
+          "description": "Filterset expression selecting tests these scripts apply to.",
           "type": [
             "string",
             "null"
@@ -594,7 +594,7 @@
           "default": null
         },
         "list-wrapper": {
-          "description": "The wrapper script to run at list time.",
+          "description": "Name of the wrapper script used during test listing.",
           "anyOf": [
             {
               "$ref": "#/$defs/ScriptId"
@@ -606,11 +606,11 @@
           "default": null
         },
         "platform": {
-          "description": "The host and/or target platforms to match against.",
+          "description": "Host and/or target platforms these scripts apply to.",
           "$ref": "#/$defs/PlatformStrings"
         },
         "run-wrapper": {
-          "description": "The wrapper script to run at run time.",
+          "description": "Name of the wrapper script used during test execution.",
           "anyOf": [
             {
               "$ref": "#/$defs/ScriptId"
@@ -622,7 +622,7 @@
           "default": null
         },
         "setup": {
-          "description": "The setup script or scripts to run.",
+          "description": "Names of setup scripts to run (single name or array).",
           "default": [],
           "oneOf": [
             {
@@ -670,7 +670,7 @@
       ]
     },
     "FinalStatusLevel": {
-      "description": "Status level to show at the end of test runs in the reporter output.\n\nStatus levels are incremental.\n\nThis differs from [`StatusLevel`] in two ways:\n* It has a \"flaky\" test indicator that's different from \"retry\" (though \"retry\" works as an alias.)\n* It has a different ordering: skipped tests are prioritized over passing ones.",
+      "description": "Level of status information to display in the final summary.\n\nStatus levels are incremental. This differs from `status-level` in two\nways:\n\n* It has a \"flaky\" test indicator distinct from \"retry\" (though \"retry\"\n  works as an alias).\n* It has a different ordering: skipped tests are prioritized over passing\n  ones.",
       "oneOf": [
         {
           "description": "No output.",
@@ -683,32 +683,32 @@
           "const": "fail"
         },
         {
-          "description": "Output flaky tests.",
+          "description": "Output flaky tests; includes `fail`. Accepts `\"retry\"` as an alias.",
           "type": "string",
           "const": "flaky"
         },
         {
-          "description": "Output information about slow tests, and all variants above.",
+          "description": "Output slow tests; includes `flaky`.",
           "type": "string",
           "const": "slow"
         },
         {
-          "description": "Output skipped tests in addition to all variants above.",
+          "description": "Output skipped tests; includes `slow`.",
           "type": "string",
           "const": "skip"
         },
         {
-          "description": "Output leaky tests in addition to all variants above.",
+          "description": "Output leaky tests; includes `skip`.",
           "type": "string",
           "const": "leak"
         },
         {
-          "description": "Output passing tests in addition to all variants above.",
+          "description": "Output passing tests; includes `leak`.",
           "type": "string",
           "const": "pass"
         },
         {
-          "description": "Currently has the same meaning as [`Pass`](Self::Pass).",
+          "description": "Equivalent to `\"pass\"` today; reserved for future expansion.",
           "type": "string",
           "const": "all"
         }
@@ -760,12 +760,12 @@
           "default": null
         },
         "path": {
-          "description": "Path to write the JUnit XML report to. If unset, JUnit support is\ndisabled.",
+          "description": "Path to write the JUnit XML report to. If unset, JUnit reporting is\ndisabled.",
           "type": "string",
           "default": null
         },
         "report-name": {
-          "description": "Name for the JUnit report.",
+          "description": "Name for the JUnit XML report.",
           "type": [
             "string",
             "null"
@@ -815,15 +815,15 @@
       ]
     },
     "LeakTimeoutResult": {
-      "description": "The result of controlling leak timeout behavior.",
+      "description": "Whether to mark a test as passed or failed when the leak timeout elapses.",
       "oneOf": [
         {
-          "description": "The test is marked as failed.",
+          "description": "Mark the test as failed.",
           "type": "string",
           "const": "fail"
         },
         {
-          "description": "The test is marked as passed.",
+          "description": "Mark the test as passed.",
           "type": "string",
           "const": "pass"
         }
@@ -1015,38 +1015,38 @@
       ]
     },
     "ScriptCommandRelativeTo": {
-      "description": "The directory to interpret a [`ScriptCommand`] as relative to, in case it is\na relative path.\n\nIf specified, the program will be joined with the provided path.",
+      "description": "Base directory a relative script program is resolved against.\n\nIf specified, the program is joined with the provided path.",
       "oneOf": [
         {
-          "description": "Do not join the program with any path.",
+          "description": "Use the program path as-is, without joining.",
           "type": "string",
           "const": "none"
         },
         {
-          "description": "Join the program with the workspace root.",
+          "description": "Resolve the program against the workspace root.",
           "type": "string",
           "const": "workspace-root"
         },
         {
-          "description": "Join the program with the target directory.",
+          "description": "Resolve the program against the target directory.",
           "type": "string",
           "const": "target"
         }
       ]
     },
     "ScriptConfig": {
-      "description": "The scripts defined in nextest configuration.",
+      "description": "Setup and wrapper scripts defined in nextest configuration.",
       "type": "object",
       "properties": {
         "setup": {
-          "description": "The setup scripts defined in nextest's configuration.",
+          "description": "Setup scripts, keyed by script name.",
           "type": "object",
           "additionalProperties": {
             "$ref": "#/$defs/SetupScriptConfig"
           }
         },
         "wrapper": {
-          "description": "The wrapper scripts defined in nextest's configuration.",
+          "description": "Wrapper scripts, keyed by script name.",
           "type": "object",
           "additionalProperties": {
             "$ref": "#/$defs/WrapperScriptConfig"
@@ -1064,25 +1064,25 @@
       "type": "object",
       "properties": {
         "capture-stderr": {
-          "description": "Whether to capture standard error for this command.",
+          "description": "Whether to capture stderr from this setup script.",
           "type": "boolean",
           "default": false
         },
         "capture-stdout": {
-          "description": "Whether to capture standard output for this command.",
+          "description": "Whether to capture stdout from this setup script.",
           "type": "boolean",
           "default": false
         },
         "command": {
-          "description": "The command to run. The first element is the program and the second element is a list\nof arguments.",
+          "description": "The command to run for this setup script.",
           "$ref": "#/$defs/ScriptCommand"
         },
         "junit": {
-          "description": "JUnit configuration for this script.",
+          "description": "JUnit XML output settings for this setup script.",
           "$ref": "#/$defs/SetupScriptJunitConfig"
         },
         "leak-timeout": {
-          "description": "An optional leak timeout for this command.",
+          "description": "Leak-timeout configuration for this setup script.",
           "anyOf": [
             {
               "$ref": "#/$defs/LeakTimeout"
@@ -1093,7 +1093,7 @@
           ]
         },
         "slow-timeout": {
-          "description": "An optional slow timeout for this command.",
+          "description": "Slow-timeout configuration for this setup script.",
           "anyOf": [
             {
               "$ref": "#/$defs/SlowTimeout"
@@ -1110,16 +1110,16 @@
       ]
     },
     "SetupScriptJunitConfig": {
-      "description": "A JUnit override configuration.",
+      "description": "JUnit XML output settings for a setup script.",
       "type": "object",
       "properties": {
         "store-failure-output": {
-          "description": "Whether to store failing output.\n\nDefaults to true.",
+          "description": "Whether to store this setup script's output on failure in the JUnit XML\nreport. Defaults to true.",
           "type": "boolean",
           "default": true
         },
         "store-success-output": {
-          "description": "Whether to store successful output.\n\nDefaults to true.",
+          "description": "Whether to store this setup script's output on success in the JUnit XML\nreport. Defaults to true.",
           "type": "boolean",
           "default": true
         }
@@ -1175,7 +1175,7 @@
       ]
     },
     "StatusLevel": {
-      "description": "Status level to show in the reporter output.\n\nStatus levels are incremental: each level causes all the statuses listed above it to be output. For example,\n[`Slow`](Self::Slow) implies [`Retry`](Self::Retry) and [`Fail`](Self::Fail).",
+      "description": "Level of status information to display during test runs.\n\nStatus levels are incremental: each level causes all the statuses listed\nabove it to be output. For example, `slow` implies `retry` and `fail`.",
       "oneOf": [
         {
           "description": "No output.",
@@ -1188,32 +1188,32 @@
           "const": "fail"
         },
         {
-          "description": "Output retries and failures.",
+          "description": "Output test retries; includes `fail`.",
           "type": "string",
           "const": "retry"
         },
         {
-          "description": "Output information about slow tests, and all variants above.",
+          "description": "Output slow tests; includes `retry`.",
           "type": "string",
           "const": "slow"
         },
         {
-          "description": "Output information about leaky tests, and all variants above.",
+          "description": "Output leaky tests; includes `slow`.",
           "type": "string",
           "const": "leak"
         },
         {
-          "description": "Output passing tests in addition to all variants above.",
+          "description": "Output passing tests; includes `leak`.",
           "type": "string",
           "const": "pass"
         },
         {
-          "description": "Output skipped tests in addition to all variants above.",
+          "description": "Output skipped tests; includes `pass`.",
           "type": "string",
           "const": "skip"
         },
         {
-          "description": "Currently has the same meaning as [`Skip`](Self::Skip).",
+          "description": "Equivalent to `\"skip\"` today; reserved for future expansion.",
           "type": "string",
           "const": "all"
         }
@@ -1236,23 +1236,23 @@
       "description": "Mode for terminating running tests when max-fail is exceeded.",
       "oneOf": [
         {
-          "description": "Wait for running tests to complete (default)",
+          "description": "Wait for running tests to complete naturally.",
           "type": "string",
           "const": "wait"
         },
         {
-          "description": "Terminate running tests immediately",
+          "description": "Send termination signals to running tests immediately.",
           "type": "string",
           "const": "immediate"
         }
       ]
     },
     "TestGroupConfig": {
-      "description": "Configuration for a test group.",
+      "description": "Configuration for a single test group.",
       "type": "object",
       "properties": {
         "max-threads": {
-          "description": "The maximum number of threads allowed for this test group.",
+          "description": "Maximum number of threads this test group may use concurrently.",
           "$ref": "#/$defs/TestThreads"
         }
       },
@@ -1265,29 +1265,29 @@
       "description": "When to display test output in the reporter.",
       "oneOf": [
         {
-          "description": "Show output immediately on execution completion.\n\nThis is the default for failing tests.",
+          "description": "Shows captured output as soon as the test completes.",
           "type": "string",
           "const": "immediate"
         },
         {
-          "description": "Show output immediately, and at the end of a test run.",
+          "description": "Shows captured output when the test completes and again at the end of\nthe run.",
           "type": "string",
           "const": "immediate-final"
         },
         {
-          "description": "Show output at the end of execution.",
+          "description": "Shows captured output only at the end of the run.",
           "type": "string",
           "const": "final"
         },
         {
-          "description": "Never show output.",
+          "description": "Never shows captured output.",
           "type": "string",
           "const": "never"
         }
       ]
     },
     "TestPriority": {
-      "description": "A test priority: a number between -100 and 100.\n\nThe sort order is from highest to lowest priority.",
+      "description": "A test priority between -100 and 100, inclusive. Higher values run sooner.",
       "type": "integer",
       "format": "int8",
       "maximum": 100,
@@ -1329,11 +1329,11 @@
       "type": "object",
       "properties": {
         "command": {
-          "description": "The command to run.",
+          "description": "The command to run as the wrapper.",
           "$ref": "#/$defs/ScriptCommand"
         },
         "target-runner": {
-          "description": "How this script interacts with a configured target runner, if any.\nDefaults to ignoring the target runner.",
+          "description": "How this wrapper composes with a configured target runner.",
           "$ref": "#/$defs/WrapperScriptTargetRunner"
         }
       },
@@ -1343,15 +1343,15 @@
       ]
     },
     "WrapperScriptTargetRunner": {
-      "description": "Interaction of wrapper script with a configured target runner.",
+      "description": "How a wrapper script composes with a configured target runner.",
       "oneOf": [
         {
-          "description": "The target runner is ignored. This is the default.",
+          "description": "The target runner is ignored.",
           "type": "string",
           "const": "ignore"
         },
         {
-          "description": "The target runner overrides the wrapper.",
+          "description": "When a target runner is configured, it replaces the wrapper; otherwise\nthe wrapper runs as usual.",
           "type": "string",
           "const": "overrides-wrapper"
         },

--- a/nextest-runner/jsonschemas/user-config.json
+++ b/nextest-runner/jsonschemas/user-config.json
@@ -5,11 +5,11 @@
   "type": "object",
   "properties": {
     "experimental": {
-      "description": "Toggles for experimental, non-stable features.\n\n```toml\n[experimental]\nrecord = true\n```",
+      "description": "Toggles for experimental, non-stable features.",
       "$ref": "#/$defs/ExperimentalConfig"
     },
     "overrides": {
-      "description": "Platform-specific overrides applied on top of the base configuration.\n\nEach entry specifies a `platform` filter and any number of settings to\nsubstitute when that filter matches. For each setting, the first\nmatching override wins; the base configuration is used if no override\nmatches.",
+      "description": "Platform-specific overrides applied on top of `[ui]` and `[record]`.\nThe first matching override per setting wins.",
       "type": "array",
       "items": {
         "$ref": "#/$defs/DeserializedOverride"
@@ -71,15 +71,15 @@
       "type": "object",
       "properties": {
         "platform": {
-          "description": "Target-spec expression selecting which platforms this override applies\nto.\n\nAccepts a target triple (e.g. `x86_64-unknown-linux-gnu`) or a `cfg()`\nexpression (e.g. `cfg(windows)`, `cfg(target_os = \"macos\")`). Matched\nagainst the platform nextest was built for.",
+          "description": "Target-spec expression selecting which platforms this override applies\nto (target triple or `cfg()` expression). Matched against the platform\nnextest was built for.",
           "type": "string"
         },
         "record": {
-          "description": "Record retention settings to substitute on matching platforms.",
+          "description": "Record retention settings substituted on matching platforms.",
           "$ref": "#/$defs/DeserializedRecordOverrideData"
         },
         "ui": {
-          "description": "UI settings to substitute on matching platforms.",
+          "description": "UI settings substituted on matching platforms.",
           "$ref": "#/$defs/DeserializedUiOverrideData"
         }
       },
@@ -89,11 +89,11 @@
       ]
     },
     "DeserializedRecordConfig": {
-      "description": "Retention policy for recorded test runs.\n\nRecording only happens when the `record` experimental feature is enabled\n_and_ `enabled` here is true. The least-recently-used runs are evicted to\nkeep within `max-records`, `max-total-size`, and `max-age`.",
+      "description": "Retention settings for the record-replay-rerun feature.\n\nRecording happens only when the `record` experimental feature is enabled\nand `enabled` here is true. The least-recently-used runs are evicted to\nkeep within `max-records`, `max-total-size`, and `max-age`.",
       "type": "object",
       "properties": {
         "enabled": {
-          "description": "Whether to record test runs.\n\nSet to false to temporarily disable recording without removing the rest\nof the configuration. Has no effect unless the `record` experimental\nfeature is also enabled.",
+          "description": "Whether to record test runs. Has no effect unless `[experimental]\nrecord = true`.",
           "type": [
             "boolean",
             "null"
@@ -101,7 +101,7 @@
           "default": null
         },
         "max-age": {
-          "description": "Maximum idle time before a recorded run is evicted (e.g. `\"30d\"`).",
+          "description": "Maximum age of a recorded run before eviction (e.g. `\"30d\"`).",
           "type": [
             "string",
             "null"
@@ -109,7 +109,7 @@
           "default": null
         },
         "max-output-size": {
-          "description": "Maximum size of a single captured stdout or stderr stream before it is\ntruncated (e.g. `\"10MB\"`).",
+          "description": "Maximum size of a single captured stdout or stderr stream before\ntruncation (e.g. `\"10MB\"`).",
           "type": [
             "string",
             "null"
@@ -117,7 +117,7 @@
           "default": null
         },
         "max-records": {
-          "description": "Maximum number of recorded runs to retain.",
+          "description": "Maximum number of recorded runs to retain before eviction.",
           "type": [
             "integer",
             "null"
@@ -127,7 +127,7 @@
           "minimum": 0
         },
         "max-total-size": {
-          "description": "Maximum combined size of all recorded runs (e.g. `\"1GB\"`).",
+          "description": "Maximum combined size of all retained recordings before eviction (e.g.\n`\"1GB\"`).",
           "type": [
             "string",
             "null"
@@ -142,7 +142,7 @@
       "type": "object",
       "properties": {
         "enabled": {
-          "description": "Whether to record test runs.",
+          "description": "Whether to record test runs. Has no effect unless `[experimental]\nrecord = true`.",
           "type": [
             "boolean",
             "null"
@@ -150,7 +150,7 @@
           "default": null
         },
         "max-age": {
-          "description": "Maximum idle time before a recorded run is evicted (e.g. `\"30d\"`).",
+          "description": "Maximum age of a recorded run before eviction (e.g. `\"30d\"`).",
           "type": [
             "string",
             "null"
@@ -158,7 +158,7 @@
           "default": null
         },
         "max-output-size": {
-          "description": "Maximum size of a single captured stdout or stderr stream before it is\ntruncated (e.g. `\"10MB\"`).",
+          "description": "Maximum size of a single captured stdout or stderr stream before\ntruncation (e.g. `\"10MB\"`).",
           "type": [
             "string",
             "null"
@@ -166,7 +166,7 @@
           "default": null
         },
         "max-records": {
-          "description": "Maximum number of recorded runs to retain.",
+          "description": "Maximum number of recorded runs to retain before eviction.",
           "type": [
             "integer",
             "null"
@@ -176,7 +176,7 @@
           "minimum": 0
         },
         "max-total-size": {
-          "description": "Maximum combined size of all recorded runs (e.g. `\"1GB\"`).",
+          "description": "Maximum combined size of all retained recordings before eviction (e.g.\n`\"1GB\"`).",
           "type": [
             "string",
             "null"
@@ -187,11 +187,11 @@
       "additionalProperties": false
     },
     "DeserializedStreampagerConfig": {
-      "description": "Settings for nextest's built-in pager (active when `pager = \":builtin\"`).",
+      "description": "Settings for nextest's builtin pager (active when `pager = \":builtin\"`).",
       "type": "object",
       "properties": {
         "interface": {
-          "description": "How the pager uses the alternate screen and when it exits.",
+          "description": "How the builtin pager uses the alternate screen and when it exits.",
           "anyOf": [
             {
               "$ref": "#/$defs/StreampagerInterface"
@@ -202,14 +202,14 @@
           ]
         },
         "show-ruler": {
-          "description": "Shows a ruler at the bottom of the pager.",
+          "description": "Whether to show a ruler at the bottom of the builtin pager.",
           "type": [
             "boolean",
             "null"
           ]
         },
         "wrapping": {
-          "description": "How long lines are wrapped.",
+          "description": "How the builtin pager wraps long lines.",
           "anyOf": [
             {
               "$ref": "#/$defs/StreampagerWrapping"
@@ -234,7 +234,7 @@
           ]
         },
         "max-progress-running": {
-          "description": "Maximum number of running tests to list in the progress bar.\n\nAccepts a non-negative integer, or `\"infinite\"` for no limit. When the\nnumber of running tests exceeds this, the remainder is collapsed into a\nsummary line.",
+          "description": "Maximum number of running tests to list in the progress bar.\n\nAccepts a non-negative integer, or `\"infinite\"` for no limit. Excess\nrunning tests are collapsed into a summary line.",
           "anyOf": [
             {
               "$ref": "#/$defs/MaxProgressRunning"
@@ -252,7 +252,7 @@
           ]
         },
         "pager": {
-          "description": "Pager command to use for output that benefits from scrolling. Use\n`\":builtin\"` to select nextest's built-in pager.",
+          "description": "Pager command to use for output that benefits from scrolling. Use\n`\":builtin\"` to select nextest's builtin pager.",
           "anyOf": [
             {
               "$ref": "#/$defs/PagerSetting"
@@ -285,7 +285,7 @@
           ]
         },
         "streampager": {
-          "description": "Settings for the built-in pager (active when `pager = \":builtin\"`).",
+          "description": "Settings for the builtin pager (active when `pager = \":builtin\"`).",
           "$ref": "#/$defs/DeserializedStreampagerConfig"
         }
       },
@@ -296,14 +296,14 @@
       "type": "object",
       "properties": {
         "input-handler": {
-          "description": "Enables the interactive keyboard input handler.",
+          "description": "Enables the interactive keyboard input handler (e.g. `t` to dump test\nstatus, `Enter` to print a summary line).",
           "type": [
             "boolean",
             "null"
           ]
         },
         "max-progress-running": {
-          "description": "Maximum number of running tests to list in the progress bar.",
+          "description": "Maximum number of running tests to list in the progress bar.\n\nAccepts a non-negative integer, or `\"infinite\"` for no limit. Excess\nrunning tests are collapsed into a summary line.",
           "anyOf": [
             {
               "$ref": "#/$defs/MaxProgressRunning"
@@ -321,7 +321,7 @@
           ]
         },
         "pager": {
-          "description": "Pager command to use for output that benefits from scrolling.",
+          "description": "Pager command to use for output that benefits from scrolling. Use\n`\":builtin\"` to select nextest's builtin pager.",
           "anyOf": [
             {
               "$ref": "#/$defs/PagerSetting"
@@ -354,18 +354,18 @@
           ]
         },
         "streampager": {
-          "description": "Settings for the built-in pager (active when `pager = \":builtin\"`).",
+          "description": "Settings for the builtin pager (active when `pager = \":builtin\"`).",
           "$ref": "#/$defs/DeserializedStreampagerConfig"
         }
       },
       "additionalProperties": false
     },
     "ExperimentalConfig": {
-      "description": "User-level experimental features.\n\nConfigured in the `[experimental]` table of the user config file:\n\n```toml\n[experimental]\nrecord = true\n```\n\nUnknown features in this table produce a warning rather than an error, so\nolder nextest binaries can load configs written for newer ones.",
+      "description": "Toggles for user-level experimental, non-stable features.\n\nConfigured in the `[experimental]` table of the user config file. Unknown\nkeys here produce a warning rather than an error so that older nextest\nbinaries can load configs written for newer ones.",
       "type": "object",
       "properties": {
         "record": {
-          "description": "Enables the record-replay-rerun feature, which stores test run results\non disk so they can be replayed or selectively rerun later.",
+          "description": "Enables the record-replay-rerun feature: stores test run results on\ndisk for replay or selective rerun.",
           "type": "boolean",
           "default": false
         }
@@ -415,7 +415,7 @@
       ]
     },
     "StreampagerInterface": {
-      "description": "How the built-in pager uses the alternate screen and when it exits.",
+      "description": "How the builtin pager uses the alternate screen and when it exits.",
       "oneOf": [
         {
           "description": "Exits immediately if the output fits on one page; otherwise switches\nto full-screen and clears on exit.",
@@ -435,7 +435,7 @@
       ]
     },
     "StreampagerWrapping": {
-      "description": "How long lines are wrapped in the built-in pager.",
+      "description": "How long lines are wrapped in the builtin pager.",
       "oneOf": [
         {
           "description": "Disables wrapping; long lines extend off-screen and can be scrolled\nhorizontally.",
@@ -478,7 +478,7 @@
           "const": "counter"
         },
         {
-          "description": "Like `bar` in interactive terminals, but additionally hides successful\ntest output (sets `status-level` to `slow` and `final-status-level` to\n`none`). Falls back to `auto` behavior in non-interactive contexts\n(e.g. piped output, CI).",
+          "description": "Like `bar` in interactive terminals, but additionally hides successful\ntest output (sets `status-level` to `slow` and `final-status-level` to\n`none`). Falls back to `auto` in non-interactive contexts (e.g. piped\noutput, CI).",
           "type": "string",
           "const": "only"
         }

--- a/nextest-runner/src/config/core/imp.rs
+++ b/nextest-runner/src/config/core/imp.rs
@@ -1511,20 +1511,21 @@ pub(crate) struct NextestConfigDeserialize {
     )]
     store: StoreConfigImpl,
 
-    /// The minimum required and recommended versions of nextest for this
-    /// configuration.
+    /// The minimum required (and optionally recommended) version of nextest
+    /// for this configuration.
     // These are parsed as part of NextestConfigVersionOnly. They're re-parsed
     // here to avoid printing an "unknown key" message.
     #[expect(unused)]
     #[serde(default)]
     nextest_version: Option<NextestVersionDeserialize>,
 
-    /// Enables experimental nextest features.
+    /// Enables experimental, non-stable features.
     #[expect(unused)]
     #[serde(default)]
     experimental: ExperimentalDeserialize,
 
-    /// Custom test groups for mutual exclusion and resource management.
+    /// Custom test groups for mutual exclusion and resource management, keyed
+    /// by group name.
     #[serde(default)]
     test_groups: BTreeMap<CustomTestGroup, TestGroupConfig>,
 
@@ -1535,11 +1536,11 @@ pub(crate) struct NextestConfigDeserialize {
     #[serde(default, rename = "script")]
     old_setup_scripts: IndexMap<ScriptId, SetupScriptConfig>,
 
-    /// Setup and wrapper scripts.
+    /// Setup and wrapper scripts, keyed by script name.
     #[serde(default)]
     scripts: ScriptConfig,
 
-    /// Test profiles.
+    /// Test profiles, keyed by profile name.
     #[serde(rename = "profile")]
     #[cfg_attr(
         feature = "config-schema",
@@ -1723,7 +1724,8 @@ impl DefaultProfileImpl {
 #[cfg_attr(feature = "config-schema", schemars(deny_unknown_fields))]
 #[serde(rename_all = "kebab-case")]
 pub(in crate::config) struct CustomProfileImpl {
-    /// The default set of tests run by `cargo nextest run`.
+    /// The default set of tests run by `cargo nextest run`, as a filterset
+    /// expression.
     #[serde(default)]
     default_filter: Option<String>,
     /// Retry policy for failed tests.
@@ -1735,7 +1737,7 @@ pub(in crate::config) struct CustomProfileImpl {
     /// Number of threads to run tests with.
     #[serde(default)]
     test_threads: Option<TestThreads>,
-    /// Number of threads each test requires.
+    /// Number of threads (slots) each test reserves from the pool.
     #[serde(default)]
     threads_required: Option<ThreadsRequired>,
     /// Extra arguments to pass to test binaries.
@@ -1760,22 +1762,23 @@ pub(in crate::config) struct CustomProfileImpl {
         deserialize_with = "deserialize_fail_fast"
     )]
     max_fail: Option<MaxFail>,
-    /// Time after which tests are considered slow, and timeout configuration.
+    /// Time after which tests are considered slow, plus optional termination
+    /// policy.
     #[serde(default, deserialize_with = "deserialize_slow_timeout")]
     slow_timeout: Option<SlowTimeout>,
-    /// A global timeout for test execution.
+    /// A global timeout for the entire test run.
     #[serde(default)]
     global_timeout: Option<GlobalTimeout>,
     /// Time to wait for child processes to exit after a test completes.
     #[serde(default, deserialize_with = "deserialize_leak_timeout")]
     leak_timeout: Option<LeakTimeout>,
-    /// Per-test setting overrides.
+    /// Per-test setting overrides, evaluated in order.
     #[serde(default)]
     overrides: Vec<DeserializedOverride>,
-    /// Profile-specific script configuration.
+    /// Profile-specific script bindings (setup and wrapper).
     #[serde(default)]
     scripts: Vec<DeserializedProfileScriptConfig>,
-    /// JUnit output configuration.
+    /// JUnit XML output configuration.
     #[serde(default)]
     junit: JunitImpl,
     /// Archive configuration for this profile.
@@ -1784,7 +1787,7 @@ pub(in crate::config) struct CustomProfileImpl {
     /// Benchmark-specific configuration.
     #[serde(default)]
     bench: Option<BenchConfig>,
-    /// The profile to inherit configuration settings from.
+    /// The profile to inherit settings from.
     #[serde(default)]
     inherits: Option<String>,
 }

--- a/nextest-runner/src/config/elements/archive.rs
+++ b/nextest-runner/src/config/elements/archive.rs
@@ -6,13 +6,13 @@ use camino::{Utf8Component, Utf8Path, Utf8PathBuf};
 use serde::{Deserialize, de::Unexpected};
 use std::fmt;
 
-/// Configuration for archives.
+/// Archive configuration for this profile.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "config-schema", schemars(deny_unknown_fields))]
 #[serde(rename_all = "kebab-case")]
 pub struct ArchiveConfig {
-    /// Files to include in the archive.
+    /// Extra paths to include in the archive.
     #[cfg_attr(
         feature = "config-schema",
         // NOTE: `include` in the JSON Schema should be optional, given the pre-deserialization logic.
@@ -21,35 +21,33 @@ pub struct ArchiveConfig {
     pub include: Vec<ArchiveInclude>,
 }
 
-/// Type for the archive-include key.
-///
-/// # Notes
-///
-/// This is `deny_unknown_fields` because if we take additional arguments in the future, they're
-/// likely to change semantics in an incompatible way.
+/// A single entry under `archive.include`.
+// This is `deny_unknown_fields` because if we take additional arguments in the
+// future, they're likely to change semantics in an incompatible way.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct ArchiveInclude {
-    /// Relative path to include.
-    // We only allow well-formed relative paths within the target directory here. It's possible we
-    // can relax this in the future, but better safe than sorry for now.
+    /// Path to include, relative to `relative-to`.
+    // We only allow well-formed relative paths within the target directory
+    // here. It's possible we can relax this in the future, but better safe than
+    // sorry for now.
     #[serde(deserialize_with = "deserialize_relative_path")]
     #[cfg_attr(
         feature = "config-schema",
         schemars(schema_with = "String::json_schema")
     )]
     path: Utf8PathBuf,
-    /// Base directory that `path` is relative to.
+    /// Base directory `path` is interpreted relative to.
     relative_to: ArchiveRelativeTo,
-    /// Maximum recursion depth.
+    /// Maximum recursion depth: a non-negative integer, or `"infinite"`.
     #[serde(default = "default_depth")]
     #[cfg_attr(
         feature = "config-schema",
         schemars(schema_with = "RecursionDepth::json_schema")
     )]
     depth: TrackDefault<RecursionDepth>,
-    /// What to do if the path is missing.
+    /// What to do if `path` is missing: `"ignore"`, `"warn"`, or `"error"`.
     #[serde(default = "default_on_missing")]
     on_missing: ArchiveIncludeOnMissing,
 }
@@ -108,18 +106,18 @@ fn join_rel_path(a: &Utf8Path, rel: &Utf8Path) -> Utf8PathBuf {
     out.into()
 }
 
-/// What to do when an archive-include path is missing.
+/// What to do when an `archive.include` path is missing.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "config-schema", schemars(rename_all = "kebab-case"))]
 pub enum ArchiveIncludeOnMissing {
-    /// Ignore and continue.
+    /// Skip the missing path (printed in verbose mode).
     Ignore,
 
-    /// Warn and continue.
+    /// Print a warning and continue.
     Warn,
 
-    /// Produce an error.
+    /// Produce an error and abort the archive operation.
     Error,
 }
 
@@ -157,12 +155,12 @@ impl<'de> Deserialize<'de> for ArchiveIncludeOnMissing {
     }
 }
 
-/// Defines the base of the path
+/// Base directory `path` is interpreted relative to.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum ArchiveRelativeTo {
-    /// Path starts at the target directory
+    /// Resolve `path` against the target directory.
     Target,
     // TODO: add support for profile relative
     //TargetProfile,

--- a/nextest-runner/src/config/elements/bench.rs
+++ b/nextest-runner/src/config/elements/bench.rs
@@ -12,9 +12,12 @@ use serde::Deserialize;
 /// Benchmark-specific configuration for the default profile.
 #[derive(Clone, Debug)]
 pub(in crate::config) struct DefaultBenchConfig {
-    /// Slow timeout for benchmarks.
+    /// Time after which benchmarks are considered slow, plus optional
+    /// termination policy. Replaces `slow-timeout` when running
+    /// `cargo nextest bench`.
     pub(in crate::config) slow_timeout: SlowTimeout,
-    /// Global timeout for benchmarks.
+    /// Global timeout for the entire benchmark run. Replaces `global-timeout`
+    /// when running `cargo nextest bench`.
     pub(in crate::config) global_timeout: GlobalTimeout,
 }
 
@@ -32,16 +35,23 @@ impl DefaultBenchConfig {
     }
 }
 
-/// Benchmark-specific configuration (deserialized form with optional fields).
+/// Benchmark-specific timeout overrides used when running
+/// `cargo nextest bench`.
+///
+/// Each field, if set, replaces its non-`bench` counterpart for benchmark
+/// runs only.
 #[derive(Clone, Debug, Default, Deserialize)]
 #[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "config-schema", schemars(deny_unknown_fields))]
 #[serde(rename_all = "kebab-case")]
 pub(in crate::config) struct BenchConfig {
-    /// Slow timeout for benchmarks.
+    /// Time after which benchmarks are considered slow, plus optional
+    /// termination policy. Replaces `slow-timeout` when running
+    /// `cargo nextest bench`.
     #[serde(default, deserialize_with = "deserialize_slow_timeout")]
     pub(in crate::config) slow_timeout: Option<SlowTimeout>,
-    /// Global timeout for benchmarks.
+    /// Global timeout for the entire benchmark run. Replaces `global-timeout`
+    /// when running `cargo nextest bench`.
     #[serde(default)]
     pub(in crate::config) global_timeout: Option<GlobalTimeout>,
 }

--- a/nextest-runner/src/config/elements/global_timeout.rs
+++ b/nextest-runner/src/config/elements/global_timeout.rs
@@ -4,7 +4,8 @@
 use serde::{Deserialize, Deserializer};
 use std::time::Duration;
 
-/// Type for the global-timeout config key.
+/// A global timeout for an entire test or benchmark run, after which nextest
+/// aborts.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GlobalTimeout {
     pub(crate) period: Duration,

--- a/nextest-runner/src/config/elements/junit.rs
+++ b/nextest-runner/src/config/elements/junit.rs
@@ -121,7 +121,7 @@ impl DefaultJunitImpl {
 #[cfg_attr(feature = "config-schema", schemars(deny_unknown_fields))]
 #[serde(rename_all = "kebab-case")]
 pub(in crate::config) struct JunitImpl {
-    /// Path to write the JUnit XML report to. If unset, JUnit support is
+    /// Path to write the JUnit XML report to. If unset, JUnit reporting is
     /// disabled.
     #[serde(default)]
     #[cfg_attr(
@@ -129,7 +129,7 @@ pub(in crate::config) struct JunitImpl {
         schemars(schema_with = "String::json_schema")
     )]
     pub(in crate::config) path: Option<Utf8PathBuf>,
-    /// Name for the JUnit report.
+    /// Name for the JUnit XML report.
     #[serde(default)]
     pub(in crate::config) report_name: Option<String>,
     /// Whether to store successful test output in the JUnit XML report.

--- a/nextest-runner/src/config/elements/leak_timeout.rs
+++ b/nextest-runner/src/config/elements/leak_timeout.rs
@@ -6,9 +6,8 @@
 use serde::{Deserialize, Serialize, de::IntoDeserializer};
 use std::{fmt, time::Duration};
 
-/// Controls leak timeout behavior.
-///
-/// Includes a period and a result (pass or fail).
+/// Time to wait for child processes to exit after a test completes, plus the
+/// pass/fail result recorded when the timeout elapses.
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
 pub struct LeakTimeout {
     /// The leak timeout period.
@@ -54,17 +53,17 @@ impl schemars::JsonSchema for LeakTimeout {
     }
 }
 
-/// The result of controlling leak timeout behavior.
+/// Whether to mark a test as passed or failed when the leak timeout elapses.
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 pub enum LeakTimeoutResult {
-    /// The test is marked as failed.
+    /// Mark the test as failed.
     Fail,
 
     #[default]
-    /// The test is marked as passed.
+    /// Mark the test as passed.
     Pass,
 }
 

--- a/nextest-runner/src/config/elements/max_fail.rs
+++ b/nextest-runner/src/config/elements/max_fail.rs
@@ -5,18 +5,20 @@ use crate::errors::MaxFailParseError;
 use serde::Deserialize;
 use std::{fmt, str::FromStr};
 
-/// Type for the max-fail flag and fail-fast configuration.
+/// The number of failures after which to stop running tests, plus the
+/// termination policy for tests already in flight.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum MaxFail {
-    /// Allow a specific number of tests to fail before exiting.
+    /// Allow a specific number of tests to fail before stopping.
     Count {
-        /// The maximum number of tests that can fail before exiting.
+        /// The maximum number of tests that may fail before stopping.
         max_fail: usize,
-        /// Whether to terminate running tests immediately or wait for them to complete.
+        /// Whether to wait for currently running tests to complete or terminate
+        /// them immediately.
         terminate: TerminateMode,
     },
 
-    /// Run all tests. Equivalent to --no-fast-fail.
+    /// Run all tests regardless of failures. Equivalent to `--no-fail-fast`.
     All,
 }
 
@@ -129,10 +131,10 @@ impl fmt::Display for MaxFail {
 #[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 pub enum TerminateMode {
-    /// Wait for running tests to complete (default)
+    /// Wait for running tests to complete naturally.
     #[default]
     Wait,
-    /// Terminate running tests immediately
+    /// Send termination signals to running tests immediately.
     Immediate,
 }
 

--- a/nextest-runner/src/config/elements/priority.rs
+++ b/nextest-runner/src/config/elements/priority.rs
@@ -4,9 +4,7 @@
 use crate::errors::TestPriorityOutOfRange;
 use serde::{Deserialize, Deserializer};
 
-/// A test priority: a number between -100 and 100.
-///
-/// The sort order is from highest to lowest priority.
+/// A test priority between -100 and 100, inclusive. Higher values run sooner.
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 pub struct TestPriority(

--- a/nextest-runner/src/config/elements/retry_policy.rs
+++ b/nextest-runner/src/config/elements/retry_policy.rs
@@ -4,10 +4,11 @@
 use serde::{Deserialize, Serialize};
 use std::{cmp::Ordering, fmt, time::Duration};
 
-/// Type for the retry config key.
+/// Retry policy for failed tests: maximum retries, plus an optional backoff
+/// schedule between attempts.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RetryPolicy {
-    /// Fixed backoff.
+    /// Fixed delay between retries.
     Fixed {
         /// Maximum retry count.
         count: u32,
@@ -15,22 +16,22 @@ pub enum RetryPolicy {
         /// Delay between retries.
         delay: Duration,
 
-        /// If set to true, randomness will be added to the delay on each retry attempt.
+        /// If true, add jitter to the delay on each retry attempt.
         jitter: bool,
     },
 
-    /// Exponential backoff.
+    /// Exponentially increasing delay between retries.
     Exponential {
         /// Maximum retry count.
         count: u32,
 
-        /// Delay between retries. Not optional for exponential backoff.
+        /// Initial delay between retries. Required for exponential backoff.
         delay: Duration,
 
-        /// If set to true, randomness will be added to the delay on each retry attempt.
+        /// If true, add jitter to the delay on each retry attempt.
         jitter: bool,
 
-        /// If set, limits the delay between retries.
+        /// If set, caps the delay between retries.
         max_delay: Option<Duration>,
     },
 }

--- a/nextest-runner/src/config/elements/slow_timeout.rs
+++ b/nextest-runner/src/config/elements/slow_timeout.rs
@@ -5,7 +5,8 @@ use crate::time::far_future_duration;
 use serde::{Deserialize, Serialize, de::IntoDeserializer};
 use std::{fmt, num::NonZeroUsize, time::Duration};
 
-/// Type for the slow-timeout config key.
+/// Time after which a test is considered slow, plus optional termination
+/// policy.
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct SlowTimeout {

--- a/nextest-runner/src/config/elements/test_group.rs
+++ b/nextest-runner/src/config/elements/test_group.rs
@@ -149,13 +149,13 @@ impl fmt::Display for CustomTestGroup {
     }
 }
 
-/// Configuration for a test group.
+/// Configuration for a single test group.
 #[derive(Clone, Debug, Deserialize)]
 #[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "config-schema", schemars(deny_unknown_fields))]
 #[serde(rename_all = "kebab-case")]
 pub struct TestGroupConfig {
-    /// The maximum number of threads allowed for this test group.
+    /// Maximum number of threads this test group may use concurrently.
     pub max_threads: TestThreads,
 }
 

--- a/nextest-runner/src/config/elements/test_threads.rs
+++ b/nextest-runner/src/config/elements/test_threads.rs
@@ -5,13 +5,13 @@ use crate::{config::core::get_num_cpus, errors::TestThreadsParseError};
 use serde::Deserialize;
 use std::{cmp::Ordering, fmt, str::FromStr};
 
-/// Type for the test-threads config key.
+/// Number of threads to run tests with.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TestThreads {
-    /// Run tests with a specified number of threads.
+    /// Run tests with a fixed number of threads.
     Count(usize),
 
-    /// Run tests with a number of threads equal to the logical CPU count.
+    /// Run tests with one thread per logical CPU.
     NumCpus,
 }
 

--- a/nextest-runner/src/config/elements/threads_required.rs
+++ b/nextest-runner/src/config/elements/threads_required.rs
@@ -5,16 +5,16 @@ use crate::config::core::get_num_cpus;
 use serde::Deserialize;
 use std::{cmp::Ordering, fmt};
 
-/// Type for the threads-required config key.
+/// Number of threads (slots) each test reserves from the pool.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ThreadsRequired {
-    /// Take up "slots" equal to the number of threads.
+    /// Reserve a fixed number of slots.
     Count(usize),
 
-    /// Take up as many slots as the number of CPUs.
+    /// Reserve as many slots as the logical CPU count.
     NumCpus,
 
-    /// Take up as many slots as the number of test threads specified.
+    /// Reserve as many slots as the configured `test-threads` value.
     NumTestThreads,
 }
 

--- a/nextest-runner/src/config/overrides/imp.rs
+++ b/nextest-runner/src/config/overrides/imp.rs
@@ -985,10 +985,10 @@ pub(crate) enum FilterOrDefaultFilter {
 #[cfg_attr(feature = "config-schema", schemars(deny_unknown_fields))]
 #[serde(rename_all = "kebab-case")]
 pub(in crate::config) struct DeserializedOverride {
-    /// The host and/or target platforms to match against.
+    /// Host and/or target platforms this override applies to.
     #[serde(default)]
     platform: PlatformStrings,
-    /// The filterset to match against.
+    /// Filterset expression selecting tests this override applies to.
     #[serde(default)]
     filter: Option<String>,
     // Overrides start here.
@@ -996,17 +996,17 @@ pub(in crate::config) struct DeserializedOverride {
     // (This used to use serde(flatten) but that has issues:
     // https://github.com/serde-rs/serde/issues/2312.)
     // ---
-    /// Test priority.
+    /// Priority for matching tests; higher values run sooner.
     #[serde(default)]
     priority: Option<TestPriority>,
-    /// The default filter for tests. Only supported if platform is specified
-    /// but filter is not.
+    /// Replaces `default-filter` for matching platforms. Requires `platform`
+    /// and must not be combined with `filter`.
     #[serde(default)]
     default_filter: Option<String>,
-    /// The number of threads required for matching tests.
+    /// Number of threads each matching test reserves from the pool.
     #[serde(default)]
     threads_required: Option<ThreadsRequired>,
-    /// Extra arguments to pass to the test runner.
+    /// Extra arguments to pass to matching test binaries.
     #[serde(default)]
     run_extra_args: Option<Vec<String>>,
     /// Retry policy for matching tests.
@@ -1015,7 +1015,7 @@ pub(in crate::config) struct DeserializedOverride {
         deserialize_with = "crate::config::elements::deserialize_retry_policy"
     )]
     retries: Option<RetryPolicy>,
-    /// Whether to treat flaky tests as passing or failing.
+    /// Whether to treat matching flaky tests as passing or failing.
     #[serde(default)]
     flaky_result: Option<FlakyResult>,
     /// Slow timeout for matching tests.
@@ -1033,16 +1033,16 @@ pub(in crate::config) struct DeserializedOverride {
     /// Test group to put matching tests in.
     #[serde(default)]
     test_group: Option<TestGroup>,
-    /// Success output display for matching tests.
+    /// When to display output for matching successful tests.
     #[serde(default)]
     success_output: Option<TestOutputDisplay>,
-    /// Failure output display for matching tests.
+    /// When to display output for matching failed tests.
     #[serde(default)]
     failure_output: Option<TestOutputDisplay>,
-    /// JUnit output configuration for matching tests.
+    /// JUnit XML output settings for matching tests.
     #[serde(default)]
     junit: DeserializedJunitOutput,
-    /// Benchmark-specific overrides.
+    /// Benchmark-specific overrides for matching tests.
     #[serde(default)]
     bench: DeserializedOverrideBench,
 }
@@ -1052,9 +1052,11 @@ pub(in crate::config) struct DeserializedOverride {
 #[cfg_attr(feature = "config-schema", schemars(deny_unknown_fields))]
 #[serde(rename_all = "kebab-case")]
 pub(in crate::config) struct DeserializedJunitOutput {
-    /// Whether to store successful test output in the JUnit XML report.
+    /// Whether to store successful output for matching tests in the JUnit XML
+    /// report.
     store_success_output: Option<bool>,
-    /// Whether to store failed test output in the JUnit XML report.
+    /// Whether to store failed output for matching tests in the JUnit XML
+    /// report.
     store_failure_output: Option<bool>,
     /// How flaky-fail tests are reported in the JUnit XML report.
     flaky_fail_status: Option<JunitFlakyFailStatus>,

--- a/nextest-runner/src/config/scripts/imp.rs
+++ b/nextest-runner/src/config/scripts/imp.rs
@@ -40,17 +40,17 @@ use std::{
 };
 use swrite::{SWrite, swrite};
 
-/// The scripts defined in nextest configuration.
+/// Setup and wrapper scripts defined in nextest configuration.
 #[derive(Clone, Debug, Default, Deserialize)]
 #[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "config-schema", schemars(deny_unknown_fields))]
 #[serde(rename_all = "kebab-case")]
 pub struct ScriptConfig {
     // These maps are ordered because scripts are used in the order they're defined.
-    /// The setup scripts defined in nextest's configuration.
+    /// Setup scripts, keyed by script name.
     #[serde(default)]
     pub setup: IndexMap<ScriptId, SetupScriptConfig>,
-    /// The wrapper scripts defined in nextest's configuration.
+    /// Wrapper scripts, keyed by script name.
     #[serde(default)]
     pub wrapper: IndexMap<ScriptId, WrapperScriptConfig>,
 }
@@ -616,24 +616,24 @@ impl ProfileScriptData {
 #[cfg_attr(feature = "config-schema", schemars(deny_unknown_fields))]
 #[serde(rename_all = "kebab-case")]
 pub(in crate::config) struct DeserializedProfileScriptConfig {
-    /// The host and/or target platforms to match against.
+    /// Host and/or target platforms these scripts apply to.
     #[serde(default)]
     pub(in crate::config) platform: PlatformStrings,
 
-    /// The filterset to match against.
+    /// Filterset expression selecting tests these scripts apply to.
     #[serde(default)]
     filter: Option<String>,
 
-    /// The setup script or scripts to run.
+    /// Names of setup scripts to run (single name or array).
     #[cfg_attr(feature = "config-schema", schemars(schema_with = "script_ids_schema"))]
     #[serde(default, deserialize_with = "deserialize_script_ids")]
     setup: Vec<ScriptId>,
 
-    /// The wrapper script to run at list time.
+    /// Name of the wrapper script used during test listing.
     #[serde(default)]
     list_wrapper: Option<ScriptId>,
 
-    /// The wrapper script to run at run time.
+    /// Name of the wrapper script used during test execution.
     #[serde(default)]
     run_wrapper: Option<ScriptId>,
 }
@@ -659,33 +659,32 @@ fn script_ids_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Sch
 #[cfg_attr(feature = "config-schema", schemars(deny_unknown_fields))]
 #[serde(rename_all = "kebab-case")]
 pub struct SetupScriptConfig {
-    /// The command to run. The first element is the program and the second element is a list
-    /// of arguments.
+    /// The command to run for this setup script.
     pub command: ScriptCommand,
 
-    /// An optional slow timeout for this command.
+    /// Slow-timeout configuration for this setup script.
     #[serde(
         default,
         deserialize_with = "crate::config::elements::deserialize_slow_timeout"
     )]
     pub slow_timeout: Option<SlowTimeout>,
 
-    /// An optional leak timeout for this command.
+    /// Leak-timeout configuration for this setup script.
     #[serde(
         default,
         deserialize_with = "crate::config::elements::deserialize_leak_timeout"
     )]
     pub leak_timeout: Option<LeakTimeout>,
 
-    /// Whether to capture standard output for this command.
+    /// Whether to capture stdout from this setup script.
     #[serde(default)]
     pub capture_stdout: bool,
 
-    /// Whether to capture standard error for this command.
+    /// Whether to capture stderr from this setup script.
     #[serde(default)]
     pub capture_stderr: bool,
 
-    /// JUnit configuration for this script.
+    /// JUnit XML output settings for this setup script.
     #[serde(default)]
     pub junit: SetupScriptJunitConfig,
 }
@@ -698,21 +697,19 @@ impl SetupScriptConfig {
     }
 }
 
-/// A JUnit override configuration.
+/// JUnit XML output settings for a setup script.
 #[derive(Copy, Clone, Debug, Deserialize)]
 #[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "config-schema", schemars(deny_unknown_fields))]
 #[serde(rename_all = "kebab-case")]
 pub struct SetupScriptJunitConfig {
-    /// Whether to store successful output.
-    ///
-    /// Defaults to true.
+    /// Whether to store this setup script's output on success in the JUnit XML
+    /// report. Defaults to true.
     #[serde(default = "default_true")]
     pub store_success_output: bool,
 
-    /// Whether to store failing output.
-    ///
-    /// Defaults to true.
+    /// Whether to store this setup script's output on failure in the JUnit XML
+    /// report. Defaults to true.
     #[serde(default = "default_true")]
     pub store_failure_output: bool,
 }
@@ -734,25 +731,25 @@ impl Default for SetupScriptJunitConfig {
 #[cfg_attr(feature = "config-schema", schemars(deny_unknown_fields))]
 #[serde(rename_all = "kebab-case")]
 pub struct WrapperScriptConfig {
-    /// The command to run.
+    /// The command to run as the wrapper.
     pub command: ScriptCommand,
 
-    /// How this script interacts with a configured target runner, if any.
-    /// Defaults to ignoring the target runner.
+    /// How this wrapper composes with a configured target runner.
     #[serde(default)]
     pub target_runner: WrapperScriptTargetRunner,
 }
 
-/// Interaction of wrapper script with a configured target runner.
+/// How a wrapper script composes with a configured target runner.
 #[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "config-schema", schemars(rename_all = "kebab-case"))]
 pub enum WrapperScriptTargetRunner {
-    /// The target runner is ignored. This is the default.
+    /// The target runner is ignored.
     #[default]
     Ignore,
 
-    /// The target runner overrides the wrapper.
+    /// When a target runner is configured, it replaces the wrapper; otherwise
+    /// the wrapper runs as usual.
     OverridesWrapper,
 
     /// The target runner runs within the wrapper script. The command line used
@@ -1077,21 +1074,20 @@ impl<'de> serde::de::DeserializeSeed<'de> for CommandInnerSeed {
     }
 }
 
-/// The directory to interpret a [`ScriptCommand`] as relative to, in case it is
-/// a relative path.
+/// Base directory a relative script program is resolved against.
 ///
-/// If specified, the program will be joined with the provided path.
+/// If specified, the program is joined with the provided path.
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "config-schema", schemars(rename_all = "kebab-case"))]
 pub enum ScriptCommandRelativeTo {
-    /// Do not join the program with any path.
+    /// Use the program path as-is, without joining.
     None,
 
-    /// Join the program with the workspace root.
+    /// Resolve the program against the workspace root.
     WorkspaceRoot,
 
-    /// Join the program with the target directory.
+    /// Resolve the program against the target directory.
     Target,
     // TODO: TargetProfile, similar to ArchiveRelativeTo
 }

--- a/nextest-runner/src/reporter/displayer/status_level.rs
+++ b/nextest-runner/src/reporter/displayer/status_level.rs
@@ -9,10 +9,10 @@ use super::TestOutputDisplay;
 use crate::reporter::events::{CancelReason, ExecutionResultDescription};
 use serde::Deserialize;
 
-/// Status level to show in the reporter output.
+/// Level of status information to display during test runs.
 ///
-/// Status levels are incremental: each level causes all the statuses listed above it to be output. For example,
-/// [`Slow`](Self::Slow) implies [`Retry`](Self::Retry) and [`Fail`](Self::Fail).
+/// Status levels are incremental: each level causes all the statuses listed
+/// above it to be output. For example, `slow` implies `retry` and `fail`.
 #[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Deserialize)]
 #[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
@@ -25,32 +25,34 @@ pub enum StatusLevel {
     /// Only output test failures.
     Fail,
 
-    /// Output retries and failures.
+    /// Output test retries; includes `fail`.
     Retry,
 
-    /// Output information about slow tests, and all variants above.
+    /// Output slow tests; includes `retry`.
     Slow,
 
-    /// Output information about leaky tests, and all variants above.
+    /// Output leaky tests; includes `slow`.
     Leak,
 
-    /// Output passing tests in addition to all variants above.
+    /// Output passing tests; includes `leak`.
     Pass,
 
-    /// Output skipped tests in addition to all variants above.
+    /// Output skipped tests; includes `pass`.
     Skip,
 
-    /// Currently has the same meaning as [`Skip`](Self::Skip).
+    /// Equivalent to `"skip"` today; reserved for future expansion.
     All,
 }
 
-/// Status level to show at the end of test runs in the reporter output.
+/// Level of status information to display in the final summary.
 ///
-/// Status levels are incremental.
+/// Status levels are incremental. This differs from `status-level` in two
+/// ways:
 ///
-/// This differs from [`StatusLevel`] in two ways:
-/// * It has a "flaky" test indicator that's different from "retry" (though "retry" works as an alias.)
-/// * It has a different ordering: skipped tests are prioritized over passing ones.
+/// * It has a "flaky" test indicator distinct from "retry" (though "retry"
+///   works as an alias).
+/// * It has a different ordering: skipped tests are prioritized over passing
+///   ones.
 #[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Deserialize)]
 #[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
@@ -63,23 +65,23 @@ pub enum FinalStatusLevel {
     /// Only output test failures.
     Fail,
 
-    /// Output flaky tests.
+    /// Output flaky tests; includes `fail`. Accepts `"retry"` as an alias.
     #[serde(alias = "retry")]
     Flaky,
 
-    /// Output information about slow tests, and all variants above.
+    /// Output slow tests; includes `flaky`.
     Slow,
 
-    /// Output skipped tests in addition to all variants above.
+    /// Output skipped tests; includes `slow`.
     Skip,
 
-    /// Output leaky tests in addition to all variants above.
+    /// Output leaky tests; includes `skip`.
     Leak,
 
-    /// Output passing tests in addition to all variants above.
+    /// Output passing tests; includes `leak`.
     Pass,
 
-    /// Currently has the same meaning as [`Pass`](Self::Pass).
+    /// Equivalent to `"pass"` today; reserved for future expansion.
     All,
 }
 

--- a/nextest-runner/src/reporter/displayer/unit_output.rs
+++ b/nextest-runner/src/reporter/displayer/unit_output.rs
@@ -27,18 +27,17 @@ use std::{fmt, io};
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 #[serde(rename_all = "kebab-case")]
 pub enum TestOutputDisplay {
-    /// Show output immediately on execution completion.
-    ///
-    /// This is the default for failing tests.
+    /// Shows captured output as soon as the test completes.
     Immediate,
 
-    /// Show output immediately, and at the end of a test run.
+    /// Shows captured output when the test completes and again at the end of
+    /// the run.
     ImmediateFinal,
 
-    /// Show output at the end of execution.
+    /// Shows captured output only at the end of the run.
     Final,
 
-    /// Never show output.
+    /// Never shows captured output.
     Never,
 }
 

--- a/nextest-runner/src/user_config/elements/record.rs
+++ b/nextest-runner/src/user_config/elements/record.rs
@@ -25,40 +25,38 @@ pub const MIN_MAX_OUTPUT_SIZE: ByteSize = ByteSize::b(1000);
 /// a recorded archive, preventing malicious archives from causing OOM.
 pub const MAX_MAX_OUTPUT_SIZE: ByteSize = ByteSize::mib(256);
 
-/// Retention policy for recorded test runs.
+/// Retention settings for the record-replay-rerun feature.
 ///
-/// Recording only happens when the `record` experimental feature is enabled
-/// _and_ `enabled` here is true. The least-recently-used runs are evicted to
+/// Recording happens only when the `record` experimental feature is enabled
+/// and `enabled` here is true. The least-recently-used runs are evicted to
 /// keep within `max-records`, `max-total-size`, and `max-age`.
 #[derive(Clone, Debug, Default, Deserialize)]
 #[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "config-schema", schemars(deny_unknown_fields))]
 #[serde(rename_all = "kebab-case")]
 pub struct DeserializedRecordConfig {
-    /// Whether to record test runs.
-    ///
-    /// Set to false to temporarily disable recording without removing the rest
-    /// of the configuration. Has no effect unless the `record` experimental
-    /// feature is also enabled.
+    /// Whether to record test runs. Has no effect unless `[experimental]
+    /// record = true`.
     #[serde(default)]
     pub enabled: Option<bool>,
 
-    /// Maximum number of recorded runs to retain.
+    /// Maximum number of recorded runs to retain before eviction.
     #[serde(default)]
     pub max_records: Option<usize>,
 
-    /// Maximum combined size of all recorded runs (e.g. `"1GB"`).
+    /// Maximum combined size of all retained recordings before eviction (e.g.
+    /// `"1GB"`).
     #[serde(default)]
     #[cfg_attr(feature = "config-schema", schemars(with = "Option<String>"))]
     pub max_total_size: Option<ByteSize>,
 
-    /// Maximum idle time before a recorded run is evicted (e.g. `"30d"`).
+    /// Maximum age of a recorded run before eviction (e.g. `"30d"`).
     #[serde(default, with = "humantime_serde")]
     #[cfg_attr(feature = "config-schema", schemars(with = "Option<String>"))]
     pub max_age: Option<Duration>,
 
-    /// Maximum size of a single captured stdout or stderr stream before it is
-    /// truncated (e.g. `"10MB"`).
+    /// Maximum size of a single captured stdout or stderr stream before
+    /// truncation (e.g. `"10MB"`).
     #[serde(default)]
     #[cfg_attr(feature = "config-schema", schemars(with = "Option<String>"))]
     pub max_output_size: Option<ByteSize>,
@@ -71,20 +69,23 @@ pub struct DeserializedRecordConfig {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct DefaultRecordConfig {
-    /// Whether recording is enabled by default.
+    /// Whether to record test runs. Has no effect unless `[experimental]
+    /// record = true`.
     pub enabled: bool,
 
-    /// Maximum number of records to keep.
+    /// Maximum number of recorded runs to retain before eviction.
     pub max_records: usize,
 
-    /// Maximum total size of all records.
+    /// Maximum combined size of all retained recordings before eviction (e.g.
+    /// `"1GB"`).
     pub max_total_size: ByteSize,
 
-    /// Maximum age of records.
+    /// Maximum age of a recorded run before eviction (e.g. `"30d"`).
     #[serde(with = "humantime_serde")]
     pub max_age: Duration,
 
-    /// Maximum size of a single output (stdout/stderr) before truncation.
+    /// Maximum size of a single captured stdout or stderr stream before
+    /// truncation (e.g. `"10MB"`).
     pub max_output_size: ByteSize,
 }
 
@@ -97,26 +98,28 @@ pub struct DefaultRecordConfig {
 #[cfg_attr(feature = "config-schema", schemars(deny_unknown_fields))]
 #[serde(rename_all = "kebab-case")]
 pub(in crate::user_config) struct DeserializedRecordOverrideData {
-    /// Whether to record test runs.
+    /// Whether to record test runs. Has no effect unless `[experimental]
+    /// record = true`.
     #[serde(default)]
     pub(in crate::user_config) enabled: Option<bool>,
 
-    /// Maximum number of recorded runs to retain.
+    /// Maximum number of recorded runs to retain before eviction.
     #[serde(default)]
     pub(in crate::user_config) max_records: Option<usize>,
 
-    /// Maximum combined size of all recorded runs (e.g. `"1GB"`).
+    /// Maximum combined size of all retained recordings before eviction (e.g.
+    /// `"1GB"`).
     #[serde(default)]
     #[cfg_attr(feature = "config-schema", schemars(with = "Option<String>"))]
     pub(in crate::user_config) max_total_size: Option<ByteSize>,
 
-    /// Maximum idle time before a recorded run is evicted (e.g. `"30d"`).
+    /// Maximum age of a recorded run before eviction (e.g. `"30d"`).
     #[serde(default, with = "humantime_serde")]
     #[cfg_attr(feature = "config-schema", schemars(with = "Option<String>"))]
     pub(in crate::user_config) max_age: Option<Duration>,
 
-    /// Maximum size of a single captured stdout or stderr stream before it is
-    /// truncated (e.g. `"10MB"`).
+    /// Maximum size of a single captured stdout or stderr stream before
+    /// truncation (e.g. `"10MB"`).
     #[serde(default)]
     #[cfg_attr(feature = "config-schema", schemars(with = "Option<String>"))]
     pub(in crate::user_config) max_output_size: Option<ByteSize>,

--- a/nextest-runner/src/user_config/elements/ui.rs
+++ b/nextest-runner/src/user_config/elements/ui.rs
@@ -25,9 +25,8 @@ pub(in crate::user_config) struct DeserializedUiConfig {
 
     /// Maximum number of running tests to list in the progress bar.
     ///
-    /// Accepts a non-negative integer, or `"infinite"` for no limit. When the
-    /// number of running tests exceeds this, the remainder is collapsed into a
-    /// summary line.
+    /// Accepts a non-negative integer, or `"infinite"` for no limit. Excess
+    /// running tests are collapsed into a summary line.
     #[serde(default, deserialize_with = "deserialize_max_progress_running")]
     max_progress_running: Option<MaxProgressRunning>,
 
@@ -39,7 +38,7 @@ pub(in crate::user_config) struct DeserializedUiConfig {
     output_indent: Option<bool>,
 
     /// Pager command to use for output that benefits from scrolling. Use
-    /// `":builtin"` to select nextest's built-in pager.
+    /// `":builtin"` to select nextest's builtin pager.
     #[serde(default)]
     pager: Option<PagerSetting>,
 
@@ -47,7 +46,7 @@ pub(in crate::user_config) struct DeserializedUiConfig {
     #[serde(default)]
     paginate: Option<PaginateSetting>,
 
-    /// Settings for the built-in pager (active when `pager = ":builtin"`).
+    /// Settings for the builtin pager (active when `pager = ":builtin"`).
     #[serde(default)]
     streampager: DeserializedStreampagerConfig,
 }
@@ -59,26 +58,31 @@ pub(in crate::user_config) struct DeserializedUiConfig {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct DefaultUiConfig {
-    /// How to show progress during test runs.
+    /// Style of progress display shown during test runs.
     show_progress: UiShowProgress,
 
-    /// Maximum running tests to display in the progress bar.
+    /// Maximum number of running tests to list in the progress bar.
+    ///
+    /// Accepts a non-negative integer, or `"infinite"` for no limit. Excess
+    /// running tests are collapsed into a summary line.
     #[serde(deserialize_with = "deserialize_max_progress_running_required")]
     max_progress_running: MaxProgressRunning,
 
-    /// Whether to enable the input handler.
+    /// Enables the interactive keyboard input handler (e.g. `t` to dump test
+    /// status, `Enter` to print a summary line).
     input_handler: bool,
 
-    /// Whether to indent captured test output.
+    /// Indents captured test output for visual clarity.
     output_indent: bool,
 
-    /// Pager command for output that benefits from scrolling.
+    /// Pager command to use for output that benefits from scrolling. Use
+    /// `":builtin"` to select nextest's builtin pager.
     pub(in crate::user_config) pager: PagerSetting,
 
-    /// When to paginate output.
+    /// When to send output through the pager.
     pub(in crate::user_config) paginate: PaginateSetting,
 
-    /// Configuration for the builtin streampager.
+    /// Settings for the builtin pager (active when `pager = ":builtin"`).
     pub(in crate::user_config) streampager: DefaultStreampagerConfig,
 }
 
@@ -95,16 +99,21 @@ pub(in crate::user_config) struct DeserializedUiOverrideData {
     pub(in crate::user_config) show_progress: Option<UiShowProgress>,
 
     /// Maximum number of running tests to list in the progress bar.
+    ///
+    /// Accepts a non-negative integer, or `"infinite"` for no limit. Excess
+    /// running tests are collapsed into a summary line.
     #[serde(default, deserialize_with = "deserialize_max_progress_running")]
     pub(in crate::user_config) max_progress_running: Option<MaxProgressRunning>,
 
-    /// Enables the interactive keyboard input handler.
+    /// Enables the interactive keyboard input handler (e.g. `t` to dump test
+    /// status, `Enter` to print a summary line).
     pub(in crate::user_config) input_handler: Option<bool>,
 
     /// Indents captured test output for visual clarity.
     pub(in crate::user_config) output_indent: Option<bool>,
 
-    /// Pager command to use for output that benefits from scrolling.
+    /// Pager command to use for output that benefits from scrolling. Use
+    /// `":builtin"` to select nextest's builtin pager.
     #[serde(default)]
     pub(in crate::user_config) pager: Option<PagerSetting>,
 
@@ -112,7 +121,7 @@ pub(in crate::user_config) struct DeserializedUiOverrideData {
     #[serde(default)]
     pub(in crate::user_config) paginate: Option<PaginateSetting>,
 
-    /// Settings for the built-in pager (active when `pager = ":builtin"`).
+    /// Settings for the builtin pager (active when `pager = ":builtin"`).
     #[serde(default)]
     pub(in crate::user_config) streampager: DeserializedStreampagerConfig,
 }
@@ -343,8 +352,8 @@ pub enum UiShowProgress {
     Counter,
     /// Like `bar` in interactive terminals, but additionally hides successful
     /// test output (sets `status-level` to `slow` and `final-status-level` to
-    /// `none`). Falls back to `auto` behavior in non-interactive contexts
-    /// (e.g. piped output, CI).
+    /// `none`). Falls back to `auto` in non-interactive contexts (e.g. piped
+    /// output, CI).
     Only,
 }
 
@@ -379,17 +388,17 @@ pub enum PaginateSetting {
 /// The special string that indicates the builtin pager should be used.
 pub const BUILTIN_PAGER_NAME: &str = ":builtin";
 
-/// Settings for nextest's built-in pager (active when `pager = ":builtin"`).
+/// Settings for nextest's builtin pager (active when `pager = ":builtin"`).
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize)]
 #[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[cfg_attr(feature = "config-schema", schemars(deny_unknown_fields))]
 #[serde(rename_all = "kebab-case")]
 pub(in crate::user_config) struct DeserializedStreampagerConfig {
-    /// How the pager uses the alternate screen and when it exits.
+    /// How the builtin pager uses the alternate screen and when it exits.
     pub(in crate::user_config) interface: Option<StreampagerInterface>,
-    /// How long lines are wrapped.
+    /// How the builtin pager wraps long lines.
     pub(in crate::user_config) wrapping: Option<StreampagerWrapping>,
-    /// Shows a ruler at the bottom of the pager.
+    /// Whether to show a ruler at the bottom of the builtin pager.
     pub(in crate::user_config) show_ruler: Option<bool>,
 }
 
@@ -399,11 +408,11 @@ pub(in crate::user_config) struct DeserializedStreampagerConfig {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub(in crate::user_config) struct DefaultStreampagerConfig {
-    /// Interface mode controlling alternate screen behavior.
+    /// How the builtin pager uses the alternate screen and when it exits.
     pub(in crate::user_config) interface: StreampagerInterface,
-    /// Text wrapping mode.
+    /// How the builtin pager wraps long lines.
     pub(in crate::user_config) wrapping: StreampagerWrapping,
-    /// Whether to show a ruler at the bottom.
+    /// Whether to show a ruler at the bottom of the builtin pager.
     pub(in crate::user_config) show_ruler: bool,
 }
 
@@ -412,11 +421,11 @@ pub(in crate::user_config) struct DefaultStreampagerConfig {
 /// These settings control behavior when `pager = ":builtin"` is configured.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct StreampagerConfig {
-    /// Interface mode controlling alternate screen behavior.
+    /// How the builtin pager uses the alternate screen and when it exits.
     pub interface: StreampagerInterface,
-    /// Text wrapping mode.
+    /// How the builtin pager wraps long lines.
     pub wrapping: StreampagerWrapping,
-    /// Whether to show a ruler at the bottom.
+    /// Whether to show a ruler at the bottom of the builtin pager.
     pub show_ruler: bool,
 }
 
@@ -444,7 +453,7 @@ impl StreampagerConfig {
     }
 }
 
-/// How the built-in pager uses the alternate screen and when it exits.
+/// How the builtin pager uses the alternate screen and when it exits.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize)]
 #[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case")]
@@ -460,7 +469,7 @@ pub enum StreampagerInterface {
     QuitQuicklyOrClearOutput,
 }
 
-/// How long lines are wrapped in the built-in pager.
+/// How long lines are wrapped in the builtin pager.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Deserialize)]
 #[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case")]

--- a/nextest-runner/src/user_config/experimental.rs
+++ b/nextest-runner/src/user_config/experimental.rs
@@ -10,23 +10,17 @@
 use serde::Deserialize;
 use std::{collections::BTreeSet, env, fmt, str::FromStr};
 
-/// User-level experimental features.
+/// Toggles for user-level experimental, non-stable features.
 ///
-/// Configured in the `[experimental]` table of the user config file:
-///
-/// ```toml
-/// [experimental]
-/// record = true
-/// ```
-///
-/// Unknown features in this table produce a warning rather than an error, so
-/// older nextest binaries can load configs written for newer ones.
+/// Configured in the `[experimental]` table of the user config file. Unknown
+/// keys here produce a warning rather than an error so that older nextest
+/// binaries can load configs written for newer ones.
 #[derive(Clone, Copy, Debug, Default, Deserialize)]
 #[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(rename_all = "kebab-case")]
 pub struct ExperimentalConfig {
-    /// Enables the record-replay-rerun feature, which stores test run results
-    /// on disk so they can be replayed or selectively rerun later.
+    /// Enables the record-replay-rerun feature: stores test run results on
+    /// disk for replay or selective rerun.
     #[serde(default)]
     pub record: bool,
 }

--- a/nextest-runner/src/user_config/imp.rs
+++ b/nextest-runner/src/user_config/imp.rs
@@ -188,11 +188,6 @@ impl UserConfigWarnings for DefaultUserConfigWarnings {
 #[serde(rename_all = "kebab-case")]
 struct DeserializedUserConfig {
     /// Toggles for experimental, non-stable features.
-    ///
-    /// ```toml
-    /// [experimental]
-    /// record = true
-    /// ```
     #[serde(default)]
     experimental: ExperimentalConfig,
 
@@ -204,12 +199,8 @@ struct DeserializedUserConfig {
     #[serde(default)]
     record: DeserializedRecordConfig,
 
-    /// Platform-specific overrides applied on top of the base configuration.
-    ///
-    /// Each entry specifies a `platform` filter and any number of settings to
-    /// substitute when that filter matches. For each setting, the first
-    /// matching override wins; the base configuration is used if no override
-    /// matches.
+    /// Platform-specific overrides applied on top of `[ui]` and `[record]`.
+    /// The first matching override per setting wins.
     #[serde(default)]
     overrides: Vec<DeserializedOverride>,
 }
@@ -221,18 +212,15 @@ struct DeserializedUserConfig {
 #[serde(rename_all = "kebab-case")]
 struct DeserializedOverride {
     /// Target-spec expression selecting which platforms this override applies
-    /// to.
-    ///
-    /// Accepts a target triple (e.g. `x86_64-unknown-linux-gnu`) or a `cfg()`
-    /// expression (e.g. `cfg(windows)`, `cfg(target_os = "macos")`). Matched
-    /// against the platform nextest was built for.
+    /// to (target triple or `cfg()` expression). Matched against the platform
+    /// nextest was built for.
     platform: String,
 
-    /// UI settings to substitute on matching platforms.
+    /// UI settings substituted on matching platforms.
     #[serde(default)]
     ui: DeserializedUiOverrideData,
 
-    /// Record retention settings to substitute on matching platforms.
+    /// Record retention settings substituted on matching platforms.
     #[serde(default)]
     record: DeserializedRecordOverrideData,
 }

--- a/site/src/docs/ci-features/archiving.md
+++ b/site/src/docs/ci-features/archiving.md
@@ -92,13 +92,13 @@ archive.include = [
 
 `archive.include` takes a list of tables, with the following parameters:
 
-- `path` — The relative path to the archive.
-- `relative-to` — The root directory that `path` is defined against. Currently, only `"target"` is
+- `path` — Path to include, relative to `relative-to`.
+- `relative-to` — Base directory `path` is interpreted relative to. Currently, only `"target"` is
   supported, to indicate the target directory.
-- `depth` — The recursion depth for directories; either a non-negative integer or `"infinite"`. The
-  default is a depth of 16, which should cover most non-degenerate use cases.
-- `on-missing` — What to do if the specified path was not found. One of `"warn"` (default),
-  `"ignore"`, or `"error"`.
+- `depth` — Maximum recursion depth for directories: a non-negative integer, or `"infinite"`. The
+  default is 16, which should cover most non-degenerate use cases.
+- `on-missing` — What to do if `path` is missing. One of `"warn"` (default), `"ignore"`, or
+  `"error"`.
 
 > NOTE: The following features are not currently supported:
 >

--- a/site/src/docs/configuration/index.md
+++ b/site/src/docs/configuration/index.md
@@ -21,7 +21,7 @@ Here is a recommended profile for CI runs:
 
 ```toml title="Configuring a CI profile in <code>.config/nextest.toml</code>"
 [profile.ci]
-# Do not cancel the test run on the first failure.
+# Run all tests regardless of failures.
 fail-fast = false
 ```
 

--- a/site/src/docs/configuration/per-test-overrides.md
+++ b/site/src/docs/configuration/per-test-overrides.md
@@ -14,53 +14,53 @@ Overrides are set via the `[[profile.<name>.overrides]]` list.
 At least one of these fields must be specified:
 
 `filter`
-: The [filterset](../filtersets/index.md) to match.
+: [Filterset](../filtersets/index.md) expression selecting tests this override applies to.
 
 `platform`
-: The platforms to match: either a string, or a map with `host` and `target`
-keys for cross-compiling. See [*Specifying platforms*](specifying-platforms.md)
-for more information.
+: Host and/or target platforms this override applies to. Either a string,
+or a map with `host` and `target` keys for cross-compiling. See
+[*Specifying platforms*](specifying-platforms.md) for more information.
 
 ## Supported overrides
 
 `priority` <!-- md:version 0.9.91 -->
-: The [test priority](test-priorities.md): a number from -100 to 100, both inclusive, with a default of 0.
+: [Priority](test-priorities.md) for matching tests; higher values run sooner. A number from -100 to 100, inclusive. Default: 0.
 
 `retries`
-: The number of retries, or a more complex [retry policy](../features/retries.md) for this test.
+: [Retry policy](../features/retries.md) for matching tests.
 
 `flaky-result` <!-- md:version 0.9.131 -->
-: Whether flaky tests are treated as [passing or failing](../features/retries.md#failing-flaky-tests).
+: Whether to treat matching flaky tests as [passing or failing](../features/retries.md#failing-flaky-tests).
 
 `threads-required`
-: Number of [threads required](threads-required.md) for this test.
+: Number of [threads](threads-required.md) each matching test reserves from the pool.
 
 `test-group`
-: An optional [test group](test-groups.md) for this test.
+: Assigns matching tests to a [test group](test-groups.md).
 
 `slow-timeout`
-: Amount of time after which [tests are marked slow](../features/slow-tests.md).
+: Time after which matching tests are considered [slow](../features/slow-tests.md), plus optional termination policy.
 
 `bench.slow-timeout` <!-- md:version 0.9.117 -->
-: Amount of time after which [benchmarks are marked slow](../features/benchmarks.md). Only applies when running benchmarks with `cargo nextest bench`.
+: Time after which matching benchmarks are considered [slow](../features/benchmarks.md), plus optional termination policy. Replaces `slow-timeout` when running `cargo nextest bench`.
 
 `leak-timeout`
-: How long to wait after the test completes [for any subprocesses to exit](../features/leaky-tests.md).
+: Time to wait for [child processes to exit](../features/leaky-tests.md) after a matching test completes.
 
 `success-output` and `failure-output`
-: Control [when standard output and standard error are displayed](../reporting.md#displaying-captured-test-output) for passing and failing tests, respectively.
+: [When to display output](../reporting.md#displaying-captured-test-output) for matching successful and failed tests, respectively.
 
 `junit.store-success-output` and `junit.store-failure-output`
-: In [JUnit reports](../machine-readable/junit.md), whether to store output for passing and failing tests, respectively.
+: Whether to store successful and failed output, respectively, for matching tests in the [JUnit XML report](../machine-readable/junit.md).
 
 `junit.flaky-fail-status` <!-- md:version 0.9.131 -->
-: In [JUnit reports](../machine-readable/junit.md), how [flaky-fail](../features/retries.md#failing-flaky-tests) tests are reported: as `"failure"` (default) or `"success"`.
+: How matching [flaky-fail](../features/retries.md#failing-flaky-tests) tests are reported in the [JUnit XML report](../machine-readable/junit.md): as `"failure"` (default) or `"success"`.
 
 `default-filter` <!-- md:version 0.9.84 -->
-: The [default filter](../selecting.md#running-a-subset-of-tests-by-default) on this platform. Only supported for overrides that specify `platform` and not `filter`.
+: Replaces [`default-filter`](../selecting.md#running-a-subset-of-tests-by-default) for matching platforms. Requires `platform` and must not be combined with `filter`.
 
 `run-extra-args` <!-- md:version 0.9.86 -->
-: [Extra arguments](extra-args.md) to pass to the test binary.
+: [Extra arguments](extra-args.md) to pass to matching test binaries.
 
 ## Example
 

--- a/site/src/docs/configuration/reference.md
+++ b/site/src/docs/configuration/reference.md
@@ -49,9 +49,9 @@ These parameters are specified at the root level of the configuration file.
 <!-- md:version 0.9.55 -->
 
 - **Type**: String or object
-- **Description**: Specifies the minimum required version of nextest
+- **Description**: The minimum required (and optionally recommended) version of nextest for this configuration.
 - **Documentation**: [_Minimum nextest versions_](minimum-versions.md)
-- **Default**: Unset: the minimum version check is disabled
+- **Default**: Unset (the minimum version check is disabled)
 - **Examples**:
   ```toml
   nextest-version = "0.9.50"
@@ -62,9 +62,9 @@ These parameters are specified at the root level of the configuration file.
 ### `experimental`
 
 - **Type**: Array of strings
-- **Description**: Enables experimental features
+- **Description**: Enables experimental, non-stable features.
 - **Documentation**: [_Setup scripts_](setup-scripts.md), [_wrapper scripts_](wrapper-scripts.md)
-- **Default**: `[]`: no experimental features are enabled
+- **Default**: `[]` (no experimental features enabled)
 - **Valid values**:
   - `"setup-scripts"` <!-- md:version 0.9.98 --> (originally <!-- md:version 0.9.59 -->)
   - `"wrapper-scripts"` <!-- md:version 0.9.98 -->
@@ -76,12 +76,12 @@ These parameters are specified at the root level of the configuration file.
 ### `store`
 
 - **Type**: Object
-- **Description**: Configuration for the nextest store directory
+- **Description**: Configuration for the nextest store directory.
 
 #### `store.dir`
 
 - **Type**: String (path)
-- **Description**: Directory where nextest stores its data
+- **Description**: Directory where nextest stores its data.
 - **Default**: `target/nextest`
 
 ## Profile configuration
@@ -95,18 +95,18 @@ Profiles are configured under `[profile.<name>]`. The default profile is called 
 <!-- md:version 0.9.115 -->
 
 - **Type**: String
-- **Description**: The profile to inherit configuration settings from
+- **Description**: The profile to inherit settings from.
 - **Documentation**: [_Profile inheritance_](index.md#profile-inheritance)
-- **Default**: `default`: the default profile
+- **Default**: `"default"`
 
 ### Core test execution
 
 #### `profile.<name>.default-filter`
 
 - **Type**: String (filterset expression)
-- **Description**: The default set of tests to run
+- **Description**: The default set of tests run by `cargo nextest run`, as a filterset expression.
 - **Documentation**: [_Running a subset of tests by default_](../selecting.md#running-a-subset-of-tests-by-default)
-- **Default**: `all()`: all tests are run
+- **Default**: `"all()"` (all tests are run)
 - **Example**: `default-filter = "not test(very_slow_tests)"`
 
 #### `profile.<name>.global-timeout`
@@ -114,15 +114,15 @@ Profiles are configured under `[profile.<name>]`. The default profile is called 
 <!-- md:version 0.9.100 -->
 
 - **Type**: String (duration)
-- **Description**: A global timeout for test execution
+- **Description**: A global timeout for the entire test run.
 - **Documentation**: [_Setting a global timeout_](../features/slow-tests.md#setting-a-global-timeout)
-- **Default**: none
+- **Default**: Unset (no global timeout)
 - **Example**: `global-timeout = "2h"`
 
 #### `profile.<name>.test-threads`
 
 - **Type**: Integer or string
-- **Description**: Number of threads to run tests with
+- **Description**: Number of threads to run tests with.
 - **Valid values**: Positive integer, negative integer (relative to CPU count), or `"num-cpus"`
 - **Default**: `"num-cpus"`
 - **Example**: `test-threads = 4` or `test-threads = "num-cpus"`
@@ -130,7 +130,7 @@ Profiles are configured under `[profile.<name>]`. The default profile is called 
 #### `profile.<name>.threads-required`
 
 - **Type**: Integer or string
-- **Description**: Number of threads each test requires
+- **Description**: Number of threads each test reserves from the pool.
 - **Documentation**: [_Heavy tests and `threads-required`_](threads-required.md)
 - **Valid values**: Positive integer, `"num-cpus"`, or `"num-test-threads"`
 - **Default**: `1`
@@ -140,9 +140,9 @@ Profiles are configured under `[profile.<name>]`. The default profile is called 
 <!-- md:version 0.9.86 -->
 
 - **Type**: Array of strings
-- **Description**: Extra arguments to pass to test binaries
+- **Description**: Extra arguments to pass to test binaries.
 - **Documentation**: [_Extra arguments_](extra-args.md)
-- **Default**: `[]`: no extra arguments
+- **Default**: `[]`
 - **Example**: `run-extra-args = ["--test-threads", "1"]`
 
 ### Retry configuration
@@ -150,7 +150,7 @@ Profiles are configured under `[profile.<name>]`. The default profile is called 
 #### `profile.<name>.retries`
 
 - **Type**: Integer or object
-- **Description**: Retry policy for failed tests
+- **Description**: Retry policy for failed tests.
 - **Documentation**: [_Retries and flaky tests_](../features/retries.md)
 - **Default**: `0`
 - **Examples**:
@@ -167,7 +167,7 @@ Profiles are configured under `[profile.<name>]`. The default profile is called 
 <!-- md:version 0.9.131 -->
 
 - **Type**: String
-- **Description**: Controls whether flaky tests are treated as passing or failing
+- **Description**: Whether to treat flaky tests as passing or failing.
 - **Documentation**: [_Failing flaky tests_](../features/retries.md#failing-flaky-tests)
 - **Valid values**: `"pass"`, `"fail"`
 - **Default**: `"pass"`
@@ -178,7 +178,7 @@ Profiles are configured under `[profile.<name>]`. The default profile is called 
 #### `profile.<name>.slow-timeout`
 
 - **Type**: String (duration) or object
-- **Description**: Time after which tests are considered slow, and timeout configuration
+- **Description**: Time after which tests are considered slow, plus optional termination policy.
 - **Documentation**: [_Slow tests and timeouts_](../features/slow-tests.md)
 - **Default**: `60s` with no termination on timeout
 - **Examples**:
@@ -200,7 +200,7 @@ The `slow-timeout` object accepts the following parameters:
 #### `profile.<name>.leak-timeout`
 
 - **Type**: String (duration) or object
-- **Description**: Time to wait for child processes to exit after a test completes
+- **Description**: Time to wait for child processes to exit after a test completes.
 - **Documentation**: [_Leaky tests_](../features/leaky-tests.md)
 - **Examples**:
   ```toml
@@ -216,18 +216,17 @@ The `slow-timeout` object accepts the following parameters:
 <!-- md:version 0.9.117 -->
 
 - **Type**: String (duration)
-- **Description**: A global timeout for benchmark execution
+- **Description**: Global timeout for the entire benchmark run. Replaces `global-timeout` when running `cargo nextest bench`.
 - **Documentation**: [_Running benchmarks_](../features/benchmarks.md)
-- **Default**: none
+- **Default**: Unset (no global timeout)
 - **Example**: `bench.global-timeout = "2h"`
-- **Note**: This setting only applies when running benchmarks with `cargo nextest bench`. The regular `global-timeout` setting is ignored for benchmarks.
 
 #### `profile.<name>.bench.slow-timeout`
 
 <!-- md:version 0.9.117 -->
 
 - **Type**: String (duration) or object
-- **Description**: Time after which benchmarks are considered slow, and timeout configuration
+- **Description**: Time after which benchmarks are considered slow, plus optional termination policy. Replaces `slow-timeout` when running `cargo nextest bench`.
 - **Documentation**: [_Running benchmarks_](../features/benchmarks.md)
 - **Default**: `60s` with no termination on timeout
 - **Examples**:
@@ -236,7 +235,6 @@ The `slow-timeout` object accepts the following parameters:
   # or
   bench.slow-timeout = { period = "60s", terminate-after = 10, grace-period = "10s" }
   ```
-- **Note**: This setting only applies when running benchmarks with `cargo nextest bench`. The regular `slow-timeout` setting is ignored for benchmarks.
 
 The `bench.slow-timeout` object accepts the same parameters as `slow-timeout`:
 
@@ -249,33 +247,53 @@ The `bench.slow-timeout` object accepts the same parameters as `slow-timeout`:
 #### `profile.<name>.status-level`
 
 - **Type**: String
-- **Description**: Level of status information to display during test runs
+- **Description**: Level of status information to display during test runs.
 - **Documentation**: [_Reporting test results_](../reporting.md)
-- **Valid values**: `"none"`, `"fail"`, `"retry"`, `"slow"`, `"leak"`, `"pass"`, `"skip"`, `"all"`
+- **Valid values** (incremental; each level includes those above it):
+  - `"none"`: no output.
+  - `"fail"`: only output test failures.
+  - `"retry"`: output test retries; includes `fail`.
+  - `"slow"`: output slow tests; includes `retry`.
+  - `"leak"`: output leaky tests; includes `slow`.
+  - `"pass"`: output passing tests; includes `leak`.
+  - `"skip"`: output skipped tests; includes `pass`.
+  - `"all"`: equivalent to `"skip"` today; reserved for future expansion.
 - **Default**: `"pass"`
 
 #### `profile.<name>.final-status-level`
 
 - **Type**: String
-- **Description**: Level of status information to display in final summary
+- **Description**: Level of status information to display in the final summary.
 - **Documentation**: [_Reporting test results_](../reporting.md)
-- **Valid values**: `"none"`, `"fail"`, `"flaky"`, `"slow"`, `"skip"`, `"leak"`, `"pass"`, `"all"`
-- **Default**: `"fail"`
+- **Valid values** (incremental; each level includes those above it):
+  - `"none"`: no output.
+  - `"fail"`: only output test failures.
+  - `"flaky"`: output flaky tests; includes `fail`. Accepts `"retry"` as an alias.
+  - `"slow"`: output slow tests; includes `flaky`.
+  - `"skip"`: output skipped tests; includes `slow`.
+  - `"leak"`: output leaky tests; includes `skip`.
+  - `"pass"`: output passing tests; includes `leak`.
+  - `"all"`: equivalent to `"pass"` today; reserved for future expansion.
+- **Default**: `"flaky"`
 
 #### `profile.<name>.failure-output`
 
 - **Type**: String
-- **Description**: When to display output for failed tests
+- **Description**: When to display output for failed tests.
 - **Documentation**: [_Reporting test results_](../reporting.md)
-- **Valid values**: `"immediate"`, `"immediate-final"`, `"final"`, `"never"`
+- **Valid values**:
+  - `"immediate"`: show captured output as soon as the test completes.
+  - `"immediate-final"`: show captured output when the test completes _and_ again at the end of the run.
+  - `"final"`: show captured output only at the end of the run.
+  - `"never"`: never show captured output.
 - **Default**: `"immediate"`
 
 #### `profile.<name>.success-output`
 
 - **Type**: String
-- **Description**: When to display output for successful tests
+- **Description**: When to display output for successful tests.
 - **Documentation**: [_Reporting test results_](../reporting.md)
-- **Valid values**: `"immediate"`, `"immediate-final"`, `"final"`, `"never"`
+- **Valid values**: same as [`failure-output`](#profilenamefailure-output)
 - **Default**: `"never"`
 
 ### Failure handling
@@ -283,7 +301,7 @@ The `bench.slow-timeout` object accepts the same parameters as `slow-timeout`:
 #### `profile.<name>.fail-fast`
 
 - **Type**: Boolean or object
-- **Description**: Controls when to stop running tests after failures
+- **Description**: Controls when to stop running tests after failures.
 - **Documentation**: [_Failing fast_](../running.md#failing-fast)
 - **Default**: `true` (stop after first failure, wait for running tests to complete)
 - **Examples**:
@@ -299,8 +317,8 @@ The `bench.slow-timeout` object accepts the same parameters as `slow-timeout`:
   ```
 
 When `max-fail` is exceeded:
-- **`terminate = "wait"`** (default): Nextest stops scheduling new tests but waits for currently running tests to finish naturally
-- **`terminate = "immediate"`** <!-- md:version 0.9.111 -->: Nextest sends termination signals to running tests (respecting the grace period configured via `slow-timeout.terminate-after`)
+- **`terminate = "wait"`** (default): nextest stops scheduling new tests but waits for currently running tests to finish naturally.
+- **`terminate = "immediate"`** <!-- md:version 0.9.111 -->: nextest sends termination signals to running tests (respecting the grace period configured via `slow-timeout.terminate-after`).
 
 ### Test grouping
 
@@ -309,7 +327,7 @@ When `max-fail` is exceeded:
 <!-- md:version 0.9.48 -->
 
 - **Type**: String
-- **Description**: Assigns tests to a custom group for resource management
+- **Description**: Assigns matching tests to a custom test group for resource management.
 - **Documentation**: [_Test groups for mutual exclusion_](test-groups.md)
 - **Valid values**: Custom group name or `"@global"`
 - **Default**: `"@global"`
@@ -319,29 +337,29 @@ When `max-fail` is exceeded:
 #### `profile.<name>.junit.path`
 
 - **Type**: String (path)
-- **Description**: Path to write JUnit XML report
+- **Description**: Path to write the JUnit XML report to. If unset, JUnit reporting is disabled.
 - **Documentation**: [_JUnit support_](../machine-readable/junit.md)
-- **Default**: JUnit support is disabled
+- **Default**: Unset
 - **Example**: `junit.path = "target/nextest/junit.xml"`
 
 #### `profile.<name>.junit.report-name`
 
 - **Type**: String
-- **Description**: Name for the JUnit report
+- **Description**: Name for the JUnit XML report.
 - **Documentation**: [_JUnit support_](../machine-readable/junit.md)
 - **Default**: `"nextest-run"`
 
 #### `profile.<name>.junit.store-success-output`
 
 - **Type**: Boolean
-- **Description**: Whether to store successful test output in JUnit XML
+- **Description**: Whether to store successful test output in the JUnit XML report.
 - **Documentation**: [_JUnit support_](../machine-readable/junit.md)
 - **Default**: `false`
 
 #### `profile.<name>.junit.store-failure-output`
 
 - **Type**: Boolean
-- **Description**: Whether to store failed test output in JUnit XML
+- **Description**: Whether to store failed test output in the JUnit XML report.
 - **Documentation**: [_JUnit support_](../machine-readable/junit.md)
 - **Default**: `true`
 
@@ -350,7 +368,7 @@ When `max-fail` is exceeded:
 <!-- md:version 0.9.131 -->
 
 - **Type**: String
-- **Description**: How flaky-fail tests are reported in the JUnit XML report
+- **Description**: How flaky-fail tests are reported in the JUnit XML report.
 - **Documentation**: [_JUnit support_](../machine-readable/junit.md)
 - **Valid values**: `"failure"` or `"success"`
 - **Default**: `"failure"`
@@ -362,7 +380,7 @@ When `max-fail` is exceeded:
 #### `profile.<name>.archive.include`
 
 - **Type**: Array of objects
-- **Description**: Files to include when creating test archives
+- **Description**: Extra paths to include in the archive.
 - **Documentation**: [_Archiving and reusing builds_](../ci-features/archiving.md)
 - **Example**:
   ```toml
@@ -375,10 +393,10 @@ When `max-fail` is exceeded:
 
 ##### Archive include parameters
 
-- `path`: Relative path to include
-- `relative-to`: Base directory (`"target"`)
-- `depth`: Maximum recursion depth (integer or `"infinite"`)
-- `on-missing`: What to do if path is missing (`"ignore"`, `"warn"`, `"error"`)
+- `path`: Path to include, relative to `relative-to`.
+- `relative-to`: Base directory `path` is interpreted relative to. Valid values: `"target"`.
+- `depth`: Maximum recursion depth (non-negative integer or `"infinite"`).
+- `on-missing`: What to do if `path` is missing. Valid values: `"ignore"`, `"warn"`, `"error"`.
 
 ## Override configuration
 
@@ -393,7 +411,7 @@ At least one of these filters must be specified.
 #### `filter`
 
 - **Type**: String (filterset expression)
-- **Description**: Selects which tests this override applies to
+- **Description**: Filterset expression selecting tests this override applies to.
 - **Documentation**: [_Filterset DSL_](../filtersets/index.md)
 - **Default**: Override applies to all tests
 - **Example**: `filter = 'test(integration_test)'`
@@ -403,7 +421,7 @@ At least one of these filters must be specified.
 <!-- md:version 0.9.58 -->
 
 - **Type**: String or Object
-- **Description**: Platform specification for when override applies
+- **Description**: Host and/or target platforms this override applies to.
 - **Documentation**: [_Specifying platforms_](specifying-platforms.md)
 - **Default**: Override applies to all platforms
 - **Examples**:
@@ -420,16 +438,15 @@ At least one of these filters must be specified.
 <!-- md:version 0.9.84 -->
 
 - **Type**: String (filterset expression)
-- **Description**: Override the default filter for specific platforms
+- **Description**: Replaces `default-filter` for matching platforms. Requires `platform` and must not be combined with `filter`.
 - **Documentation**: [_Running a subset of tests by default_](../selecting.md#running-a-subset-of-tests-by-default)
-- **Note**: Can only be used with `platform` specification
 
 #### `priority`
 
 <!-- md:version 0.9.91 -->
 
 - **Type**: Integer (-100 to 100)
-- **Description**: Test priority (a greater number means a higher priority)
+- **Description**: Priority for matching tests; higher values run sooner.
 - **Documentation**: [_Test priorities_](test-priorities.md)
 - **Default**: `0`
 
@@ -461,7 +478,7 @@ For detailed information, see [_Test groups for mutual exclusion_](test-groups.m
 #### `test-groups.<name>.max-threads`
 
 - **Type**: Integer or string
-- **Description**: Maximum number of threads this test group can use
+- **Description**: Maximum number of threads this test group may use concurrently.
 - **Valid values**: Positive integer or `"num-cpus"`
 
 ## Script configuration
@@ -479,7 +496,7 @@ For detailed information, see [_Setup scripts_](setup-scripts.md).
 #### `scripts.setup.<name>.command`
 
 - **Type**: String, array, or object
-- **Description**: The command to execute
+- **Description**: The command to run for this setup script.
 - **Examples**:
   ```toml
   command = "echo hello"
@@ -492,7 +509,7 @@ For detailed information, see [_Setup scripts_](setup-scripts.md).
 #### `scripts.setup.<name>.slow-timeout`
 
 - **Type**: String (duration) or object
-- **Description**: Timeout configuration for the setup script
+- **Description**: Slow-timeout configuration for this setup script.
 - **Default**: No timeout
 - **Examples**:
   ```toml
@@ -504,7 +521,7 @@ For detailed information, see [_Setup scripts_](setup-scripts.md).
 #### `scripts.setup.<name>.leak-timeout`
 
 - **Type**: String (duration) or object
-- **Description**: Leak timeout for the setup script
+- **Description**: Leak-timeout configuration for this setup script.
 - **Default**: `200ms`
 - **Examples**:
   ```toml
@@ -516,25 +533,25 @@ For detailed information, see [_Setup scripts_](setup-scripts.md).
 #### `scripts.setup.<name>.capture-stdout`
 
 - **Type**: Boolean
-- **Description**: Whether to capture stdout from the script
+- **Description**: Whether to capture stdout from this setup script.
 - **Default**: `false`
 
 #### `scripts.setup.<name>.capture-stderr`
 
 - **Type**: Boolean
-- **Description**: Whether to capture stderr from the script
+- **Description**: Whether to capture stderr from this setup script.
 - **Default**: `false`
 
 #### `scripts.setup.<name>.junit.store-success-output`
 
 - **Type**: Boolean
-- **Description**: Store successful script output in JUnit
+- **Description**: Whether to store this setup script's output on success in the JUnit XML report.
 - **Default**: `true`
 
 #### `scripts.setup.<name>.junit.store-failure-output`
 
 - **Type**: Boolean
-- **Description**: Store failed script output in JUnit
+- **Description**: Whether to store this setup script's output on failure in the JUnit XML report.
 - **Default**: `true`
 
 ### Wrapper scripts
@@ -546,7 +563,7 @@ For detailed information, see [_Wrapper scripts_](wrapper-scripts.md).
 #### `scripts.wrapper.<name>.command`
 
 - **Type**: String, array, or object
-- **Description**: The wrapper command to execute
+- **Description**: The command to run as the wrapper.
 - **Examples**:
   ```toml
   command = "my-script.sh"
@@ -559,9 +576,13 @@ For detailed information, see [_Wrapper scripts_](wrapper-scripts.md).
 #### `scripts.wrapper.<name>.target-runner`
 
 - **Type**: String
-- **Description**: How to interact with the configured target runner
+- **Description**: How this wrapper composes with a configured target runner.
 - **Documentation**: [_Target runners_](../features/target-runners.md)
-- **Valid values**: `"ignore"`, `"overrides-wrapper"`, `"within-wrapper"`, `"around-wrapper"`
+- **Valid values**:
+  - `"ignore"`: the target runner is ignored.
+  - `"overrides-wrapper"`: when a target runner is configured, it replaces the wrapper; otherwise the wrapper runs as usual.
+  - `"within-wrapper"`: the target runner runs within the wrapper script (command line: `<wrapper> <target-runner> <test-binary> <args>`).
+  - `"around-wrapper"`: the target runner runs around the wrapper script (command line: `<target-runner> <wrapper> <test-binary> <args>`).
 - **Default**: `"ignore"`
 
 ## Profile script configuration
@@ -577,7 +598,7 @@ At least one of these filters must be specified.
 #### `platform`
 
 - **Type**: String or object
-- **Description**: Platform specification for when scripts apply
+- **Description**: Host and/or target platforms these scripts apply to.
 - **Documentation**: [_Specifying platforms_](specifying-platforms.md)
 - **Default**: Scripts apply to all platforms
 - **Examples**:
@@ -590,7 +611,7 @@ At least one of these filters must be specified.
 #### `filter`
 
 - **Type**: String (filterset expression)
-- **Description**: Test filter for when scripts apply
+- **Description**: Filterset expression selecting tests these scripts apply to.
 - **Documentation**: [_Filterset DSL_](../filtersets/index.md)
 - **Default**: Scripts apply to all tests
 - **Example**: `filter = 'test(integration_test)'`
@@ -602,7 +623,7 @@ At least one instruction must be specified.
 #### `setup`
 
 - **Type**: String or array of strings
-- **Description**: Setup script(s) to run
+- **Description**: Names of setup scripts to run (single name or array).
 - **Documentation**: [_Setup scripts_](setup-scripts.md)
 - **Examples**:
   ```toml
@@ -614,14 +635,14 @@ At least one instruction must be specified.
 #### `list-wrapper`
 
 - **Type**: String
-- **Description**: Wrapper script to use during test listing
+- **Description**: Name of the wrapper script used during test listing.
 - **Documentation**: [_Wrapper scripts_](wrapper-scripts.md)
 - **Example**: `list-wrapper = "my-list-wrapper"`
 
 #### `run-wrapper`
 
 - **Type**: String
-- **Description**: Wrapper script to use during test execution
+- **Description**: Name of the wrapper script used during test execution.
 - **Documentation**: [_Wrapper scripts_](wrapper-scripts.md)
 - **Example**: `run-wrapper = "my-run-wrapper"`
 

--- a/site/src/docs/running.md
+++ b/site/src/docs/running.md
@@ -59,7 +59,7 @@ For more information, see [_Selecting tests_](selecting.md).
 
 ## Failing fast
 
-By default, nextest cancels the test run on encountering a single failure. Tests currently running are run to completion, but new tests are not started.
+By default, nextest stops running tests after the first failure. Tests currently running are run to completion, but new tests are not started.
 
 This behavior can be customized through either the command-line, or through [configuration](configuration/index.md).
 
@@ -69,8 +69,8 @@ This behavior can be customized through either the command-line, or through [con
 
 When max-fail is exceeded, nextest supports two termination modes:
 
-- **`wait` (default)**: Nextest stops scheduling new tests but waits for currently running tests to finish naturally. This is the safest option and ensures tests complete their cleanup logic.
-- **`immediate`**: Nextest sends termination signals to running tests (respecting the [grace period](features/slow-tests.md#how-nextest-terminates-tests) configured via `slow-timeout.terminate-after`). This is faster but may interrupt tests mid-execution.
+- **`wait` (default)**: nextest stops scheduling new tests but waits for currently running tests to finish naturally. This is the safest option and ensures tests complete their cleanup logic.
+- **`immediate`**: nextest sends termination signals to running tests (respecting the [grace period](features/slow-tests.md#how-nextest-terminates-tests) configured via `slow-timeout.terminate-after`). This is faster but may interrupt tests mid-execution.
 
 ### Command-line options
 

--- a/site/src/docs/user-config/reference.md
+++ b/site/src/docs/user-config/reference.md
@@ -48,7 +48,7 @@ Experimental features are configured under `[experimental]`.
 ### `experimental.record`
 
 - **Type**: Boolean
-- **Description**: Enables the record feature
+- **Description**: Enables the record-replay-rerun feature: stores test run results on disk for replay or selective rerun.
 - **Documentation**: [_Record, replay, and rerun_](../features/record-replay-rerun/index.md)
 - **Default**: `false`
 - **Environment variable**: `NEXTEST_EXPERIMENTAL_RECORD=1`
@@ -69,7 +69,7 @@ For detailed information, see [_Record, replay, and rerun_](../features/record-r
 ### `record.enabled`
 
 - **Type**: Boolean
-- **Description**: Whether to record test runs
+- **Description**: Whether to record test runs. Has no effect unless `[experimental] record = true`.
 - **Default**: `false`
 - **Example**:
   ```toml
@@ -80,25 +80,25 @@ For detailed information, see [_Record, replay, and rerun_](../features/record-r
 ### `record.max-output-size`
 
 - **Type**: String (size)
-- **Description**: Maximum size per output file before truncation
+- **Description**: Maximum size of a single captured stdout or stderr stream before truncation (e.g. `"10MB"`).
 - **Default**: `"10MB"`
 
 ### `record.max-records`
 
 - **Type**: Integer
-- **Description**: Maximum number of recorded runs to retain
+- **Description**: Maximum number of recorded runs to retain before eviction.
 - **Default**: `100`
 
 ### `record.max-total-size`
 
 - **Type**: String (size)
-- **Description**: Maximum total size of all recorded runs
+- **Description**: Maximum combined size of all retained recordings before eviction (e.g. `"1GB"`).
 - **Default**: `"1GB"`
 
 ### `record.max-age`
 
 - **Type**: String (duration)
-- **Description**: Maximum age of recorded runs before eviction
+- **Description**: Maximum age of a recorded run before eviction (e.g. `"30d"`).
 - **Default**: `"30d"`
 
 ## UI configuration
@@ -110,13 +110,13 @@ UI settings are configured under `[ui]`.
 <!-- md:version 0.9.118 -->
 
 - **Type**: String
-- **Description**: Controls how progress is displayed during test runs
+- **Description**: Style of progress display shown during test runs.
 - **Valid values**:
-  - `"auto"`: Auto-detect based on terminal capabilities
-  - `"none"`: No progress display
-  - `"bar"`: Show a progress bar with running tests
-  - `"counter"`: Show a simple test counter (e.g., "(1/10)")
-  - `"only"`: Show only the progress bar, hide successful test output
+  - `"auto"`: picks a display based on terminal capabilities — a progress bar in interactive terminals, a counter otherwise.
+  - `"none"`: disables progress display entirely.
+  - `"bar"`: shows a progress bar listing the currently running tests.
+  - `"counter"`: shows a single-line counter (e.g. `(1/10)`).
+  - `"only"`: like `"bar"` in interactive terminals, but additionally hides successful test output (sets `status-level` to `slow` and `final-status-level` to `none`). Falls back to `"auto"` in non-interactive contexts (e.g. piped output, CI).
 - **Default**: `"auto"`
 - **CLI equivalent**: `--show-progress`
 - **Environment variable**: `NEXTEST_SHOW_PROGRESS`
@@ -131,11 +131,11 @@ UI settings are configured under `[ui]`.
 <!-- md:version 0.9.118 -->
 
 - **Type**: Integer or string
-- **Description**: Maximum number of running tests to display in the progress bar. When more tests are running than this limit, the progress bar shows the first N tests and a summary (e.g., "... and 24 more tests running").
+- **Description**: Maximum number of running tests to list in the progress bar. Excess running tests are collapsed into a summary line.
 - **Valid values**:
-  - Positive integer (e.g., `8`): Display up to this many running tests
-  - `0`: Hide running tests entirely
-  - `"infinite"`: Display all running tests
+  - Positive integer (e.g. `8`): display up to this many running tests.
+  - `0`: hide the list of running tests entirely (the bar still tracks progress).
+  - `"infinite"`: display all running tests, no limit.
 - **Default**: `8`
 - **CLI equivalent**: `--max-progress-running`
 - **Environment variable**: `NEXTEST_MAX_PROGRESS_RUNNING`
@@ -157,7 +157,7 @@ UI settings are configured under `[ui]`.
 <!-- md:version 0.9.118 -->
 
 - **Type**: Boolean
-- **Description**: Controls whether nextest's [keyboard input handler](../reporting.md#live-output) is enabled. When enabled, nextest accepts keyboard shortcuts during test runs (e.g., `t` to dump test information, `Enter` to produce a summary line).
+- **Description**: Enables the interactive [keyboard input handler](../reporting.md#live-output) (e.g. `t` to dump test status, `Enter` to print a summary line).
 - **Valid values**: `true` or `false`
 - **Default**: `true` (input handler enabled)
 - **CLI equivalent**: `--no-input-handler` (to disable)
@@ -174,7 +174,7 @@ UI settings are configured under `[ui]`.
 <!-- md:version 0.9.118 -->
 
 - **Type**: Boolean
-- **Description**: Controls whether captured test output is indented. By default, test output produced by `--failure-output` and `--success-output` is indented for visual clarity.
+- **Description**: Indents captured test output for visual clarity. Applies to output produced by `--failure-output` and `--success-output`.
 - **Valid values**: `true` or `false`
 - **Default**: `true`
 - **CLI equivalent**: `--no-output-indent` (to disable)
@@ -191,12 +191,12 @@ UI settings are configured under `[ui]`.
 <!-- md:version 0.9.120 -->
 
 - **Type**: String, array, or table
-- **Description**: Specifies the pager command for output that benefits from scrolling (e.g., `nextest list`, help output). See [_Pager support_](pager.md) for details.
+- **Description**: Pager command for output that benefits from scrolling (e.g. `nextest list`, help output). Use `":builtin"` for the builtin pager. See [_Pager support_](pager.md) for details.
 - **Valid values**:
   - String: `"less -FRX"` (split on whitespace)
   - Array: `["less", "-FRX"]`
   - Table: `{ command = ["less", "-FRX"], env = { LESSCHARSET = "utf-8" } }`
-  - `":builtin"`: Use the builtin pager
+  - `":builtin"`: use the builtin pager.
 - **Default**: `{ command = ["less", "-FRX"], env = { LESSCHARSET = "utf-8" } }` on Unix, `":builtin"` on Windows (specified via an override)
 - **CLI equivalent**: `--no-pager` (to disable paging)
 - **Examples**:
@@ -223,10 +223,10 @@ UI settings are configured under `[ui]`.
 <!-- md:version 0.9.120 -->
 
 - **Type**: String
-- **Description**: Controls when to paginate output.
+- **Description**: When to send output through the pager.
 - **Valid values**:
-  - `"auto"`: Page supported commands if stdout is a terminal
-  - `"never"`: Never use a pager
+  - `"auto"`: pages output from supported commands when stdout is a terminal.
+  - `"never"`: disables pagination entirely.
 - **Default**: `"auto"`
 - **CLI equivalent**: `--no-pager` (equivalent to `paginate = "never"`)
 - **Example**:
@@ -245,11 +245,11 @@ When `pager = ":builtin"` is set, the builtin pager's behavior can be customized
 ### `ui.streampager.interface`
 
 - **Type**: String
-- **Description**: Controls how the builtin pager uses the alternate screen.
+- **Description**: How the builtin pager uses the alternate screen and when it exits.
 - **Valid values**:
-  - `"quit-if-one-page"`: Exit immediately if content fits on one page; otherwise use full screen and clear on exit
-  - `"full-screen-clear-output"`: Always use full screen mode and clear the screen on exit
-  - `"quit-quickly-or-clear-output"`: Wait briefly before entering full screen; clear on exit if entered
+  - `"quit-if-one-page"`: exits immediately if the output fits on one page; otherwise switches to full-screen and clears on exit.
+  - `"full-screen-clear-output"`: always uses full-screen mode and clears the screen on exit.
+  - `"quit-quickly-or-clear-output"`: waits briefly before entering full-screen mode; clears on exit only if it switched to full-screen.
 - **Default**: `"quit-if-one-page"`
 - **Example**:
   ```toml
@@ -260,11 +260,11 @@ When `pager = ":builtin"` is set, the builtin pager's behavior can be customized
 ### `ui.streampager.wrapping`
 
 - **Type**: String
-- **Description**: Controls text wrapping in the builtin pager.
+- **Description**: How the builtin pager wraps long lines.
 - **Valid values**:
-  - `"none"`: No wrapping; allow horizontal scrolling
-  - `"word"`: Wrap at word boundaries
-  - `"anywhere"`: Wrap at any character (grapheme) boundary
+  - `"none"`: disables wrapping; long lines extend off-screen and can be scrolled horizontally.
+  - `"word"`: wraps at word boundaries.
+  - `"anywhere"`: wraps at any character (grapheme) boundary.
 - **Default**: `"word"`
 - **Example**:
   ```toml
@@ -306,7 +306,7 @@ Each override has a required `platform` filter and optional settings in the `ui`
 #### `overrides.platform`
 
 - **Type**: String (target spec expression)
-- **Description**: Platform specification for when this override applies. The expression is evaluated against the _build target_: the platform nextest was compiled for. This is distinct from the `platform` field in [per-test overrides](../configuration/per-test-overrides.md#selecting-tests), which is matched against the host or target platform of the tests being run.
+- **Description**: Target-spec expression selecting which platforms this override applies to (target triple or `cfg()` expression). Matched against the platform nextest was built for. This is distinct from the `platform` field in [per-test overrides](../configuration/per-test-overrides.md#selecting-tests), which is matched against the host or target platform of the tests being run.
 - **Required**: Yes
 - **Documentation**: [_Specifying platforms_](../configuration/specifying-platforms.md)
 - **Valid formats**:


### PR DESCRIPTION
Use a consistent style across all three -- they had organically diverged over time.

At some point we should probably build tooling to make sure all of these are aligned.