### PR TITLE
[cargo-nextest] add a custom help subcommand

### DIFF
--- a/cargo-nextest/src/dispatch/app.rs
+++ b/cargo-nextest/src/dispatch/app.rs
@@ -91,6 +91,7 @@ enum NextestSubcommand {
     version = crate::version::short(),
     long_version = crate::version::long(),
     display_name = "cargo-nextest",
+    disable_help_subcommand = true,
 )]
 pub(crate) struct AppOpts {
     #[clap(flatten)]
@@ -202,6 +203,7 @@ impl AppOpts {
                 let user_config = resolve_user_config(early_args.user_config_location())?;
                 command.exec(&early_args, self.common.manifest_path, &user_config, output)
             }
+            Command::Help { path } => super::help::exec_help(path, &early_args, output),
         }
     }
 }
@@ -290,6 +292,12 @@ pub(crate) enum Command {
     Store {
         #[clap(subcommand)]
         command: StoreCommand,
+    },
+    /// Show help for a command or topic.
+    Help {
+        /// The command path or help topic to show help for.
+        #[arg(value_name = "COMMAND_OR_TOPIC")]
+        path: Vec<String>,
     },
 }
 

--- a/cargo-nextest/src/dispatch/help.rs
+++ b/cargo-nextest/src/dispatch/help.rs
@@ -1,0 +1,32 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Support for `cargo nextest self <command-path>`.
+//!
+//! For now, this just forwards to `cargo nextest <command> --help`, but in the
+//! future this will also cover custom help topics.
+
+use super::{EarlyArgs, app::CargoNextestApp, clap_error::handle_clap_error};
+use crate::{Result, output::OutputContext};
+use clap::CommandFactory;
+
+/// Renders help output for the given command path..
+pub(crate) fn exec_help(
+    command_path: Vec<String>,
+    early_args: &EarlyArgs,
+    _output: OutputContext,
+) -> Result<i32> {
+    delegate_command_help(&command_path, early_args)
+}
+
+/// Forwards `[..path, --help]` to clap.
+fn delegate_command_help(path: &[String], early_args: &EarlyArgs) -> Result<i32> {
+    let mut argv = vec!["cargo".to_string(), "nextest".to_string()];
+    argv.extend(path.iter().cloned());
+    argv.push("--help".to_string());
+
+    match CargoNextestApp::command().try_get_matches_from(argv) {
+        Ok(_) => Ok(0),
+        Err(err) => Ok(handle_clap_error(err, early_args)),
+    }
+}

--- a/cargo-nextest/src/dispatch/mod.rs
+++ b/cargo-nextest/src/dispatch/mod.rs
@@ -7,6 +7,7 @@ mod app;
 mod clap_error;
 mod common;
 mod core;
+mod help;
 mod helpers;
 mod imp;
 mod utility;


### PR DESCRIPTION
For now this just forwards to the built-in `--help`, but in the future this will also handle custom help topics.