### PR TITLE
[nextest-runner] keep multi-word hyperlinks contiguous in help output

### DIFF
--- a/integration-tests/tests/integration/snapshots/integration__help_filterset_color.snap
+++ b/integration-tests/tests/integration/snapshots/integration__help_filterset_color.snap
@@ -18,7 +18,7 @@ This section contains the full set of operators supported by the filterset DSL.
     Include all tests matching [36mname-matcher[0m.
 
 [32;1mgroup(name-matcher) [3m(since 0.9.133)[0m
-    Include all tests in [34;4m]8;;https://nexte.st/docs/configuration/test-groups/\test]8;;\ ]8;;https://nexte.st/docs/configuration/test-groups/\groups]8;;\[0m matching [36mname-matcher[0m. This predicate can
+    Include all tests in [34;4m]8;;https://nexte.st/docs/configuration/test-groups/\test groups[0m]8;;\ matching [36mname-matcher[0m. This predicate can
     only be used on the command line.
 
 [32;1mpackage(name-matcher)[0m
@@ -33,7 +33,7 @@ This section contains the full set of operators supported by the filterset DSL.
     (possibly transitively) depend on [36mname-matcher[0m.
 
 [32;1mbinary_id(name-matcher)[0m
-    Include all tests in [34;4m]8;;https://nexte.st/docs/glossary/#binary-id\binary]8;;\ ]8;;https://nexte.st/docs/glossary/#binary-id\IDs]8;;\[0m matching [36mname-matcher[0m. Covers all of
+    Include all tests in [34;4m]8;;https://nexte.st/docs/glossary/#binary-id\binary IDs[0m]8;;\ matching [36mname-matcher[0m. Covers all of
     [36mpackage()[0m, [36mkind()[0m and [36mbinary()[0m.
 
 [32;1mkind(name-matcher)[0m
@@ -46,11 +46,11 @@ This section contains the full set of operators supported by the filterset DSL.
     of the integration test, benchmark, or binary target.
 
 [32;1mplatform(host) or platform(target)[0m
-    Include all tests that are [34;4m]8;;https://nexte.st/docs/selecting/#filtering-by-build-platform\built]8;;\ ]8;;https://nexte.st/docs/selecting/#filtering-by-build-platform\for]8;;\ ]8;;https://nexte.st/docs/selecting/#filtering-by-build-platform\the]8;;\ ]8;;https://nexte.st/docs/selecting/#filtering-by-build-platform\host]8;;\ ]8;;https://nexte.st/docs/selecting/#filtering-by-build-platform\or]8;;\ ]8;;https://nexte.st/docs/selecting/#filtering-by-build-platform\target]8;;\ ]8;;https://nexte.st/docs/selecting/#filtering-by-build-platform\platform]8;;\[0m,
+    Include all tests that are [34;4m]8;;https://nexte.st/docs/selecting/#filtering-by-build-platform\built for the host or target platform[0m]8;;\,
     respectively.
 
 [32;1mdefault() [3m(since 0.9.75)[0m
-    The default set of tests to run; see [34;4m[3m]8;;https://nexte.st/docs/selecting/#running-a-subset-of-tests-by-default\Running]8;;\ ]8;;https://nexte.st/docs/selecting/#running-a-subset-of-tests-by-default\a]8;;\ ]8;;https://nexte.st/docs/selecting/#running-a-subset-of-tests-by-default\subset]8;;\ ]8;;https://nexte.st/docs/selecting/#running-a-subset-of-tests-by-default\of]8;;\ ]8;;https://nexte.st/docs/selecting/#running-a-subset-of-tests-by-default\tests]8;;\ ]8;;https://nexte.st/docs/selecting/#running-a-subset-of-tests-by-default\by]8;;\ ]8;;https://nexte.st/docs/selecting/#running-a-subset-of-tests-by-default\default]8;;\[0m
+    The default set of tests to run; see [34;4m[3m]8;;https://nexte.st/docs/selecting/#running-a-subset-of-tests-by-default\Running a subset of tests by default]8;;\[0m
     for more information.
 
 │ [1mTip: Binary exclusions[0m
@@ -64,7 +64,7 @@ This section contains the full set of operators supported by the filterset DSL.
 │
 │ This is generally what you want, but if you would like to list tests anyway,
 │ include a [36mtest()[0m predicate. For example, to list test binaries for the target
-│ platform (using, for example, a [34;4m]8;;https://nexte.st/docs/features/target-runners/\target]8;;\ ]8;;https://nexte.st/docs/features/target-runners/\runner]8;;\[0m), but skip running them:
+│ platform (using, for example, a [34;4m]8;;https://nexte.st/docs/features/target-runners/\target runner[0m]8;;\), but skip running them:
 │
 │     [36mcargo nextest list -E 'platform(host) + not test(/.*/)' --verbose[0m
 
@@ -117,7 +117,7 @@ Cargo.
     Integration tests, typically in the [36mtests/[0m directory.
 
 [32;1mbench[0m
-    Benchmark tests. For example, see [34;4m[3m]8;;https://nexte.st/docs/integrations/criterion/\Criterion]8;;\ ]8;;https://nexte.st/docs/integrations/criterion/\benchmarks]8;;\[0m.
+    Benchmark tests. For example, see [34;4m[3m]8;;https://nexte.st/docs/integrations/criterion/\Criterion benchmarks[0m]8;;\.
 
 [32;1mproc-macro[0m
     Unit tests for proc-macro crates, in the [36msrc/[0m directory under [36m#[cfg(test)][0m.
@@ -141,11 +141,11 @@ This defines the general syntax for matching against names.
 [32;1m/regex/[0m
     [3mRegex matcher[0m—match a package or test name if any part of it matches the
     regular expression [36mregex[0m. To match the entire string against a regular
-    expression, use [36m/^regex$/[0m. The implementation uses the [34;4m]8;;https://github.com/rust-lang/regex\regex]8;;\[0m crate.
+    expression, use [36m/^regex$/[0m. The implementation uses the [34;4m]8;;https://github.com/rust-lang/regex\regex[0m]8;;\ crate.
 
 [32;1m#glob[0m
     [3mGlob matcher[0m—match a package or test name if the full name matches the glob
-    expression [36mglob[0m. The implementation uses the [34;4m]8;;https://docs.rs/globset\globset]8;;\ ]8;;https://docs.rs/globset\crate]8;;\[0m.
+    expression [36mglob[0m. The implementation uses the [34;4m]8;;https://docs.rs/globset\globset crate[0m]8;;\.
 
 [32;1mstring[0m
     Default matching strategy for the predicate.
@@ -205,6 +205,6 @@ For the [3mglob matcher[0m, to match against a literal glob metacharacter such
 
 All other escape sequences are invalid.
 
-The [3mregular expression[0m matcher supports the same escape sequences that [34;4m]8;;https://docs.rs/regex/latest/regex/#escape-sequences\the]8;;\ ]8;;https://docs.rs/regex/latest/regex/#escape-sequences\regex]8;;\[0m
-[34;4m]8;;https://docs.rs/regex/latest/regex/#escape-sequences\crate]8;;\ ]8;;https://docs.rs/regex/latest/regex/#escape-sequences\does]8;;\[0m. This includes character classes like [36m\d[0m. Additionally, [36m\/[0m is
+The [3mregular expression[0m matcher supports the same escape sequences that [34;4m]8;;https://docs.rs/regex/latest/regex/#escape-sequences\the regex]8;;\[0m
+[34;4m]8;;https://docs.rs/regex/latest/regex/#escape-sequences\crate does[0m]8;;\. This includes character classes like [36m\d[0m. Additionally, [36m\/[0m is
 interpreted as an escaped [36m/[0m.

--- a/nextest-runner/src/help_render.rs
+++ b/nextest-runner/src/help_render.rs
@@ -226,11 +226,36 @@ const CODE_INDENT: &str = "    ";
 /// most of them in theory.
 type StyleStack = SmallVec<[Style; 4]>;
 
+/// The target of a hyperlink for a run of text.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+enum LinkTarget {
+    /// The text is not linked.
+    #[default]
+    Unlinked,
+    /// The text is linked to the given URL.
+    Linked(String),
+}
+
+impl LinkTarget {
+    fn is_linked(&self) -> bool {
+        match self {
+            LinkTarget::Unlinked => false,
+            LinkTarget::Linked(_) => true,
+        }
+    }
+}
+
+/// The presentation attributes of a run of text.
+#[derive(Clone, Debug, Default)]
+struct RunAttrs {
+    styles: StyleStack,
+    link: LinkTarget,
+}
+
 /// A styled run of text.
 struct Span {
     text: String,
-    styles: StyleStack,
-    link: Option<String>,
+    desired: RunAttrs,
 }
 
 /// A single word to be rendered.
@@ -247,11 +272,10 @@ impl Word {
         self.spans.is_empty()
     }
 
-    fn push(&mut self, text: &str, styles: &[Style], link: Option<&str>) {
+    fn push(&mut self, text: &str, desired: &RunAttrs) {
         self.spans.push(Span {
             text: text.to_string(),
-            styles: StyleStack::from_slice(styles),
-            link: link.map(str::to_string),
+            desired: desired.clone(),
         });
         self.width += display_width(text);
     }
@@ -342,9 +366,14 @@ struct LineWriter {
     /// The state of the current line being written.
     line: LineState,
 
-    /// The current word, plus a pending styled break.
+    /// The current word, plus a pending space that can act as a line break.
     word: Word,
-    pending_space: Option<StyleStack>,
+    pending_space: Option<PendingSpace>,
+}
+
+/// A pending space that can also act as a line break.
+struct PendingSpace {
+    desired: RunAttrs,
 }
 
 /// The mutable state of a line that is currently open.
@@ -353,7 +382,7 @@ struct OpenLine {
     /// The number of visible columns used so far in this line.
     column: usize,
     /// The active styles emitted so far in this line.
-    emitted: StyleStack,
+    emitted: RunAttrs,
 }
 
 #[derive(Clone, Debug)]
@@ -386,17 +415,19 @@ impl LineWriter {
     }
 
     /// Adds a styled segment into the current word.
-    fn add_segment(&mut self, text: &str, styles: &[Style], link: Option<&str>) {
+    fn add_segment(&mut self, text: &str, desired: &RunAttrs) {
         if text.is_empty() {
             return;
         }
-        self.word.push(text, styles, link);
+        self.word.push(text, desired);
     }
 
     /// Adds a breakable space, styled by the surrounding context.
-    fn add_space(&mut self, styles: &[Style]) {
+    fn add_space(&mut self, desired: &RunAttrs) {
         self.flush_word();
-        self.pending_space = Some(StyleStack::from_slice(styles));
+        self.pending_space = Some(PendingSpace {
+            desired: desired.clone(),
+        });
     }
 
     /// Emits the buffered word, wrapping to the provided width with a hanging
@@ -408,12 +439,12 @@ impl LineWriter {
         let pending = self.pending_space.take();
         match &self.line {
             LineState::Open(open) => {
-                if let Some(space_styles) = pending {
+                if let Some(space) = pending {
                     if open.column + 1 + self.word.width > self.width {
                         self.end_line();
                         self.open_line();
                     } else {
-                        self.emit_space(&space_styles);
+                        self.emit_space(&space.desired);
                     }
                 }
             }
@@ -436,36 +467,38 @@ impl LineWriter {
         };
         for span in spans {
             if *color {
-                write_style_diff(out, open, &span.styles);
+                write_style_diff(out, open, &span.desired.styles);
             }
-            let linked = *hyperlinks && span.link.is_some();
-            if linked {
-                let url = span.link.as_deref().expect("link is present");
-                swrite!(out, "\x1b]8;;{url}\x1b\\");
+            if *hyperlinks {
+                sync_link(out, open, &span.desired.link);
             }
             out.push_str(&span.text);
-            if linked {
-                out.push_str("\x1b]8;;\x1b\\");
-            }
             open.column += display_width(&span.text);
         }
     }
 
-    fn emit_space(&mut self, styles: &[Style]) {
-        self.write_open(" ", styles);
+    fn emit_space(&mut self, desired: &RunAttrs) {
+        self.write_open(" ", desired);
     }
 
     /// Writes styled text to the current open line, syncing styles and advancing
     /// the column.
-    fn write_open(&mut self, text: &str, styles: &[Style]) {
+    fn write_open(&mut self, text: &str, desired: &RunAttrs) {
         let Self {
-            out, line, color, ..
+            out,
+            line,
+            color,
+            hyperlinks,
+            ..
         } = self;
         let LineState::Open(open) = line else {
             return;
         };
         if *color {
-            write_style_diff(out, open, styles);
+            write_style_diff(out, open, &desired.styles);
+        }
+        if *hyperlinks {
+            sync_link(out, open, &desired.link);
         }
         out.push_str(text);
         open.column += display_width(text);
@@ -474,7 +507,7 @@ impl LineWriter {
     /// Writes text verbatim (without wrapping), preserving newlines.
     ///
     /// Used for code blocks.
-    fn verbatim(&mut self, s: &str, styles: &[Style]) {
+    fn verbatim(&mut self, s: &str, desired: &RunAttrs) {
         let lines: Vec<&str> = s.split('\n').collect();
         let last = lines.len() - 1;
         for (i, &line) in lines.iter().enumerate() {
@@ -490,7 +523,7 @@ impl LineWriter {
                 }
             } else {
                 self.open_line();
-                self.write_open(line, styles);
+                self.write_open(line, desired);
             }
         }
     }
@@ -528,7 +561,7 @@ impl LineWriter {
         self.out.push_str(&prefix);
         self.line = LineState::Open(OpenLine {
             column: display_width(&prefix),
-            emitted: StyleStack::new(),
+            emitted: RunAttrs::default(),
         });
     }
 
@@ -536,12 +569,16 @@ impl LineWriter {
         let LineState::Open(open) = &self.line else {
             return;
         };
-        let reset = self.color && !open.emitted.is_empty();
+        let reset = self.color && !open.emitted.styles.is_empty();
+        let close_link = open.emitted.link.is_linked();
         // Drop trailing spaces so that blank and prefix-only lines don't carry
         // any whitespace. We use trim_end_matches rather than trim_end to avoid
         // eating newlines. If we used trim_end, we'd potentially end up
         // consuming the `\n` from the previous line.
         self.out.truncate(self.out.trim_end_matches(' ').len());
+        if close_link {
+            self.out.push_str("\x1b]8;;\x1b\\");
+        }
         if reset {
             self.out.push_str(RESET_COLOR);
         }
@@ -568,23 +605,42 @@ impl LineWriter {
 /// Diffs the currently-emitted stack of styles with the desired set of styles,
 /// emitting the minimum number of style changes to match the target.
 fn write_style_diff(out: &mut String, open: &mut OpenLine, desired: &[Style]) {
-    if open.emitted.as_slice() == desired {
+    if open.emitted.styles.as_slice() == desired {
         return;
     }
-    let common = open.emitted.len();
-    if desired.len() > common && &desired[..common] == open.emitted.as_slice() {
+    let common = open.emitted.styles.len();
+    if desired.len() > common && &desired[..common] == open.emitted.styles.as_slice() {
         for style in &desired[common..] {
             out.push_str(&style.prefix_formatter().to_string());
         }
     } else {
-        if !open.emitted.is_empty() {
+        if !open.emitted.styles.is_empty() {
             out.push_str(RESET_COLOR);
         }
         for style in desired {
             out.push_str(&style.prefix_formatter().to_string());
         }
     }
-    open.emitted = StyleStack::from_slice(desired);
+    open.emitted.styles = StyleStack::from_slice(desired);
+}
+
+/// When displaying OSC 8 hyperlinks, sync the open hyperlink with the desired
+/// target.
+///
+/// This closes the current link and/or opens a new one as needed.
+fn sync_link(out: &mut String, open: &mut OpenLine, desired: &LinkTarget) {
+    if open.emitted.link == *desired {
+        // We're already displaying this link, so there's no need to change the
+        // link target.
+        return;
+    }
+    if open.emitted.link.is_linked() {
+        out.push_str("\x1b]8;;\x1b\\");
+    }
+    if let LinkTarget::Linked(url) = desired {
+        swrite!(out, "\x1b]8;;{url}\x1b\\");
+    }
+    open.emitted.link = desired.clone();
 }
 
 struct Rendered {
@@ -606,10 +662,9 @@ fn render_markdown(
         writer: LineWriter::new(opts.color, opts.hyperlinks, opts.width),
         palette,
         site_dir,
-        styles: StyleStack::new(),
+        desired_attrs: RunAttrs::default(),
         context: InlineContext::Normal,
         list_stack: Vec::new(),
-        link_url: None,
         dropped: Vec::new(),
     };
 
@@ -643,12 +698,10 @@ struct Renderer {
     writer: LineWriter,
     palette: Styles,
     site_dir: &'static [&'static str],
-    /// The desired style stack.
-    styles: StyleStack,
+    desired_attrs: RunAttrs,
     context: InlineContext,
     // The stack of open lists.
     list_stack: Vec<ListFrame>,
-    link_url: Option<String>,
     dropped: Vec<String>,
 }
 
@@ -762,42 +815,40 @@ impl Renderer {
                     if self.writer.hyperlinks {
                         self.push_style(self.palette.link);
                     }
-                    self.link_url = Some(url);
+                    self.desired_attrs.link = LinkTarget::Linked(url);
                 }
             }
             Event::End(TagEnd::Link) => {
                 // (None was a same-page anchor -- see Event::Start(Tag::Link {
                 // .. }) above.)
-                if let Some(url) = self.link_url.take() {
+                if let LinkTarget::Linked(url) = std::mem::take(&mut self.desired_attrs.link) {
                     if self.writer.hyperlinks {
                         self.pop_style();
                     } else {
                         // The terminal doesn't support hyperlinks, so show the
                         // URL inline in the surrounding style.
-                        self.writer.add_space(&self.styles);
+                        self.writer.add_space(&self.desired_attrs);
                         self.writer
-                            .add_segment(&format!("<{url}>"), &self.styles, None);
+                            .add_segment(&format!("<{url}>"), &self.desired_attrs);
                     }
                 }
             }
 
             Event::Text(text) => match self.context {
-                InlineContext::CodeBlock => self.writer.verbatim(&text, &self.styles),
+                InlineContext::CodeBlock => self.writer.verbatim(&text, &self.desired_attrs),
                 InlineContext::Normal | InlineContext::Term => self.push_text(&text),
             },
             Event::Code(code) => match self.context {
                 InlineContext::Term => {
-                    self.writer
-                        .add_segment(&code, &self.styles, self.link_url.as_deref());
+                    self.writer.add_segment(&code, &self.desired_attrs);
                 }
                 InlineContext::Normal | InlineContext::CodeBlock => {
                     self.push_style(self.palette.code);
-                    self.writer
-                        .add_segment(&code, &self.styles, self.link_url.as_deref());
+                    self.writer.add_segment(&code, &self.desired_attrs);
                     self.pop_style();
                 }
             },
-            Event::SoftBreak => self.writer.add_space(&self.styles),
+            Event::SoftBreak => self.writer.add_space(&self.desired_attrs),
             Event::HardBreak => self.writer.hard_break(),
 
             // Ignore other events such as images, raw HTML, tables, footnotes,
@@ -835,19 +886,18 @@ impl Renderer {
 
     fn emit_run(&mut self, run: &str, is_ws: bool) {
         if is_ws {
-            self.writer.add_space(&self.styles);
+            self.writer.add_space(&self.desired_attrs);
         } else {
-            self.writer
-                .add_segment(run, &self.styles, self.link_url.as_deref());
+            self.writer.add_segment(run, &self.desired_attrs);
         }
     }
 
     fn push_style(&mut self, style: Style) {
-        self.styles.push(style);
+        self.desired_attrs.styles.push(style);
     }
 
     fn pop_style(&mut self) {
-        self.styles.pop();
+        self.desired_attrs.styles.pop();
     }
 }
 
@@ -892,6 +942,40 @@ mod tests {
             without.contains("<https://nexte.st/"),
             "inline URL fallback"
         );
+    }
+
+    #[test]
+    fn multi_word_link_is_one_continuous_hyperlink() {
+        let doc = HelpDoc {
+            markdown: "[click here](https://example.com/page) and more text\n".into(),
+            site_dir: &[],
+        };
+        let rendered = render(
+            &doc,
+            RenderOptions {
+                color: false,
+                hyperlinks: true,
+                width: 80,
+            },
+        );
+        insta::assert_snapshot!(rendered);
+    }
+
+    #[test]
+    fn wrapped_link_does_not_span_a_newline() {
+        let doc = HelpDoc {
+            markdown: "[alpha beta gamma](https://example.com/x)\n".into(),
+            site_dir: &[],
+        };
+        let rendered = render(
+            &doc,
+            RenderOptions {
+                color: false,
+                hyperlinks: true,
+                width: 12,
+            },
+        );
+        insta::assert_snapshot!(rendered);
     }
 
     #[test]

--- a/nextest-runner/src/snapshots/nextest_runner__help_render__tests__multi_word_link_is_one_continuous_hyperlink.snap
+++ b/nextest-runner/src/snapshots/nextest_runner__help_render__tests__multi_word_link_is_one_continuous_hyperlink.snap
@@ -1,0 +1,5 @@
+---
+source: nextest-runner/src/help_render.rs
+expression: rendered
+---
+]8;;https://example.com/page\click here]8;;\ and more text

--- a/nextest-runner/src/snapshots/nextest_runner__help_render__tests__wrapped_link_does_not_span_a_newline.snap
+++ b/nextest-runner/src/snapshots/nextest_runner__help_render__tests__wrapped_link_does_not_span_a_newline.snap
@@ -1,0 +1,6 @@
+---
+source: nextest-runner/src/help_render.rs
+expression: rendered
+---
+]8;;https://example.com/x\alpha beta]8;;\
+]8;;https://example.com/x\gamma]8;;\


### PR DESCRIPTION
We used to split hyperlinks on every word. Switch to only splitting when the link target actually changes.