### PR TITLE
[nextest-runner] extract shared progress-bar style, switch to anstyle-progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle-progress"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee65f3323c89eac2de51015f125682e9a88c3bf7a10d0c39b3768ff6af654ff7"
+
+[[package]]
 name = "anstyle-query"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2552,6 +2558,7 @@ name = "nextest-runner"
 version = "0.121.0"
 dependencies = [
  "aho-corasick",
+ "anstyle-progress",
  "async-scoped",
  "atomicwrites",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ exclude = ["src/**/AGENTS.md", "src/**/CLAUDE.md"]
 
 [workspace.dependencies]
 aho-corasick = "1.1.4"
+anstyle-progress = "0.1.0"
 async-scoped = { version = "0.9.0", features = ["use-tokio"] }
 atomicwrites = "0.4.4"
 bitflags = "2.13.0"

--- a/cargo-nextest/src/dispatch/core/run.rs
+++ b/cargo-nextest/src/dispatch/core/run.rs
@@ -26,7 +26,7 @@ use nextest_runner::{
         core::ConfigExperimental,
         elements::{MaxFail, RetryPolicy, TestThreads},
     },
-    helpers::{force_or_new_run_id, plural},
+    helpers::{ShowTerminalProgress, force_or_new_run_id, plural},
     input::InputHandlerKind,
     list::{BinaryList, TestExecuteContext, TestList},
     record::{
@@ -36,7 +36,7 @@ use nextest_runner::{
     },
     redact::Redactor,
     reporter::{
-        MaxProgressRunning, ReporterBuilder, ShowProgress, ShowTerminalProgress, TestOutputDisplay,
+        MaxProgressRunning, ReporterBuilder, ShowProgress, TestOutputDisplay,
         events::{FinalRunStats, RunStats},
         structured,
     },

--- a/nextest-runner/Cargo.toml
+++ b/nextest-runner/Cargo.toml
@@ -16,6 +16,7 @@ exclude.workspace = true
 
 [dependencies]
 aho-corasick.workspace = true
+anstyle-progress.workspace = true
 async-scoped.workspace = true
 atomicwrites.workspace = true
 bstr.workspace = true

--- a/nextest-runner/src/helpers.rs
+++ b/nextest-runner/src/helpers.rs
@@ -3,6 +3,8 @@
 
 //! General support code for nextest-runner.
 
+pub(crate) mod progress;
+
 use crate::{
     config::scripts::ScriptId,
     list::{OwnedTestInstanceId, Styles, TestInstanceId},
@@ -14,6 +16,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use console::AnsiCodeIterator;
 use nextest_metadata::TestCaseName;
 use owo_colors::{OwoColorize, Style};
+pub use progress::ShowTerminalProgress;
 use quick_junit::ReportUuid;
 use std::{fmt, io, ops::ControlFlow, path::PathBuf, process::ExitStatus, time::Duration};
 use swrite::{SWrite, swrite};

--- a/nextest-runner/src/helpers/progress.rs
+++ b/nextest-runner/src/helpers/progress.rs
@@ -1,0 +1,164 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::cargo_config::{CargoConfigs, DiscoveredConfig};
+use anstyle_progress::{TermProgress, supports_term_progress};
+use indicatif::ProgressStyle;
+use std::{
+    env,
+    io::{self, Write},
+};
+use tracing::debug;
+
+/// The refresh rate for the progress bar, set to a minimal value.
+///
+/// For progress, during each tick, two things happen:
+///
+/// - We update the message, calling self.bar.set_message.
+/// - We print any buffered output.
+///
+/// We want both of these updates to be combined into one terminal flush, so we
+/// set *this* to a minimal value (so self.bar.set_message doesn't do a redraw),
+/// and rely on ProgressBarState::print_and_force_redraw to always flush the
+/// terminal.
+pub(crate) const PROGRESS_REFRESH_RATE_HZ: u8 = 1;
+
+pub(crate) fn progress_bar_style(progress_chars: &str, suffix: &str) -> ProgressStyle {
+    // Create the template. This is a little confusing -- {{foo}} is what's
+    // passed into the ProgressBar, while {bar} is inserted by the format!()
+    // statement.
+    let template = format!("{{prefix:>12}} [{{elapsed_precise:>9}}] {{wide_bar}} {suffix}");
+    ProgressStyle::default_bar()
+        .progress_chars(progress_chars)
+        .template(&template)
+        .expect("template is known to be valid")
+}
+
+/// Whether to show OSC 9;4 terminal progress.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ShowTerminalProgress {
+    /// Show terminal progress.
+    Yes,
+
+    /// Do not show terminal progress.
+    No,
+}
+
+impl ShowTerminalProgress {
+    const ENV: &str = "CARGO_TERM_PROGRESS_TERM_INTEGRATION";
+
+    /// Determines whether to show terminal progress based on Cargo configs and
+    /// whether the output is a terminal.
+    pub fn from_cargo_configs(configs: &CargoConfigs, is_terminal: bool) -> Self {
+        // See whether terminal integration is enabled in Cargo.
+        for config in configs.discovered_configs() {
+            match config {
+                DiscoveredConfig::CliOption { config, source } => {
+                    if let Some(v) = config.term.progress.term_integration {
+                        if v {
+                            debug!("enabling terminal progress reporting based on {source:?}");
+                            return Self::Yes;
+                        } else {
+                            debug!("disabling terminal progress reporting based on {source:?}");
+                            return Self::No;
+                        }
+                    }
+                }
+                DiscoveredConfig::Env => {
+                    if let Some(v) = env::var_os(Self::ENV) {
+                        if v == "true" {
+                            debug!(
+                                "enabling terminal progress reporting based on \
+                                 CARGO_TERM_PROGRESS_TERM_INTEGRATION environment variable"
+                            );
+                            return Self::Yes;
+                        } else if v == "false" {
+                            debug!(
+                                "disabling terminal progress reporting based on \
+                                 CARGO_TERM_PROGRESS_TERM_INTEGRATION environment variable"
+                            );
+                            return Self::No;
+                        } else {
+                            debug!(
+                                "invalid value for CARGO_TERM_PROGRESS_TERM_INTEGRATION \
+                                 environment variable: {v:?}, ignoring"
+                            );
+                        }
+                    }
+                }
+                DiscoveredConfig::File { config, source } => {
+                    if let Some(v) = config.term.progress.term_integration {
+                        if v {
+                            debug!("enabling terminal progress reporting based on {source:?}");
+                            return Self::Yes;
+                        } else {
+                            debug!("disabling terminal progress reporting based on {source:?}");
+                            return Self::No;
+                        }
+                    }
+                }
+            }
+        }
+
+        let show = supports_term_progress(is_terminal);
+        debug!(is_terminal, show, "autodetected terminal progress support");
+        if show { Self::Yes } else { Self::No }
+    }
+}
+
+/// OSC 9 terminal progress reporting.
+#[derive(Default)]
+pub(crate) struct TerminalProgress {
+    last_value: TermProgress,
+}
+
+impl TerminalProgress {
+    pub(crate) fn new(show: ShowTerminalProgress) -> Option<Self> {
+        match show {
+            ShowTerminalProgress::Yes => Some(Self::default()),
+            ShowTerminalProgress::No => None,
+        }
+    }
+
+    pub(crate) fn set(&mut self, value: TermProgress) {
+        self.last_value = value;
+    }
+
+    pub(crate) fn emit(&self) {
+        // Use the write! macro rather than eprint! so that we ignore errors
+        // rather than panicking. Terminal progress reporting is cosmetic and
+        // best-effort.
+        let _ = write!(io::stderr(), "{}", self.last_value);
+    }
+}
+
+pub(crate) fn term_progress_percent(done: usize, total: usize) -> u8 {
+    if total == 0 {
+        return 100;
+    }
+    ((done as f64 / total as f64) * 100.0)
+        .round()
+        .clamp(0.0, 100.0) as u8
+}
+
+#[cfg(test)]
+mod tests {
+    use super::term_progress_percent;
+
+    #[test]
+    fn term_progress_percent_boundaries() {
+        // Handle 0/0 properly.
+        assert_eq!(term_progress_percent(0, 0), 100);
+        assert_eq!(term_progress_percent(0, 10), 0);
+        assert_eq!(term_progress_percent(1, 2), 50);
+        assert_eq!(term_progress_percent(1, 4), 25);
+        assert_eq!(term_progress_percent(10, 10), 100);
+
+        // We round away from zero (12.5 -> 13, 37.5 -> 38).
+        assert_eq!(term_progress_percent(1, 8), 13);
+        assert_eq!(term_progress_percent(3, 8), 38);
+
+        // We stay within 0..=100 for the percentage.
+        assert_eq!(term_progress_percent(11, 10), 100);
+    }
+}

--- a/nextest-runner/src/record/replay.rs
+++ b/nextest-runner/src/record/replay.rs
@@ -598,6 +598,7 @@ fn read_output_file(
 use crate::{
     config::overrides::CompiledDefaultFilter,
     errors::WriteEventError,
+    helpers::progress::ShowTerminalProgress,
     record::{
         run_id_index::{RunIdIndex, ShortestRunIdPrefix},
         store::{RecordedRunInfo, RecordedRunStatus},
@@ -605,8 +606,8 @@ use crate::{
     redact::Redactor,
     reporter::{
         DisplayConfig, DisplayReporter, DisplayReporterBuilder, DisplayerKind, FinalStatusLevel,
-        MaxProgressRunning, OutputLoadDecider, ReporterOutput, ShowProgress, ShowTerminalProgress,
-        StatusLevel, TestOutputDisplay,
+        MaxProgressRunning, OutputLoadDecider, ReporterOutput, ShowProgress, StatusLevel,
+        TestOutputDisplay,
     },
 };
 use chrono::{DateTime, FixedOffset};

--- a/nextest-runner/src/reporter/AGENTS.md
+++ b/nextest-runner/src/reporter/AGENTS.md
@@ -38,7 +38,7 @@ reporter/
 │   ├── imp.rs                # DisplayReporter, DisplayReporterImpl (~1200 lines)
 │   ├── status_level.rs       # StatusLevel, FinalStatusLevel, output decision logic
 │   ├── unit_output.rs        # TestOutputDisplay, ChildOutputSpec, ANSI handling
-│   ├── progress.rs           # ProgressBarState, OSC 9;4 terminal progress
+│   ├── progress.rs           # ProgressBarState, event → OSC 9;4 mapping (terminal_progress_value)
 │   └── formatters.rs         # Duration formatters, skip counts, final warnings
 │
 ├── aggregator/               # Disk-based metadata output
@@ -136,7 +136,7 @@ This logic accounts for cancellation scenarios (interrupt, signal, test failure 
 - **Stacked hide states**: `hidden_no_capture`, `hidden_run_paused`, `hidden_info_response`.
 - **Running test tracking**: `Vec<RunningTest>` with status (Running, Slow, Delay, Retry).
 - **Chunked output**: `print_lines_in_chunks()` prevents terminal overwhelm during large output bursts.
-- **OSC 9;4 progress**: Terminal progress codes for supported terminals (Windows Terminal, iTerm, WezTerm, Ghostty).
+- **OSC 9;4 progress**: `terminal_progress_value()` (this file) maps each event to a progress state; emission and terminal detection live in the shared `crate::helpers::progress` module via the `anstyle-progress` crate, which decides which terminals advertise support.
 
 The refresh rate is intentionally set to 1 Hz (`PROGRESS_REFRESH_RATE_HZ`) to batch updates efficiently.
 
@@ -315,7 +315,7 @@ When adding a new `TestEventKind` variant:
 1. Add the variant to `TestEventKind` in `events.rs`.
 2. Update `DisplayReporterImpl::write_event_impl()` in `displayer/imp.rs`.
 3. Update `ProgressBarState::update_progress_bar()` in `displayer/progress.rs` if it affects progress.
-4. Update `TerminalProgress::update_progress()` if it affects OSC 9;4 reporting.
+4. Update `terminal_progress_value()` in `displayer/progress.rs` if it affects OSC 9;4 reporting.
 5. Update `LibtestReporter::write_event()` in `structured/libtest.rs` if it maps to libtest output.
 6. Consider whether it should be recorded (update `TestEventSummary::from_test_event()`).
 7. Add snapshot tests for the new output.

--- a/nextest-runner/src/reporter/displayer/imp.rs
+++ b/nextest-runner/src/reporter/displayer/imp.rs
@@ -14,7 +14,8 @@ use super::{
         write_final_warnings, write_skip_counts,
     },
     progress::{
-        MaxProgressRunning, ProgressBarState, progress_bar_msg, progress_str, write_summary_str,
+        MaxProgressRunning, ProgressBarState, progress_bar_msg, progress_str,
+        terminal_progress_value, write_summary_str,
     },
     unit_output::{OutputDisplayOverrides, TestOutputDisplay},
 };
@@ -28,18 +29,14 @@ use crate::{
     helpers::{
         DisplayCounterIndex, DisplayScriptInstance, DisplayTestInstance, DurationRounding,
         ThemeCharacters, decimal_char_width, plural,
+        progress::{ShowTerminalProgress, TerminalProgress},
     },
     indenter::indented,
     list::TestInstanceId,
     output_spec::{LiveSpec, RecordingSpec},
     record::{LoadOutput, OutputEventKind, ReplayHeader, ShortestRunIdPrefix},
     redact::Redactor,
-    reporter::{
-        displayer::progress::{ShowTerminalProgress, TerminalProgress},
-        events::*,
-        helpers::Styles,
-        imp::ReporterOutput,
-    },
+    reporter::{events::*, helpers::Styles, imp::ReporterOutput},
     run_mode::NextestRunMode,
     runner::StressCount,
     write_str::WriteStr,
@@ -191,7 +188,7 @@ impl<'a> DisplayReporter<'a> {
                 term_progress,
             } => {
                 if let Some(term_progress) = term_progress {
-                    term_progress.update_progress(event);
+                    term_progress.set(terminal_progress_value(event));
                 }
 
                 if let Some(state) = progress_bar {
@@ -449,7 +446,7 @@ impl ReporterOutputImpl<'_> {
                     // text, so it can be directly written out to stderr without
                     // going through the progress bar (which screws up
                     // indicatif's calculations).
-                    eprint!("{}", term_progress.last_value())
+                    term_progress.emit()
                 }
             }
             ReporterOutputImpl::Writer(_) => {
@@ -469,7 +466,7 @@ impl ReporterOutputImpl<'_> {
                 }
                 if let Some(term_progress) = term_progress {
                     // The last value is expected to be Remove.
-                    eprint!("{}", term_progress.last_value())
+                    term_progress.emit()
                 }
             }
             ReporterOutputImpl::Writer(_) => {

--- a/nextest-runner/src/reporter/displayer/mod.rs
+++ b/nextest-runner/src/reporter/displayer/mod.rs
@@ -14,6 +14,6 @@ pub(crate) use config::*;
 pub(crate) use formatters::DisplayUnitKind;
 pub use imp::OutputLoadDecider;
 pub(crate) use imp::*;
-pub use progress::{MaxProgressRunning, ShowProgress, ShowTerminalProgress};
+pub use progress::{MaxProgressRunning, ShowProgress};
 pub use status_level::*;
 pub use unit_output::*;

--- a/nextest-runner/src/reporter/displayer/progress.rs
+++ b/nextest-runner/src/reporter/displayer/progress.rs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use crate::{
-    cargo_config::{CargoConfigs, DiscoveredConfig},
-    helpers::{DisplayTestInstance, plural},
+    helpers::{
+        DisplayTestInstance, plural,
+        progress::{PROGRESS_REFRESH_RATE_HZ, progress_bar_style, term_progress_percent},
+    },
     list::TestInstanceId,
     reporter::{
         displayer::formatters::DisplayBracketedHhMmSs,
@@ -12,7 +14,8 @@ use crate::{
     },
     run_mode::NextestRunMode,
 };
-use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
+use anstyle_progress::TermProgress;
+use indicatif::{ProgressBar, ProgressDrawTarget};
 use nextest_metadata::{RustBinaryId, TestCaseName};
 use owo_colors::OwoColorize;
 use std::{
@@ -22,20 +25,6 @@ use std::{
     time::{Duration, Instant},
 };
 use swrite::{SWrite, swrite};
-use tracing::debug;
-
-/// The refresh rate for the progress bar, set to a minimal value.
-///
-/// For progress, during each tick, two things happen:
-///
-/// - We update the message, calling self.bar.set_message.
-/// - We print any buffered output.
-///
-/// We want both of these updates to be combined into one terminal flush, so we
-/// set *this* to a minimal value (so self.bar.set_message doesn't do a redraw),
-/// and rely on ProgressBar::print_and_flush_buffer to always flush the
-/// terminal.
-const PROGRESS_REFRESH_RATE_HZ: u8 = 1;
 
 /// The maximum number of running tests to display with
 /// `--show-progress=running` or `only`.
@@ -235,20 +224,8 @@ impl ProgressBarState {
     ) -> Self {
         let bar = ProgressBar::new(run_count as u64);
         let run_count_width = format!("{run_count}").len();
-        // Create the template using the width as input. This is a
-        // little confusing -- {{foo}} is what's passed into the
-        // ProgressBar, while {bar} is inserted by the format!()
-        // statement.
-        let template = format!(
-            "{{prefix:>12}} [{{elapsed_precise:>9}}] {{wide_bar}} \
-            {{pos:>{run_count_width}}}/{{len:{run_count_width}}}: {{msg}}"
-        );
-        bar.set_style(
-            ProgressStyle::default_bar()
-                .progress_chars(progress_chars)
-                .template(&template)
-                .expect("template is known to be valid"),
-        );
+        let suffix = format!("{{pos:>{run_count_width}}}/{{len:{run_count_width}}}: {{msg}}");
+        bar.set_style(progress_bar_style(progress_chars, &suffix));
 
         let running_tests =
             (!matches!(max_progress_running, MaxProgressRunning::Count(0))).then(Vec::new);
@@ -549,212 +526,58 @@ impl ProgressBarState {
     }
 }
 
-/// Whether to show OSC 9;4 terminal progress.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum ShowTerminalProgress {
-    /// Show terminal progress.
-    Yes,
-
-    /// Do not show terminal progress.
-    No,
-}
-
-impl ShowTerminalProgress {
-    const ENV: &str = "CARGO_TERM_PROGRESS_TERM_INTEGRATION";
-
-    /// Determines whether to show terminal progress based on Cargo configs and
-    /// whether the output is a terminal.
-    pub fn from_cargo_configs(configs: &CargoConfigs, is_terminal: bool) -> Self {
-        // See whether terminal integration is enabled in Cargo.
-        for config in configs.discovered_configs() {
-            match config {
-                DiscoveredConfig::CliOption { config, source } => {
-                    if let Some(v) = config.term.progress.term_integration {
-                        if v {
-                            debug!("enabling terminal progress reporting based on {source:?}");
-                            return Self::Yes;
-                        } else {
-                            debug!("disabling terminal progress reporting based on {source:?}");
-                            return Self::No;
-                        }
-                    }
-                }
-                DiscoveredConfig::Env => {
-                    if let Some(v) = env::var_os(Self::ENV) {
-                        if v == "true" {
-                            debug!(
-                                "enabling terminal progress reporting based on \
-                                 CARGO_TERM_PROGRESS_TERM_INTEGRATION environment variable"
-                            );
-                            return Self::Yes;
-                        } else if v == "false" {
-                            debug!(
-                                "disabling terminal progress reporting based on \
-                                 CARGO_TERM_PROGRESS_TERM_INTEGRATION environment variable"
-                            );
-                            return Self::No;
-                        } else {
-                            debug!(
-                                "invalid value for CARGO_TERM_PROGRESS_TERM_INTEGRATION \
-                                 environment variable: {v:?}, ignoring"
-                            );
-                        }
-                    }
-                }
-                DiscoveredConfig::File { config, source } => {
-                    if let Some(v) = config.term.progress.term_integration {
-                        if v {
-                            debug!("enabling terminal progress reporting based on {source:?}");
-                            return Self::Yes;
-                        } else {
-                            debug!("disabling terminal progress reporting based on {source:?}");
-                            return Self::No;
-                        }
-                    }
-                }
+pub(super) fn terminal_progress_value(event: &TestEvent<'_>) -> TermProgress {
+    match &event.kind {
+        TestEventKind::RunStarted { .. }
+        | TestEventKind::StressSubRunStarted { .. }
+        | TestEventKind::StressSubRunFinished { .. }
+        | TestEventKind::SetupScriptStarted { .. }
+        | TestEventKind::SetupScriptSlow { .. }
+        | TestEventKind::SetupScriptFinished { .. } => TermProgress::none(),
+        TestEventKind::TestStarted { current_stats, .. }
+        | TestEventKind::TestFinished { current_stats, .. } => {
+            if current_stats.has_failures() || current_stats.cancel_reason.is_some() {
+                term_progress_errored(current_stats)
+            } else {
+                term_progress_running(current_stats)
             }
         }
-
-        if supports_osc_9_4(is_terminal) {
-            Self::Yes
-        } else {
-            Self::No
+        TestEventKind::TestSlow { .. }
+        | TestEventKind::TestAttemptFailedWillRetry { .. }
+        | TestEventKind::TestRetryStarted { .. }
+        | TestEventKind::TestSkipped { .. }
+        | TestEventKind::InfoStarted { .. }
+        | TestEventKind::InfoResponse { .. }
+        | TestEventKind::InfoFinished { .. }
+        | TestEventKind::InputEnter { .. } => TermProgress::none(),
+        TestEventKind::RunBeginCancel { current_stats, .. }
+        | TestEventKind::RunBeginKill { current_stats, .. } => term_progress_errored(current_stats),
+        TestEventKind::RunPaused { .. }
+        | TestEventKind::RunContinued { .. }
+        | TestEventKind::RunFinished { .. } => {
+            // Reset the terminal state to nothing, since nextest is giving up
+            // control of the terminal at this point. (We don't use the paused
+            // terminal state here because the user might run other programs
+            // with their own progress bars while nextest is paused.)
+            TermProgress::remove()
         }
     }
 }
 
-/// OSC 9 terminal progress reporting.
-#[derive(Default)]
-pub(super) struct TerminalProgress {
-    last_value: TerminalProgressValue,
+fn term_progress_running(current_stats: &RunStats) -> TermProgress {
+    let percent = term_progress_percent(
+        current_stats.finished_count,
+        current_stats.initial_run_count,
+    );
+    TermProgress::start().percent(percent)
 }
 
-impl TerminalProgress {
-    pub(super) fn new(show: ShowTerminalProgress) -> Option<Self> {
-        match show {
-            ShowTerminalProgress::Yes => Some(Self::default()),
-            ShowTerminalProgress::No => None,
-        }
-    }
-
-    pub(super) fn update_progress(&mut self, event: &TestEvent<'_>) {
-        let value = match &event.kind {
-            TestEventKind::RunStarted { .. }
-            | TestEventKind::StressSubRunStarted { .. }
-            | TestEventKind::StressSubRunFinished { .. }
-            | TestEventKind::SetupScriptStarted { .. }
-            | TestEventKind::SetupScriptSlow { .. }
-            | TestEventKind::SetupScriptFinished { .. } => TerminalProgressValue::None,
-            TestEventKind::TestStarted { current_stats, .. }
-            | TestEventKind::TestFinished { current_stats, .. } => {
-                let percentage = (current_stats.finished_count as f64
-                    / current_stats.initial_run_count as f64)
-                    * 100.0;
-                if current_stats.has_failures() || current_stats.cancel_reason.is_some() {
-                    TerminalProgressValue::Error(percentage)
-                } else {
-                    TerminalProgressValue::Value(percentage)
-                }
-            }
-            TestEventKind::TestSlow { .. }
-            | TestEventKind::TestAttemptFailedWillRetry { .. }
-            | TestEventKind::TestRetryStarted { .. }
-            | TestEventKind::TestSkipped { .. }
-            | TestEventKind::InfoStarted { .. }
-            | TestEventKind::InfoResponse { .. }
-            | TestEventKind::InfoFinished { .. }
-            | TestEventKind::InputEnter { .. } => TerminalProgressValue::None,
-            TestEventKind::RunBeginCancel { current_stats, .. }
-            | TestEventKind::RunBeginKill { current_stats, .. } => {
-                // In this case, always indicate an error.
-                let percentage = (current_stats.finished_count as f64
-                    / current_stats.initial_run_count as f64)
-                    * 100.0;
-                TerminalProgressValue::Error(percentage)
-            }
-            TestEventKind::RunPaused { .. }
-            | TestEventKind::RunContinued { .. }
-            | TestEventKind::RunFinished { .. } => {
-                // Reset the terminal state to nothing, since nextest is giving
-                // up control of the terminal at this point.
-                TerminalProgressValue::Remove
-            }
-        };
-
-        self.last_value = value;
-    }
-
-    pub(super) fn last_value(&self) -> &TerminalProgressValue {
-        &self.last_value
-    }
-}
-
-/// Determines whether the terminal supports ANSI OSC 9;4.
-fn supports_osc_9_4(is_terminal: bool) -> bool {
-    if !is_terminal {
-        debug!(
-            "autodetect terminal progress reporting: disabling since \
-             passed-in stream (usually stderr) is not a terminal"
-        );
-        return false;
-    }
-    if std::env::var_os("WT_SESSION").is_some() {
-        debug!("autodetect terminal progress reporting: enabling since WT_SESSION is set");
-        return true;
-    };
-    if std::env::var_os("ConEmuANSI").is_some_and(|term| term == "ON") {
-        debug!("autodetect terminal progress reporting: enabling since ConEmuANSI is ON");
-        return true;
-    }
-    if let Ok(term) = std::env::var("TERM_PROGRAM")
-        && (term == "WezTerm" || term == "ghostty" || term == "iTerm.app")
-    {
-        debug!("autodetect terminal progress reporting: enabling since TERM_PROGRAM is {term}");
-        return true;
-    }
-
-    false
-}
-
-/// A progress status value printable as an ANSI OSC 9;4 escape code.
-///
-/// Adapted from Cargo 1.87.
-#[derive(PartialEq, Debug, Default)]
-pub(super) enum TerminalProgressValue {
-    /// No output.
-    #[default]
-    None,
-    /// Remove progress.
-    Remove,
-    /// Progress value (0-100).
-    Value(f64),
-    /// Indeterminate state (no bar, just animation)
-    ///
-    /// We don't use this yet, but might in the future.
-    #[expect(dead_code)]
-    Indeterminate,
-    /// Progress value in an error state (0-100).
-    Error(f64),
-}
-
-impl fmt::Display for TerminalProgressValue {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // From https://conemu.github.io/en/AnsiEscapeCodes.html#ConEmu_specific_OSC
-        // ESC ] 9 ; 4 ; st ; pr ST
-        // When st is 0: remove progress.
-        // When st is 1: set progress value to pr (number, 0-100).
-        // When st is 2: set error state in taskbar, pr is optional.
-        // When st is 3: set indeterminate state, pr is ignored.
-        // When st is 4: set paused state, pr is optional.
-        let (state, progress) = match self {
-            Self::None => return Ok(()), // No output
-            Self::Remove => (0, 0.0),
-            Self::Value(v) => (1, *v),
-            Self::Indeterminate => (3, 0.0),
-            Self::Error(v) => (2, *v),
-        };
-        write!(f, "\x1b]9;4;{state};{progress:.0}\x1b\\")
-    }
+fn term_progress_errored(current_stats: &RunStats) -> TermProgress {
+    let percent = term_progress_percent(
+        current_stats.finished_count,
+        current_stats.initial_run_count,
+    );
+    TermProgress::error().percent(percent)
 }
 
 /// Returns a summary of current progress.
@@ -937,6 +760,93 @@ mod tests {
     };
     use bytes::Bytes;
     use chrono::Local;
+
+    #[test]
+    fn terminal_progress_value_escape_codes() {
+        let binary_id = RustBinaryId::new("test-binary");
+        let test_name = TestCaseName::new("test_name");
+
+        let normal = TestEvent {
+            timestamp: Local::now().fixed_offset(),
+            elapsed: Duration::ZERO,
+            kind: TestEventKind::TestStarted {
+                stress_index: None,
+                test_instance: TestInstanceId {
+                    binary_id: &binary_id,
+                    test_name: &test_name,
+                },
+                slot_assignment: global_slot_assignment(0),
+                current_stats: RunStats {
+                    initial_run_count: 10,
+                    finished_count: 3,
+                    ..RunStats::default()
+                },
+                running: 1,
+                command_line: vec![],
+            },
+        };
+        assert_eq!(
+            terminal_progress_value(&normal).to_string(),
+            "\x1b]9;4;1;30\x1b\\"
+        );
+
+        let failing = TestEvent {
+            timestamp: Local::now().fixed_offset(),
+            elapsed: Duration::ZERO,
+            kind: TestEventKind::TestStarted {
+                stress_index: None,
+                test_instance: TestInstanceId {
+                    binary_id: &binary_id,
+                    test_name: &test_name,
+                },
+                slot_assignment: global_slot_assignment(0),
+                current_stats: RunStats {
+                    initial_run_count: 10,
+                    finished_count: 3,
+                    failed: 1,
+                    ..RunStats::default()
+                },
+                running: 1,
+                command_line: vec![],
+            },
+        };
+        assert_eq!(
+            terminal_progress_value(&failing).to_string(),
+            "\x1b]9;4;2;30\x1b\\"
+        );
+
+        let cancelling = TestEvent {
+            timestamp: Local::now().fixed_offset(),
+            elapsed: Duration::ZERO,
+            kind: TestEventKind::RunBeginCancel {
+                setup_scripts_running: 0,
+                current_stats: RunStats {
+                    initial_run_count: 4,
+                    finished_count: 1,
+                    cancel_reason: Some(CancelReason::Signal),
+                    ..RunStats::default()
+                },
+                running: 3,
+            },
+        };
+        assert_eq!(
+            terminal_progress_value(&cancelling).to_string(),
+            "\x1b]9;4;2;25\x1b\\"
+        );
+
+        let paused = TestEvent {
+            timestamp: Local::now().fixed_offset(),
+            elapsed: Duration::ZERO,
+            kind: TestEventKind::RunPaused {
+                setup_scripts_running: 0,
+                running: 2,
+            },
+        };
+        assert_eq!(
+            terminal_progress_value(&paused).to_string(),
+            "\x1b]9;4;0;\x1b\\"
+        );
+    }
 
     #[test]
     fn test_progress_bar_prefix() {

--- a/nextest-runner/src/reporter/imp.rs
+++ b/nextest-runner/src/reporter/imp.rs
@@ -8,11 +8,12 @@
 use super::{
     DisplayConfig, DisplayerKind, FinalStatusLevel, MaxProgressRunning, StatusLevel,
     TestOutputDisplay,
-    displayer::{DisplayReporter, DisplayReporterBuilder, ShowTerminalProgress},
+    displayer::{DisplayReporter, DisplayReporterBuilder},
 };
 use crate::{
     config::core::EvaluatableProfile,
     errors::WriteEventError,
+    helpers::progress::ShowTerminalProgress,
     list::TestList,
     record::{ShortestRunIdPrefix, StoreSizes},
     redact::Redactor,

--- a/nextest-runner/src/reporter/mod.rs
+++ b/nextest-runner/src/reporter/mod.rs
@@ -17,8 +17,8 @@ pub(crate) mod test_helpers;
 
 pub(crate) use displayer::{DisplayConfig, DisplayReporter, DisplayReporterBuilder, DisplayerKind};
 pub use displayer::{
-    FinalStatusLevel, MaxProgressRunning, OutputLoadDecider, ShowProgress, ShowTerminalProgress,
-    StatusLevel, TestOutputDisplay,
+    FinalStatusLevel, MaxProgressRunning, OutputLoadDecider, ShowProgress, StatusLevel,
+    TestOutputDisplay,
 };
 pub use error_description::*;
 pub use helpers::highlight_end;

--- a/nextest-runner/src/update.rs
+++ b/nextest-runner/src/update.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     errors::{UpdateError, UpdateVersionParseError},
-    helpers::ThemeCharacters,
+    helpers::{ThemeCharacters, progress::progress_bar_style},
 };
 use camino::{Utf8Path, Utf8PathBuf};
 use indicatif::{ProgressBar, ProgressStyle};
@@ -454,22 +454,17 @@ impl MuktiUpdateContext<'_> {
         let progress_bar = match content_length {
             Some(size) => {
                 let pb = ProgressBar::new(size);
-                pb.set_style(
-                    ProgressStyle::default_bar()
-                        .template(
-                            "  {prefix:>10} [{elapsed_precise:>9}] {wide_bar} \
-                             {bytes:>9}/{total_bytes:>9}",
-                        )
-                        .expect("valid progress bar template")
-                        .progress_chars(styles.theme_characters.progress_chars()),
-                );
+                pb.set_style(progress_bar_style(
+                    styles.theme_characters.progress_chars(),
+                    "{bytes:>9}/{total_bytes:>9}",
+                ));
                 pb
             }
             None => {
                 let pb = ProgressBar::new_spinner();
                 pb.set_style(
                     ProgressStyle::default_spinner()
-                        .template("  {prefix:>10} [{elapsed_precise:>9}] {bytes}")
+                        .template("{prefix:>12} [{elapsed_precise:>9}] {bytes}")
                         .expect("valid progress spinner template"),
                 );
                 pb


### PR DESCRIPTION
* Extract the generic indicatif style construction into a shared crate-visible helper.
* Replace the hand-rolled OSC 9;4 code with the anstyle-progress crate.