### PR TITLE
[nextest-runner] fill missing JUnit failure messages

### DIFF
--- a/integration-tests/tests/integration/fixtures.rs
+++ b/integration-tests/tests/integration/fixtures.rs
@@ -1310,8 +1310,8 @@ const ABORT_MESSAGE_PREFIXES: &[&str] = &["process was terminated"];
 /// How to verify the JUnit message field for a non-success test case.
 #[derive(Clone, Debug)]
 enum JunitExpectedMessage<'a> {
-    /// Don't verify the message.
-    None,
+    /// The message must equal the given string.
+    Exact(&'a str),
     /// The message must be present and start with one of the given prefixes.
     /// This is used for failure types where the message format is known but
     /// the exact content is test-specific.
@@ -1334,7 +1334,15 @@ impl JunitExpectedMessage<'_> {
         properties: RunProperties,
     ) {
         match self {
-            JunitExpectedMessage::None => {}
+            JunitExpectedMessage::Exact(expected) => {
+                assert_eq!(
+                    actual_message,
+                    Some(*expected),
+                    "{test_name}: JUnit message mismatch (properties: {})\n\
+                     JUnit path: {junit_path}",
+                    debug_run_properties(properties),
+                );
+            }
             JunitExpectedMessage::StartsWithOneOf(prefixes) => {
                 let message = actual_message.unwrap_or_else(|| {
                     panic!(
@@ -1403,9 +1411,7 @@ fn expected_junit_for_result(
         CheckResult::LeakFail => Some(ExpectedJunit {
             kind: quick_junit::NonSuccessKind::Error,
             ty: "test exited with code 0, but leaked handles so was marked failed",
-            // LeakFail tests exit with code 0 (no panic), so there's no error
-            // output to extract a message from.
-            message: JunitExpectedMessage::None,
+            message: JunitExpectedMessage::Exact("failed: exited with code 0, but leaked handles"),
         }),
         CheckResult::Fail => Some(ExpectedJunit {
             kind: quick_junit::NonSuccessKind::Failure,
@@ -1439,10 +1445,7 @@ fn expected_junit_for_result(
             Some(ExpectedJunit {
                 kind: quick_junit::NonSuccessKind::Failure,
                 ty: timeout_kind,
-                // Timed-out tests are killed without producing panic output,
-                // and FailureDescription::Timeout doesn't generate an abort
-                // description, so there's no error to extract a message from.
-                message: JunitExpectedMessage::None,
+                message: JunitExpectedMessage::Exact("timed out"),
             })
         }
     }

--- a/nextest-runner/src/reporter/aggregator/junit.rs
+++ b/nextest-runner/src/reporter/aggregator/junit.rs
@@ -105,6 +105,7 @@ impl<'cfg> MetadataJunit<'cfg> {
                     || (junit_store_failure_output && !is_success);
 
                 set_execute_status_props(
+                    UnitKind::Script,
                     &run_status.output,
                     store_stdout_stderr,
                     TestcaseOrRerun::Testcase(&mut testcase),
@@ -205,6 +206,7 @@ impl<'cfg> MetadataJunit<'cfg> {
                         .set_type(ty);
 
                     set_execute_status_props(
+                        UnitKind::Test,
                         &rerun.output,
                         junit_store_failure_output,
                         TestcaseOrRerun::Rerun(&mut test_rerun),
@@ -234,6 +236,7 @@ impl<'cfg> MetadataJunit<'cfg> {
                     || (junit_store_failure_output && !is_success_for_output);
 
                 set_execute_status_props(
+                    UnitKind::Test,
                     &main_status.output,
                     store_stdout_stderr,
                     TestcaseOrRerun::Testcase(&mut testcase),
@@ -495,15 +498,23 @@ impl TestcaseOrRerun<'_> {
 }
 
 fn set_execute_status_props(
+    kind: UnitKind,
     exec_output: &ChildExecutionOutputDescription<LiveSpec>,
     store_stdout_stderr: bool,
     mut out: TestcaseOrRerun<'_>,
 ) {
-    // Currently we only aggregate test results, so always specify UnitKind::Test.
+    // Preserve the existing JUnit behavior of extracting test-style panic and
+    // error output for both tests and setup scripts.
     let description = UnitErrorDescription::new(UnitKind::Test, exec_output);
     if let Some(errors) = description.all_error_list() {
         out.set_message(errors.short_message());
         out.set_description(DisplayErrorChain::new(errors).to_string());
+    } else if exec_output.has_errors() {
+        let message = match kind {
+            UnitKind::Test => "test failed",
+            UnitKind::Script => "setup script failed",
+        };
+        out.set_message(message);
     }
 
     if store_stdout_stderr {
@@ -566,6 +577,7 @@ mod tests {
         let cases = [
             ExecuteStatusPropsCase {
                 comment: "success + combined + store",
+                kind: UnitKind::Test,
                 status: TestCaseStatus::success(),
                 output: ChildExecutionOutput::Output {
                     result: Some(ExecutionResult::Pass),
@@ -583,6 +595,7 @@ mod tests {
             },
             ExecuteStatusPropsCase {
                 comment: "success + combined + no store",
+                kind: UnitKind::Test,
                 status: TestCaseStatus::success(),
                 output: ChildExecutionOutput::Output {
                     result: Some(ExecutionResult::Pass),
@@ -600,6 +613,7 @@ mod tests {
             },
             ExecuteStatusPropsCase {
                 comment: "success + split + store",
+                kind: UnitKind::Test,
                 status: TestCaseStatus::success(),
                 output: ChildExecutionOutput::Output {
                     result: Some(ExecutionResult::Pass),
@@ -620,6 +634,7 @@ mod tests {
             // it's just another combination of the above.
             ExecuteStatusPropsCase {
                 comment: "failure + combined + store",
+                kind: UnitKind::Test,
                 status: TestCaseStatus::non_success(NonSuccessKind::Failure),
                 output: ChildExecutionOutput::Output {
                     result: Some(ExecutionResult::Fail {
@@ -647,6 +662,7 @@ mod tests {
             },
             ExecuteStatusPropsCase {
                 comment: "failure + split + no store",
+                kind: UnitKind::Test,
                 status: TestCaseStatus::non_success(NonSuccessKind::Failure),
                 output: ChildExecutionOutput::Output {
                     result: Some(ExecutionResult::Fail {
@@ -675,9 +691,68 @@ mod tests {
                 system_out: None,
                 system_err: None,
             },
+            ExecuteStatusPropsCase {
+                comment: "failure + no extracted error + no store",
+                kind: UnitKind::Test,
+                status: TestCaseStatus::non_success(NonSuccessKind::Failure),
+                output: failed_split_output(Some("ordinary output"), None),
+                store_stdout_stderr: false,
+                message: Some("test failed"),
+                description: None,
+                system_out: None,
+                system_err: None,
+            },
+            ExecuteStatusPropsCase {
+                comment: "flaky failure message + successful final attempt",
+                kind: UnitKind::Test,
+                status: {
+                    let mut status = TestCaseStatus::non_success(NonSuccessKind::Failure);
+                    status.set_message("flaky failure");
+                    status
+                },
+                output: ChildExecutionOutput::Output {
+                    result: Some(ExecutionResult::Pass),
+                    output: ChildOutput::Combined {
+                        output: Bytes::new().into(),
+                    },
+                    errors: None,
+                }
+                .into(),
+                store_stdout_stderr: false,
+                message: Some("flaky failure"),
+                description: None,
+                system_out: None,
+                system_err: None,
+            },
+            ExecuteStatusPropsCase {
+                comment: "setup script failure + no extracted error + no store",
+                kind: UnitKind::Script,
+                status: TestCaseStatus::non_success(NonSuccessKind::Failure),
+                output: failed_split_output(None, Some("ordinary error output")),
+                store_stdout_stderr: false,
+                message: Some("setup script failed"),
+                description: None,
+                system_out: None,
+                system_err: None,
+            },
+            ExecuteStatusPropsCase {
+                comment: "setup script failure + extracted panic + no store",
+                kind: UnitKind::Script,
+                status: TestCaseStatus::non_success(NonSuccessKind::Failure),
+                output: failed_split_output(
+                    None,
+                    Some("thread 'setup' panicked at setup.rs:10:\nbad setup"),
+                ),
+                store_stdout_stderr: false,
+                message: Some("thread 'setup' panicked at setup.rs:10"),
+                description: Some("thread 'setup' panicked at setup.rs:10:\nbad setup"),
+                system_out: None,
+                system_err: None,
+            },
             #[cfg(unix)]
             ExecuteStatusPropsCase {
                 comment: "abort + split + store (unix)",
+                kind: UnitKind::Test,
                 status: TestCaseStatus::non_success(NonSuccessKind::Failure),
                 output: ChildExecutionOutput::Output {
                     result: Some(ExecutionResult::Fail {
@@ -700,6 +775,7 @@ mod tests {
             #[cfg(unix)]
             ExecuteStatusPropsCase {
                 comment: "abort + multiple errors + no store (unix)",
+                kind: UnitKind::Test,
                 status: TestCaseStatus::non_success(NonSuccessKind::Failure),
                 output: ChildExecutionOutput::Output {
                     result: Some(ExecutionResult::Fail {
@@ -735,6 +811,7 @@ mod tests {
             },
             ExecuteStatusPropsCase {
                 comment: "multiple errors + store",
+                kind: UnitKind::Test,
                 status: TestCaseStatus::non_success(NonSuccessKind::Failure),
                 output: ChildExecutionOutput::Output {
                     result: Some(ExecutionResult::Fail {
@@ -769,6 +846,7 @@ mod tests {
             },
             ExecuteStatusPropsCase {
                 comment: "exec fail + combined + store (exec fail means nothing to store)",
+                kind: UnitKind::Test,
                 status: TestCaseStatus::non_success(NonSuccessKind::Error),
                 output: ChildExecutionOutput::StartError(ChildStartError::Spawn(Arc::new(
                     io::Error::other("start error"),
@@ -791,6 +869,7 @@ mod tests {
 
             let mut testcase = TestCase::new("test", case.status);
             set_execute_status_props(
+                case.kind,
                 &case.output,
                 case.store_stdout_stderr,
                 TestcaseOrRerun::Testcase(&mut testcase),
@@ -816,11 +895,22 @@ mod tests {
                 "system_err matches"
             );
         }
+
+        let output = failed_split_output(Some("ordinary retry output"), None);
+        let mut rerun = TestRerun::new(NonSuccessKind::Failure);
+        set_execute_status_props(
+            UnitKind::Test,
+            &output,
+            false,
+            TestcaseOrRerun::Rerun(&mut rerun),
+        );
+        assert_eq!(rerun.message.as_deref(), Some("test failed"));
     }
 
     #[derive(Debug)]
     struct ExecuteStatusPropsCase<'a> {
         comment: &'a str,
+        kind: UnitKind,
         status: TestCaseStatus,
         output: ChildExecutionOutputDescription<LiveSpec>,
         store_stdout_stderr: bool,
@@ -828,6 +918,24 @@ mod tests {
         description: Option<&'a str>,
         system_out: Option<&'a str>,
         system_err: Option<&'a str>,
+    }
+
+    fn failed_split_output(
+        stdout: Option<&str>,
+        stderr: Option<&str>,
+    ) -> ChildExecutionOutputDescription<LiveSpec> {
+        ChildExecutionOutput::Output {
+            result: Some(ExecutionResult::Fail {
+                failure_status: FailureStatus::ExitCode(1),
+                leaked: false,
+            }),
+            output: ChildOutput::Split(ChildSplitOutput {
+                stdout: stdout.map(|output| Bytes::copy_from_slice(output.as_bytes()).into()),
+                stderr: stderr.map(|output| Bytes::copy_from_slice(output.as_bytes()).into()),
+            }),
+            errors: None,
+        }
+        .into()
     }
 
     fn get_message(status: &TestCaseStatus) -> Option<&str> {

--- a/nextest-runner/src/reporter/aggregator/junit.rs
+++ b/nextest-runner/src/reporter/aggregator/junit.rs
@@ -105,7 +105,6 @@ impl<'cfg> MetadataJunit<'cfg> {
                     || (junit_store_failure_output && !is_success);
 
                 set_execute_status_props(
-                    UnitKind::Script,
                     &run_status.output,
                     store_stdout_stderr,
                     TestcaseOrRerun::Testcase(&mut testcase),
@@ -206,7 +205,6 @@ impl<'cfg> MetadataJunit<'cfg> {
                         .set_type(ty);
 
                     set_execute_status_props(
-                        UnitKind::Test,
                         &rerun.output,
                         junit_store_failure_output,
                         TestcaseOrRerun::Rerun(&mut test_rerun),
@@ -236,7 +234,6 @@ impl<'cfg> MetadataJunit<'cfg> {
                     || (junit_store_failure_output && !is_success_for_output);
 
                 set_execute_status_props(
-                    UnitKind::Test,
                     &main_status.output,
                     store_stdout_stderr,
                     TestcaseOrRerun::Testcase(&mut testcase),
@@ -498,7 +495,6 @@ impl TestcaseOrRerun<'_> {
 }
 
 fn set_execute_status_props(
-    kind: UnitKind,
     exec_output: &ChildExecutionOutputDescription<LiveSpec>,
     store_stdout_stderr: bool,
     mut out: TestcaseOrRerun<'_>,
@@ -510,11 +506,7 @@ fn set_execute_status_props(
         out.set_message(errors.short_message());
         out.set_description(DisplayErrorChain::new(errors).to_string());
     } else if exec_output.has_errors() {
-        let message = match kind {
-            UnitKind::Test => "test failed",
-            UnitKind::Script => "setup script failed",
-        };
-        out.set_message(message);
+        out.set_message(exec_output.short_display());
     }
 
     if store_stdout_stderr {
@@ -577,7 +569,6 @@ mod tests {
         let cases = [
             ExecuteStatusPropsCase {
                 comment: "success + combined + store",
-                kind: UnitKind::Test,
                 status: TestCaseStatus::success(),
                 output: ChildExecutionOutput::Output {
                     result: Some(ExecutionResult::Pass),
@@ -595,7 +586,6 @@ mod tests {
             },
             ExecuteStatusPropsCase {
                 comment: "success + combined + no store",
-                kind: UnitKind::Test,
                 status: TestCaseStatus::success(),
                 output: ChildExecutionOutput::Output {
                     result: Some(ExecutionResult::Pass),
@@ -613,7 +603,6 @@ mod tests {
             },
             ExecuteStatusPropsCase {
                 comment: "success + split + store",
-                kind: UnitKind::Test,
                 status: TestCaseStatus::success(),
                 output: ChildExecutionOutput::Output {
                     result: Some(ExecutionResult::Pass),
@@ -634,7 +623,6 @@ mod tests {
             // it's just another combination of the above.
             ExecuteStatusPropsCase {
                 comment: "failure + combined + store",
-                kind: UnitKind::Test,
                 status: TestCaseStatus::non_success(NonSuccessKind::Failure),
                 output: ChildExecutionOutput::Output {
                     result: Some(ExecutionResult::Fail {
@@ -662,7 +650,6 @@ mod tests {
             },
             ExecuteStatusPropsCase {
                 comment: "failure + split + no store",
-                kind: UnitKind::Test,
                 status: TestCaseStatus::non_success(NonSuccessKind::Failure),
                 output: ChildExecutionOutput::Output {
                     result: Some(ExecutionResult::Fail {
@@ -693,18 +680,16 @@ mod tests {
             },
             ExecuteStatusPropsCase {
                 comment: "failure + no extracted error + no store",
-                kind: UnitKind::Test,
                 status: TestCaseStatus::non_success(NonSuccessKind::Failure),
                 output: failed_split_output(Some("ordinary output"), None),
                 store_stdout_stderr: false,
-                message: Some("test failed"),
+                message: Some("failed with exit code 1"),
                 description: None,
                 system_out: None,
                 system_err: None,
             },
             ExecuteStatusPropsCase {
                 comment: "flaky failure message + successful final attempt",
-                kind: UnitKind::Test,
                 status: {
                     let mut status = TestCaseStatus::non_success(NonSuccessKind::Failure);
                     status.set_message("flaky failure");
@@ -726,18 +711,16 @@ mod tests {
             },
             ExecuteStatusPropsCase {
                 comment: "setup script failure + no extracted error + no store",
-                kind: UnitKind::Script,
                 status: TestCaseStatus::non_success(NonSuccessKind::Failure),
                 output: failed_split_output(None, Some("ordinary error output")),
                 store_stdout_stderr: false,
-                message: Some("setup script failed"),
+                message: Some("failed with exit code 1"),
                 description: None,
                 system_out: None,
                 system_err: None,
             },
             ExecuteStatusPropsCase {
                 comment: "setup script failure + extracted panic + no store",
-                kind: UnitKind::Script,
                 status: TestCaseStatus::non_success(NonSuccessKind::Failure),
                 output: failed_split_output(
                     None,
@@ -752,7 +735,6 @@ mod tests {
             #[cfg(unix)]
             ExecuteStatusPropsCase {
                 comment: "abort + split + store (unix)",
-                kind: UnitKind::Test,
                 status: TestCaseStatus::non_success(NonSuccessKind::Failure),
                 output: ChildExecutionOutput::Output {
                     result: Some(ExecutionResult::Fail {
@@ -775,7 +757,6 @@ mod tests {
             #[cfg(unix)]
             ExecuteStatusPropsCase {
                 comment: "abort + multiple errors + no store (unix)",
-                kind: UnitKind::Test,
                 status: TestCaseStatus::non_success(NonSuccessKind::Failure),
                 output: ChildExecutionOutput::Output {
                     result: Some(ExecutionResult::Fail {
@@ -811,7 +792,6 @@ mod tests {
             },
             ExecuteStatusPropsCase {
                 comment: "multiple errors + store",
-                kind: UnitKind::Test,
                 status: TestCaseStatus::non_success(NonSuccessKind::Failure),
                 output: ChildExecutionOutput::Output {
                     result: Some(ExecutionResult::Fail {
@@ -846,7 +826,6 @@ mod tests {
             },
             ExecuteStatusPropsCase {
                 comment: "exec fail + combined + store (exec fail means nothing to store)",
-                kind: UnitKind::Test,
                 status: TestCaseStatus::non_success(NonSuccessKind::Error),
                 output: ChildExecutionOutput::StartError(ChildStartError::Spawn(Arc::new(
                     io::Error::other("start error"),
@@ -869,7 +848,6 @@ mod tests {
 
             let mut testcase = TestCase::new("test", case.status);
             set_execute_status_props(
-                case.kind,
                 &case.output,
                 case.store_stdout_stderr,
                 TestcaseOrRerun::Testcase(&mut testcase),
@@ -898,19 +876,72 @@ mod tests {
 
         let output = failed_split_output(Some("ordinary retry output"), None);
         let mut rerun = TestRerun::new(NonSuccessKind::Failure);
-        set_execute_status_props(
-            UnitKind::Test,
-            &output,
-            false,
-            TestcaseOrRerun::Rerun(&mut rerun),
+        set_execute_status_props(&output, false, TestcaseOrRerun::Rerun(&mut rerun));
+        assert_eq!(rerun.message.as_deref(), Some("failed with exit code 1"));
+    }
+
+    #[test]
+    fn test_child_execution_output_short_display() {
+        let cases = [
+            (Some(ExecutionResult::Pass), "passed"),
+            (
+                Some(ExecutionResult::Leak {
+                    result: LeakTimeoutResult::Pass,
+                }),
+                "passed with leaked handles",
+            ),
+            (
+                Some(ExecutionResult::Leak {
+                    result: LeakTimeoutResult::Fail,
+                }),
+                "failed: exited with code 0, but leaked handles",
+            ),
+            (
+                Some(ExecutionResult::Fail {
+                    failure_status: FailureStatus::ExitCode(3),
+                    leaked: true,
+                }),
+                "failed with exit code 3 (leaked handles)",
+            ),
+            (Some(ExecutionResult::ExecFail), "failed to execute"),
+            (
+                Some(ExecutionResult::Timeout {
+                    result: SlowTimeoutResult::Pass,
+                }),
+                "passed with timeout",
+            ),
+            (
+                Some(ExecutionResult::Timeout {
+                    result: SlowTimeoutResult::Fail,
+                }),
+                "timed out",
+            ),
+            (None, "unknown status"),
+        ];
+
+        for (result, expected) in cases {
+            assert_eq!(output_for_result(result).short_display(), expected);
+        }
+
+        #[cfg(unix)]
+        assert_eq!(
+            output_for_result(Some(ExecutionResult::Fail {
+                failure_status: FailureStatus::Abort(AbortStatus::UnixSignal(SIGTERM)),
+                leaked: false,
+            }))
+            .short_display(),
+            "aborted with signal 15 (SIGTERM)",
         );
-        assert_eq!(rerun.message.as_deref(), Some("test failed"));
+
+        let start_error = ChildExecutionOutputDescription::<LiveSpec>::StartError(
+            ChildStartError::Spawn(Arc::new(io::Error::other("start error"))).into(),
+        );
+        assert_eq!(start_error.short_display(), "failed to start");
     }
 
     #[derive(Debug)]
     struct ExecuteStatusPropsCase<'a> {
         comment: &'a str,
-        kind: UnitKind,
         status: TestCaseStatus,
         output: ChildExecutionOutputDescription<LiveSpec>,
         store_stdout_stderr: bool,
@@ -933,6 +964,19 @@ mod tests {
                 stdout: stdout.map(|output| Bytes::copy_from_slice(output.as_bytes()).into()),
                 stderr: stderr.map(|output| Bytes::copy_from_slice(output.as_bytes()).into()),
             }),
+            errors: None,
+        }
+        .into()
+    }
+
+    fn output_for_result(
+        result: Option<ExecutionResult>,
+    ) -> ChildExecutionOutputDescription<LiveSpec> {
+        ChildExecutionOutput::Output {
+            result,
+            output: ChildOutput::Combined {
+                output: Bytes::new().into(),
+            },
             errors: None,
         }
         .into()

--- a/nextest-runner/src/reporter/events.rs
+++ b/nextest-runner/src/reporter/events.rs
@@ -1459,6 +1459,44 @@ impl<S: OutputSpec> ChildExecutionOutputDescription<S> {
             Self::StartError(_) => true,
         }
     }
+
+    /// Returns a short, human-readable description of this output's result.
+    pub fn short_display(&self) -> String {
+        match self {
+            Self::Output { result, .. } => match result {
+                Some(ExecutionResultDescription::Pass) => "passed".to_owned(),
+                Some(ExecutionResultDescription::Leak {
+                    result: LeakTimeoutResult::Pass,
+                }) => "passed with leaked handles".to_owned(),
+                Some(ExecutionResultDescription::Leak {
+                    result: LeakTimeoutResult::Fail,
+                }) => "failed: exited with code 0, but leaked handles".to_owned(),
+                Some(ExecutionResultDescription::Fail {
+                    failure: FailureDescription::ExitCode { code },
+                    leaked,
+                }) => {
+                    let leaked = if *leaked { " (leaked handles)" } else { "" };
+                    format!("failed with exit code {code}{leaked}")
+                }
+                Some(ExecutionResultDescription::Fail {
+                    failure: FailureDescription::Abort { abort },
+                    leaked,
+                }) => {
+                    let leaked = if *leaked { " (leaked handles)" } else { "" };
+                    format!("{abort}{leaked}")
+                }
+                Some(ExecutionResultDescription::ExecFail) => "failed to execute".to_owned(),
+                Some(ExecutionResultDescription::Timeout {
+                    result: SlowTimeoutResult::Pass,
+                }) => "passed with timeout".to_owned(),
+                Some(ExecutionResultDescription::Timeout {
+                    result: SlowTimeoutResult::Fail,
+                }) => "timed out".to_owned(),
+                None => "unknown status".to_owned(),
+            },
+            Self::StartError(_) => "failed to start".to_owned(),
+        }
+    }
 }
 
 /// The output of a child process during live execution.


### PR DESCRIPTION
Closes #961.

## Summary

- add unit-specific fallback messages when JUnit failures have no richer extracted error
- preserve panic and execution details for tests, setup scripts, and reruns

## Validation

- `cargo xfmt` - passed
- `cargo nextest run -p nextest-runner reporter::aggregator::junit::tests::test_set_execute_status_props` - passed
- `cargo clippy -p nextest-runner --lib --tests -- -D warnings` - passed
- full `nextest-runner` package run - not completed locally; the seed-archive setup exhausted the available filesystem before tests began
