### PR TITLE
[nextest-runner] show a progress bar during the list phase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2063,6 +2063,7 @@ dependencies = [
 name = "integration-tests"
 version = "0.1.0"
 dependencies = [
+ "anstyle-progress",
  "camino",
  "camino-tempfile",
  "camino-tempfile-ext",

--- a/cargo-nextest/src/dispatch/app.rs
+++ b/cargo-nextest/src/dispatch/app.rs
@@ -125,7 +125,11 @@ impl AppOpts {
                     output_writer,
                 )?;
                 let app = App::new(base, list_opts.build_filter)?;
-                app.exec_list(list_opts.message_format, list_opts.list_type)?;
+                app.exec_list(
+                    list_opts.message_format,
+                    list_opts.list_type,
+                    list_opts.show_progress,
+                )?;
                 Ok(0)
             }
             Command::Run(run_opts) => {

--- a/cargo-nextest/src/dispatch/core/filter.rs
+++ b/cargo-nextest/src/dispatch/core/filter.rs
@@ -11,7 +11,7 @@ use guppy::graph::PackageGraph;
 use nextest_runner::{
     cargo_config::EnvironmentMap,
     config::core::{EvaluatableProfile, get_num_cpus},
-    list::{BinaryList, RustTestArtifact, TestExecuteContext, TestList},
+    list::{BinaryList, ListProgressOptions, RustTestArtifact, TestExecuteContext, TestList},
     partition::PartitionerBuilder,
     reuse_build::ReuseBuildInfo,
     run_mode::NextestRunMode,
@@ -104,6 +104,7 @@ impl TestBuildFilter {
         env: EnvironmentMap,
         profile: &EvaluatableProfile<'_>,
         reuse_build: &ReuseBuildInfo,
+        list_progress_options: ListProgressOptions,
     ) -> Result<TestList<'g>> {
         let path_mapper = make_path_mapper(
             reuse_build,
@@ -144,6 +145,7 @@ impl TestBuildFilter {
             },
             // TODO: do we need to allow customizing this?
             get_num_cpus(),
+            list_progress_options,
         )
         .map_err(|err| ExpectedError::CreateTestListError { err })
     }

--- a/cargo-nextest/src/dispatch/core/list.rs
+++ b/cargo-nextest/src/dispatch/core/list.rs
@@ -6,7 +6,7 @@
 use super::{
     filter::TestBuildFilter,
     run::App,
-    value_enums::{ListType, MessageFormatOpts},
+    value_enums::{ListType, MessageFormatOpts, ShowProgressOpt},
 };
 use crate::{
     Result,
@@ -21,6 +21,7 @@ use nextest_runner::{
     helpers::force_or_new_run_id,
     list::TestExecuteContext,
     pager::PagedOutput,
+    reporter::ShowProgress,
     run_mode::NextestRunMode,
     runner::VersionEnvVars,
     show_config::{ShowTestGroupSettings, ShowTestGroups, ShowTestGroupsMode},
@@ -59,6 +60,16 @@ pub(crate) struct ListOpts {
     )]
     pub(crate) list_type: ListType,
 
+    /// Show list progress in the specified manner.
+    ///
+    /// List progress is only shown if building the test list takes more than 2
+    /// seconds.
+    ///
+    /// This can also be set via user config at `~/.config/nextest/config.toml`.
+    /// See <https://nexte.st/docs/user-config>.
+    #[arg(long, env = "NEXTEST_SHOW_PROGRESS", help_heading = "Output options")]
+    pub(crate) show_progress: Option<ShowProgressOpt>,
+
     #[clap(flatten)]
     pub(crate) reuse_build: ReuseBuildOpts,
 }
@@ -68,6 +79,7 @@ impl App {
         &self,
         message_format: MessageFormatOpts,
         list_type: ListType,
+        show_progress: Option<ShowProgressOpt>,
     ) -> Result<()> {
         let pcx = ParseContext::new(self.base.graph());
 
@@ -142,12 +154,22 @@ impl App {
                     target_runner,
                 };
 
-                let test_list = self.build_test_list(&ctx, binary_list, &test_filter, &profile)?;
+                // The precedence for showing progress during listing is CLI ->
+                // env -> resolved config, same as the run path.
+                let list_show_progress = show_progress
+                    .map(ShowProgress::from)
+                    .unwrap_or_else(|| resolved_user_config.ui.show_progress.into());
+                let test_list = self.build_test_list(
+                    &ctx,
+                    binary_list,
+                    &test_filter,
+                    &profile,
+                    list_show_progress,
+                )?;
 
-                // Spawn the pager after building the list. (In an upcoming
-                // change we're going to add a progress bar to the list display
-                // -- we want to ensure the pager doesn't collide with the
-                // progress bar.)
+                // Spawn the pager after building the list. (We sometimes
+                // display a progress bar during the list phase -- we want to
+                // ensure the pager doesn't collide with the progress bar.)
                 let mut paged_output = if should_page {
                     PagedOutput::request_pager(
                         &pager_setting,
@@ -223,10 +245,17 @@ impl App {
             target_runner,
         };
 
-        let test_list = self.build_test_list(&ctx, binary_list, &test_filter, &profile)?;
-
         let resolved_user_config =
             resolve_user_config(self.base.early_args.user_config_location())?;
+
+        let test_list = self.build_test_list(
+            &ctx,
+            binary_list,
+            &test_filter,
+            &profile,
+            resolved_user_config.ui.show_progress.into(),
+        )?;
+
         let (pager_setting, paginate) =
             self.base.early_args.resolve_pager(&resolved_user_config.ui);
 

--- a/cargo-nextest/src/dispatch/core/run.rs
+++ b/cargo-nextest/src/dispatch/core/run.rs
@@ -26,9 +26,9 @@ use nextest_runner::{
         core::ConfigExperimental,
         elements::{MaxFail, RetryPolicy, TestThreads},
     },
-    helpers::{ShowTerminalProgress, force_or_new_run_id, plural},
+    helpers::{ShowTerminalProgress, ThemeCharacters, force_or_new_run_id, plural},
     input::InputHandlerKind,
-    list::{BinaryList, TestExecuteContext, TestList},
+    list::{BinaryList, ListProgressOptions, TestExecuteContext, TestList},
     record::{
         ComputedRerunInfo, PortableRecording, RecordOpts, RecordReader, RecordRetentionPolicy,
         RecordSession, RecordSessionConfig, RerunRootInfo, RunIdOrRecordingSelector, RunIdSelector,
@@ -712,15 +712,10 @@ impl ReporterOpts {
         }
 
         // Determine show_progress with precedence: CLI/env > resolved config.
-        let show_progress = match (self.show_progress, self.hide_progress_bar) {
-            (Some(show_progress), true) => {
-                warn!("ignoring --hide-progress-bar because --show-progress is specified");
-                show_progress.into()
-            }
-            (Some(show_progress), false) => show_progress.into(),
-            (None, true) => ShowProgress::None,
-            (None, false) => resolved_ui.show_progress.into(),
-        };
+        if self.show_progress.is_some() && self.hide_progress_bar {
+            warn!("ignoring --hide-progress-bar because --show-progress is specified");
+        }
+        let show_progress = self.resolved_show_progress(resolved_ui);
 
         // Determine max_progress_running with precedence: CLI/env > resolved config.
         let max_progress_running = self
@@ -755,6 +750,14 @@ impl ReporterOpts {
         }
         builder
     }
+
+    fn resolved_show_progress(&self, resolved_ui: &UiConfig) -> ShowProgress {
+        match (self.show_progress, self.hide_progress_bar) {
+            (Some(show_progress), _) => show_progress.into(),
+            (None, true) => ShowProgress::None,
+            (None, false) => resolved_ui.show_progress.into(),
+        }
+    }
 }
 
 /// Benchmark reporter options.
@@ -780,6 +783,12 @@ pub(crate) struct BenchReporterOpts {
 }
 
 impl BenchReporterOpts {
+    fn resolved_show_progress(&self, resolved_ui: &UiConfig) -> ShowProgress {
+        self.show_progress
+            .map(ShowProgress::from)
+            .unwrap_or_else(|| resolved_ui.show_progress.into())
+    }
+
     pub(crate) fn to_builder(
         &self,
         should_colorize: bool,
@@ -789,11 +798,7 @@ impl BenchReporterOpts {
         builder.set_no_capture(true);
         builder.set_colorize(should_colorize);
         // Determine show_progress with precedence: CLI/env > resolved config.
-        let show_progress = self
-            .show_progress
-            .map(ShowProgress::from)
-            .unwrap_or(resolved_ui.show_progress.into());
-        builder.set_show_progress(show_progress);
+        builder.set_show_progress(self.resolved_show_progress(resolved_ui));
         if crate::output::should_redact() {
             builder.set_redactor(Redactor::for_snapshot_testing());
         }
@@ -851,6 +856,7 @@ impl App {
         binary_list: Arc<BinaryList>,
         test_filter: &TestFilter,
         profile: &nextest_runner::config::core::EvaluatableProfile<'_>,
+        show_progress: ShowProgress,
     ) -> Result<TestList<'_>> {
         let env = EnvironmentMap::new(&self.base.cargo_configs);
         self.build_filter.compute_test_list(
@@ -862,6 +868,24 @@ impl App {
             env,
             profile,
             &self.base.reuse_build,
+            self.list_progress_options(show_progress),
+        )
+    }
+
+    fn list_progress_options(&self, show_progress: ShowProgress) -> ListProgressOptions {
+        let is_terminal = std::io::stderr().is_terminal();
+        let show_terminal_progress =
+            ShowTerminalProgress::from_cargo_configs(&self.base.cargo_configs, is_terminal);
+        let should_colorize = self
+            .base
+            .output
+            .color
+            .should_colorize(supports_color::Stream::Stderr);
+        ListProgressOptions::new(
+            show_progress,
+            show_terminal_progress,
+            ThemeCharacters::detect(supports_unicode::Stream::Stderr),
+            should_colorize,
         )
     }
 
@@ -1014,7 +1038,13 @@ impl App {
             target_runner,
         };
 
-        let test_list = self.build_test_list(&ctx, binary_list, &test_filter, &profile)?;
+        let test_list = self.build_test_list(
+            &ctx,
+            binary_list,
+            &test_filter,
+            &profile,
+            reporter_opts.resolved_show_progress(&resolved_user_config.ui),
+        )?;
 
         // Validate interceptor mode requirements.
         if runner_opts.interceptor.is_active() {
@@ -1285,7 +1315,13 @@ impl App {
             target_runner,
         };
 
-        let test_list = self.build_test_list(&ctx, binary_list, &test_filter, &profile)?;
+        let test_list = self.build_test_list(
+            &ctx,
+            binary_list,
+            &test_filter,
+            &profile,
+            reporter_opts.resolved_show_progress(&resolved_user_config.ui),
+        )?;
 
         // Validate interceptor mode requirements.
         if runner_opts.interceptor.is_active() {

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -67,6 +67,7 @@ zstd.workspace = true
 tar.workspace = true
 
 [dev-dependencies]
+anstyle-progress.workspace = true
 camino-tempfile-ext.workspace = true
 cfg-if.workspace = true
 cp_r.workspace = true

--- a/integration-tests/tests/integration/list_progress.rs
+++ b/integration-tests/tests/integration/list_progress.rs
@@ -1,0 +1,71 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Integration tests for list progress.
+
+use crate::temp_project::TempProject;
+use anstyle_progress::TermProgress;
+use integration_tests::{env::set_env_vars_for_test, nextest_cli::CargoNextestCli};
+
+#[test]
+fn test_list_emits_terminal_progress() {
+    let env_info = set_env_vars_for_test();
+    let p = TempProject::new(&env_info).unwrap();
+
+    let output = CargoNextestCli::for_test(&env_info)
+        .env("__NEXTEST_LIST_PROGRESS_DELAY_MS", "0")
+        .env("CARGO_TERM_PROGRESS_TERM_INTEGRATION", "true")
+        .args([
+            "--manifest-path",
+            p.manifest_path().as_str(),
+            "list",
+            "--workspace",
+            "--all-targets",
+        ])
+        .output();
+
+    let completed = TermProgress::start().percent(100).to_string();
+    let removed = TermProgress::remove().to_string();
+
+    let Some(completed_pos) = find_subslice(&output.stderr, completed.as_bytes()) else {
+        panic!(
+            "stderr should contain an OSC 9;4 completion sequence:\n{}",
+            output.stderr_as_str()
+        );
+    };
+    let Some(removed_pos) = rfind_subslice(&output.stderr, removed.as_bytes()) else {
+        panic!(
+            "stderr should contain an OSC 9;4 remove sequence once listing finishes:\n{}",
+            output.stderr_as_str()
+        );
+    };
+
+    assert!(
+        completed_pos < removed_pos,
+        "the completion sequence (at byte {completed_pos}) should appear before the remove \
+         sequence (at byte {removed_pos}):\n{}",
+        output.stderr_as_str()
+    );
+
+    const OSC_9_4_INTRODUCER: &[u8] = b"\x1b]9;4;";
+    let last_osc_pos = rfind_subslice(&output.stderr, OSC_9_4_INTRODUCER)
+        .expect("an OSC 9;4 introducer exists, since the remove sequence was found above");
+    assert_eq!(
+        last_osc_pos,
+        removed_pos,
+        "the remove sequence should be the last OSC 9;4 emission on stderr:\n{}",
+        output.stderr_as_str()
+    );
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+fn rfind_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .rposition(|window| window == needle)
+}

--- a/integration-tests/tests/integration/main.rs
+++ b/integration-tests/tests/integration/main.rs
@@ -39,6 +39,7 @@ mod cargo_message_format;
 mod fixtures;
 mod interceptor;
 mod large_alloc;
+mod list_progress;
 mod record_replay;
 #[cfg(unix)]
 mod sigttou;

--- a/nextest-runner/src/helpers/progress.rs
+++ b/nextest-runner/src/helpers/progress.rs
@@ -124,6 +124,11 @@ impl TerminalProgress {
         self.last_value = value;
     }
 
+    #[cfg(test)]
+    pub(crate) fn last_value(&self) -> TermProgress {
+        self.last_value
+    }
+
     pub(crate) fn emit(&self) {
         // Use the write! macro rather than eprint! so that we ignore errors
         // rather than panicking. Terminal progress reporting is cosmetic and
@@ -157,6 +162,9 @@ mod tests {
         // We round away from zero (12.5 -> 13, 37.5 -> 38).
         assert_eq!(term_progress_percent(1, 8), 13);
         assert_eq!(term_progress_percent(3, 8), 38);
+        assert_eq!(term_progress_percent(1, 40), 3);
+        assert_eq!(term_progress_percent(1, 3), 33);
+        assert_eq!(term_progress_percent(2, 3), 67);
 
         // We stay within 0..=100 for the percentage.
         assert_eq!(term_progress_percent(11, 10), 100);

--- a/nextest-runner/src/list/mod.rs
+++ b/nextest-runner/src/list/mod.rs
@@ -12,6 +12,7 @@ mod display_filter;
 mod output_format;
 #[cfg(test)]
 mod partition_tests;
+mod progress;
 mod rust_build_meta;
 #[cfg(test)]
 mod test_helpers;
@@ -20,6 +21,8 @@ mod test_list;
 pub use binary_list::*;
 pub(crate) use display_filter::*;
 pub use output_format::*;
+pub use progress::ListProgressOptions;
+pub(crate) use progress::{ListProgressEvent, ListProgressReporter};
 pub use rust_build_meta::*;
 pub use test_list::*;
 

--- a/nextest-runner/src/list/progress.rs
+++ b/nextest-runner/src/list/progress.rs
@@ -1,0 +1,437 @@
+// Copyright (c) The nextest Contributors
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::{
+    helpers::{
+        ThemeCharacters, decimal_char_width, plural,
+        progress::{
+            PROGRESS_REFRESH_RATE_HZ, ShowTerminalProgress, TerminalProgress, progress_bar_style,
+            term_progress_percent,
+        },
+    },
+    reporter::ShowProgress,
+};
+use anstyle_progress::TermProgress;
+use indicatif::{ProgressBar, ProgressDrawTarget};
+use owo_colors::{OwoColorize, Style};
+use std::{
+    env,
+    io::{self, IsTerminal},
+    time::{Duration, Instant},
+};
+
+const LIST_PROGRESS_REVEAL_DELAY: Duration = Duration::from_secs(2);
+
+const LIST_PROGRESS_TICK_INTERVAL: Duration = Duration::from_millis(100);
+
+const LIST_PROGRESS_DELAY_ENV: &str = "__NEXTEST_LIST_PROGRESS_DELAY_MS";
+
+pub(crate) enum ListProgressEvent {
+    Tick,
+    BinaryProcessed,
+}
+
+/// Options for the list progress reporter.
+#[derive(Debug)]
+pub struct ListProgressOptions {
+    show_progress: ShowProgress,
+    show_terminal_progress: ShowTerminalProgress,
+    theme_characters: ThemeCharacters,
+    should_colorize: bool,
+}
+
+impl ListProgressOptions {
+    /// Creates a new set of list progress reporter options.
+    pub fn new(
+        show_progress: ShowProgress,
+        show_terminal_progress: ShowTerminalProgress,
+        theme_characters: ThemeCharacters,
+        should_colorize: bool,
+    ) -> Self {
+        Self {
+            show_progress,
+            show_terminal_progress,
+            theme_characters,
+            should_colorize,
+        }
+    }
+}
+
+pub(crate) struct ListProgressReporter {
+    bar: Option<ProgressBar>,
+    term_progress: Option<TerminalProgress>,
+    total: usize,
+    listed: usize,
+    state: RevealState,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum RevealState {
+    Hidden { start: Instant, delay: Duration },
+    Revealed,
+    Finished,
+}
+
+impl ListProgressReporter {
+    pub(crate) fn new(total: usize, options: &ListProgressOptions) -> Self {
+        let is_terminal = io::stderr().is_terminal();
+        let is_ci = is_ci::uncached();
+        let bar = list_bar_enabled(options.show_progress, is_terminal, is_ci).then(|| {
+            make_bar(
+                total,
+                options.theme_characters.progress_chars(),
+                options.should_colorize,
+            )
+        });
+        let term_progress = TerminalProgress::new(options.show_terminal_progress);
+        Self::from_parts(total, bar, term_progress, reveal_delay_from_env())
+    }
+
+    fn from_parts(
+        total: usize,
+        bar: Option<ProgressBar>,
+        term_progress: Option<TerminalProgress>,
+        reveal_delay: Duration,
+    ) -> Self {
+        Self {
+            bar,
+            term_progress,
+            total,
+            listed: 0,
+            state: RevealState::Hidden {
+                start: Instant::now(),
+                delay: reveal_delay,
+            },
+        }
+    }
+
+    pub(crate) fn tick_interval(&self) -> Duration {
+        LIST_PROGRESS_TICK_INTERVAL
+    }
+
+    pub(crate) fn handle_event(&mut self, event: ListProgressEvent) {
+        match event {
+            ListProgressEvent::BinaryProcessed => {
+                self.listed += 1;
+                debug_assert!(
+                    self.listed <= self.total,
+                    "at most {} binaries can be processed, but saw {}",
+                    self.total,
+                    self.listed,
+                );
+                if let Some(bar) = &self.bar {
+                    bar.inc(1);
+                }
+                if self.is_revealed() {
+                    // Terminal progress doesn't have a timer, so re-emit it
+                    // only when we learn that a new binary has been listed.
+                    //
+                    // Worth noting that we do not install a signal handler
+                    // during this phase, so in case of a Ctrl-C we don't clear
+                    // terminal progress. A signal handler is quite tricky here
+                    // and adds complexity for minimal benefit (unlike at
+                    // runtime, where signals are part of the test lifecycle
+                    // state machine).
+                    let value = self.current_term_progress();
+                    self.emit_terminal_progress(value);
+                }
+            }
+            ListProgressEvent::Tick => {
+                if let RevealState::Hidden { start, delay } = self.state
+                    && start.elapsed() >= delay
+                {
+                    self.reveal();
+                }
+                if self.is_revealed()
+                    && let Some(bar) = &self.bar
+                {
+                    // Force a redraw each tick so the elapsed timer advances.
+                    bar.force_draw();
+                }
+            }
+        }
+    }
+
+    fn finish(&mut self) {
+        let was_revealed = match self.state {
+            RevealState::Hidden { .. } => false,
+            RevealState::Revealed => true,
+            RevealState::Finished => return,
+        };
+        self.state = RevealState::Finished;
+        if let Some(bar) = &self.bar {
+            bar.finish_and_clear();
+        }
+        if was_revealed {
+            self.emit_terminal_progress(TermProgress::remove());
+        }
+    }
+
+    fn reveal(&mut self) {
+        self.state = RevealState::Revealed;
+        if let Some(bar) = &self.bar {
+            bar.set_draw_target(ProgressDrawTarget::stderr_with_hz(PROGRESS_REFRESH_RATE_HZ));
+        }
+        let value = self.current_term_progress();
+        self.emit_terminal_progress(value);
+    }
+
+    fn emit_terminal_progress(&mut self, value: TermProgress) {
+        if let Some(term_progress) = &mut self.term_progress {
+            term_progress.set(value);
+            term_progress.emit();
+        }
+    }
+
+    fn current_term_progress(&self) -> TermProgress {
+        TermProgress::start().percent(term_progress_percent(self.listed, self.total))
+    }
+
+    fn is_revealed(&self) -> bool {
+        match self.state {
+            RevealState::Revealed => true,
+            RevealState::Hidden { .. } | RevealState::Finished => false,
+        }
+    }
+}
+
+impl Drop for ListProgressReporter {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
+fn list_bar_enabled(show_progress: ShowProgress, is_terminal: bool, is_ci: bool) -> bool {
+    match show_progress {
+        ShowProgress::Auto { .. } | ShowProgress::Running => is_terminal && !is_ci,
+        ShowProgress::Counter | ShowProgress::None => false,
+    }
+}
+
+fn make_bar(total: usize, progress_chars: &str, should_colorize: bool) -> ProgressBar {
+    let styles = ListProgressStyles::new(should_colorize);
+    let bar = ProgressBar::new(total as u64);
+    // We start with the progress bar being hidden, and only reveal it after the
+    // delay. This makes fast listings be silent while showing progress for
+    // slower ones.
+    bar.set_draw_target(ProgressDrawTarget::hidden());
+    let count_width = decimal_char_width(total);
+    let suffix = format!("{{pos:>{count_width}}}/{{len:{count_width}}} {{msg}}");
+    bar.set_style(progress_bar_style(progress_chars, &suffix));
+    bar.set_prefix("Listing".style(styles.label).to_string());
+    bar.set_message(plural::binaries_str(total).style(styles.label).to_string());
+    bar
+}
+
+struct ListProgressStyles {
+    label: Style,
+}
+
+impl ListProgressStyles {
+    fn new(should_colorize: bool) -> Self {
+        let label = if should_colorize {
+            Style::new().green().bold()
+        } else {
+            Style::new()
+        };
+        Self { label }
+    }
+}
+
+fn reveal_delay_from_env() -> Duration {
+    let Some(raw) = env::var_os(LIST_PROGRESS_DELAY_ENV) else {
+        return LIST_PROGRESS_REVEAL_DELAY;
+    };
+    let raw = raw.to_str().unwrap_or_else(|| {
+        panic!("{LIST_PROGRESS_DELAY_ENV} contains non-UTF-8 bytes");
+    });
+    let ms: u64 = raw.parse().unwrap_or_else(|err| {
+        panic!(
+            "{LIST_PROGRESS_DELAY_ENV}={raw:?} is not a valid number of \
+             milliseconds: {err}"
+        )
+    });
+    Duration::from_millis(ms)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn enabled_reporter(total: usize, reveal_delay: Duration) -> ListProgressReporter {
+        ListProgressReporter::from_parts(
+            total,
+            Some(make_bar(total, "=> ", false)),
+            None,
+            reveal_delay,
+        )
+    }
+
+    #[test]
+    fn list_bar_enabled_gating() {
+        let bar_modes = [
+            ShowProgress::Auto {
+                suppress_success: false,
+            },
+            ShowProgress::Auto {
+                suppress_success: true,
+            },
+            ShowProgress::Running,
+        ];
+        for mode in bar_modes {
+            assert!(
+                list_bar_enabled(mode, true, false),
+                "{mode:?}: interactive terminal shows a bar"
+            );
+            assert!(
+                !list_bar_enabled(mode, false, false),
+                "{mode:?}: piped output shows no bar"
+            );
+            assert!(
+                !list_bar_enabled(mode, true, true),
+                "{mode:?}: CI shows no bar"
+            );
+            assert!(
+                !list_bar_enabled(mode, false, true),
+                "{mode:?}: piped in CI shows no bar"
+            );
+        }
+
+        for mode in [ShowProgress::Counter, ShowProgress::None] {
+            for is_terminal in [true, false] {
+                for is_ci in [true, false] {
+                    assert!(
+                        !list_bar_enabled(mode, is_terminal, is_ci),
+                        "{mode:?} never shows a list bar"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn bar_hidden_until_reveal_delay() {
+        let mut reporter = enabled_reporter(10, Duration::MAX);
+        assert!(!reporter.is_revealed(), "the bar starts unrevealed");
+
+        reporter.handle_event(ListProgressEvent::Tick);
+        assert!(
+            !reporter.is_revealed(),
+            "the bar is not revealed before the reveal delay elapses"
+        );
+
+        let mut reporter = enabled_reporter(10, Duration::ZERO);
+        assert!(!reporter.is_revealed(), "the bar starts unrevealed");
+
+        reporter.handle_event(ListProgressEvent::Tick);
+        assert!(
+            reporter.is_revealed(),
+            "the bar is revealed once the reveal delay elapses"
+        );
+    }
+
+    #[test]
+    fn binary_processed_advances_position() {
+        let mut reporter = enabled_reporter(4, Duration::MAX);
+        let bar = reporter.bar.as_ref().expect("bar is enabled").clone();
+        assert_eq!(bar.position(), 0);
+
+        reporter.handle_event(ListProgressEvent::BinaryProcessed);
+        reporter.handle_event(ListProgressEvent::BinaryProcessed);
+
+        assert_eq!(bar.position(), 2);
+        assert_eq!(reporter.listed, 2);
+    }
+
+    fn terminal_only_reporter(total: usize, reveal_delay: Duration) -> ListProgressReporter {
+        let term_progress = TerminalProgress::new(ShowTerminalProgress::Yes)
+            .expect("Yes yields a terminal progress reporter");
+        ListProgressReporter::from_parts(total, None, Some(term_progress), reveal_delay)
+    }
+
+    fn last_osc(reporter: &ListProgressReporter) -> String {
+        reporter
+            .term_progress
+            .as_ref()
+            .expect("terminal progress is enabled")
+            .last_value()
+            .to_string()
+    }
+
+    #[test]
+    fn terminal_progress_silent_until_revealed() {
+        let mut reporter = terminal_only_reporter(4, Duration::MAX);
+
+        reporter.handle_event(ListProgressEvent::BinaryProcessed);
+        reporter.handle_event(ListProgressEvent::BinaryProcessed);
+        reporter.handle_event(ListProgressEvent::Tick);
+        assert!(
+            last_osc(&reporter).is_empty(),
+            "no OSC value is emitted before the reveal delay"
+        );
+
+        reporter.finish();
+        assert!(
+            last_osc(&reporter).is_empty(),
+            "a listing that never revealed emits no Remove"
+        );
+    }
+
+    #[test]
+    fn terminal_progress_emits_after_reveal() {
+        let mut reporter = terminal_only_reporter(4, Duration::ZERO);
+
+        reporter.handle_event(ListProgressEvent::BinaryProcessed);
+        reporter.handle_event(ListProgressEvent::BinaryProcessed);
+        assert!(
+            last_osc(&reporter).is_empty(),
+            "no OSC value is emitted before the first tick reveals"
+        );
+
+        reporter.handle_event(ListProgressEvent::Tick);
+        assert!(reporter.is_revealed());
+        assert_eq!(
+            last_osc(&reporter),
+            TermProgress::start().percent(50).to_string(),
+            "reveal emits the current percentage"
+        );
+
+        reporter.handle_event(ListProgressEvent::BinaryProcessed);
+        assert_eq!(
+            last_osc(&reporter),
+            TermProgress::start().percent(75).to_string(),
+            "a subsequent binary re-emits the updated percentage"
+        );
+
+        reporter.finish();
+        assert_eq!(
+            last_osc(&reporter),
+            TermProgress::remove().to_string(),
+            "finish emits Remove once revealed"
+        );
+    }
+
+    #[test]
+    fn reveal_delay_from_env_values() {
+        unsafe { env::remove_var(LIST_PROGRESS_DELAY_ENV) };
+        assert_eq!(
+            reveal_delay_from_env(),
+            LIST_PROGRESS_REVEAL_DELAY,
+            "an unset variable falls back to the default delay"
+        );
+
+        unsafe { env::set_var(LIST_PROGRESS_DELAY_ENV, "250") };
+        assert_eq!(
+            reveal_delay_from_env(),
+            Duration::from_millis(250),
+            "a valid value is parsed as milliseconds"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "is not a valid number of milliseconds")]
+    fn reveal_delay_from_env_panics_on_malformed_value() {
+        unsafe { env::set_var(LIST_PROGRESS_DELAY_ENV, "0ms") };
+        reveal_delay_from_env();
+    }
+}

--- a/nextest-runner/src/list/test_list.rs
+++ b/nextest-runner/src/list/test_list.rs
@@ -15,7 +15,10 @@ use crate::{
     },
     helpers::{convert_build_platform, dylib_path, dylib_path_envvar, write_test_name},
     indenter::indented,
-    list::{BinaryList, OutputFormat, RustBuildMeta, Styles, TestListState},
+    list::{
+        BinaryList, ListProgressEvent, ListProgressOptions, ListProgressReporter, OutputFormat,
+        RustBuildMeta, Styles, TestListState,
+    },
     partition::{Partitioner, PartitionerBuilder, PartitionerScope},
     reuse_build::PathMapper,
     run_mode::NextestRunMode,
@@ -53,7 +56,7 @@ use std::{
     sync::{Arc, OnceLock},
 };
 use swrite::{SWrite, swrite};
-use tokio::runtime::Runtime;
+use tokio::{runtime::Runtime, time::MissedTickBehavior};
 use tracing::debug;
 
 /// A Rust test binary built by Cargo. This artifact hasn't been run yet so there's no information
@@ -259,6 +262,7 @@ impl<'g> TestList<'g> {
         profile: &impl ListProfile,
         bound: FilterBound,
         list_threads: usize,
+        list_progress_options: ListProgressOptions,
     ) -> Result<Self, CreateTestListError>
     where
         I: IntoIterator<Item = RustTestArtifact<'g>>,
@@ -286,50 +290,84 @@ impl<'g> TestList<'g> {
 
         let ecx = profile.filterset_ecx();
 
-        let runtime = Runtime::new().map_err(CreateTestListError::TokioRuntimeCreate)?;
+        let test_artifacts: Vec<RustTestArtifact<'g>> = test_artifacts.into_iter().collect();
+        let parsed_binaries: Vec<ParsedTestBinary<'g>> = if test_artifacts.is_empty() {
+            // No binaries to list, so skip all the fancy setup and progress
+            // reporting done in the event loop below.
+            Vec::new()
+        } else {
+            let mut list_progress =
+                ListProgressReporter::new(test_artifacts.len(), &list_progress_options);
 
-        // Phase 1: run test binaries and parse their output. Binary-level
-        // filtering decides which binaries to execute; test-level filtering is
-        // deferred to a separate sequential phase below.
-        let stream = futures::stream::iter(test_artifacts).map(|test_binary| {
-            async {
-                let binary_query = test_binary.to_binary_query();
-                let binary_match = filter.filter_binary_match(&binary_query, &ecx, bound);
-                match binary_match {
-                    FilterBinaryMatch::Definite | FilterBinaryMatch::Possible => {
-                        debug!(
-                            "executing test binary to obtain test list \
+            let runtime = Runtime::new().map_err(CreateTestListError::TokioRuntimeCreate)?;
+
+            // Phase 1: run test binaries and parse their output. Binary-level
+            // filtering decides which binaries to execute; test-level filtering is
+            // deferred to a separate sequential phase below.
+            let stream = futures::stream::iter(test_artifacts).map(|test_binary| {
+                async {
+                    let binary_query = test_binary.to_binary_query();
+                    let binary_match = filter.filter_binary_match(&binary_query, &ecx, bound);
+                    match binary_match {
+                        FilterBinaryMatch::Definite | FilterBinaryMatch::Possible => {
+                            debug!(
+                                "executing test binary to obtain test list \
                             (match result is {binary_match:?}): {}",
-                            test_binary.binary_id,
-                        );
-                        // Run the binary to obtain the test list.
-                        let list_settings = profile.list_settings_for(&binary_query);
-                        let (non_ignored, ignored) = test_binary
-                            .exec(&lctx, &list_settings, ctx.target_runner)
-                            .await?;
-                        let parsed = Self::parse_output(
-                            test_binary,
-                            non_ignored.as_str(),
-                            ignored.as_str(),
-                        )?;
-                        Ok::<_, CreateTestListError>(parsed)
-                    }
-                    FilterBinaryMatch::Mismatch { reason } => {
-                        debug!("skipping test binary: {reason}: {}", test_binary.binary_id,);
-                        Ok(Self::make_skipped(test_binary, reason))
+                                test_binary.binary_id,
+                            );
+                            // Run the binary to obtain the test list.
+                            let list_settings = profile.list_settings_for(&binary_query);
+                            let (non_ignored, ignored) = test_binary
+                                .exec(&lctx, &list_settings, ctx.target_runner)
+                                .await?;
+                            let parsed = Self::parse_output(
+                                test_binary,
+                                non_ignored.as_str(),
+                                ignored.as_str(),
+                            )?;
+                            Ok::<_, CreateTestListError>(parsed)
+                        }
+                        FilterBinaryMatch::Mismatch { reason } => {
+                            debug!("skipping test binary: {reason}: {}", test_binary.binary_id,);
+                            Ok(Self::make_skipped(test_binary, reason))
+                        }
                     }
                 }
-            }
-        });
-        let fut = stream
-            .buffer_unordered(list_threads)
-            .try_collect::<Vec<_>>();
+            });
+            let tick_interval = list_progress.tick_interval();
 
-        let parsed_binaries: Vec<ParsedTestBinary<'g>> = runtime.block_on(fut)?;
+            let result: Result<Vec<ParsedTestBinary<'g>>, CreateTestListError> =
+                runtime.block_on(async {
+                    let buffered = stream.buffer_unordered(list_threads);
+                    futures::pin_mut!(buffered);
+                    let mut interval = tokio::time::interval(tick_interval);
+                    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+                    let mut parsed = Vec::new();
+                    loop {
+                        tokio::select! {
+                            item = buffered.next() => match item {
+                                Some(res) => {
+                                    parsed.push(res?);
+                                    list_progress.handle_event(ListProgressEvent::BinaryProcessed);
+                                }
+                                None => break,
+                            },
+                            _ = interval.tick() => {
+                                list_progress.handle_event(ListProgressEvent::Tick);
+                            }
+                        }
+                    }
+                    Ok(parsed)
+                });
 
-        // Ensure that the runtime doesn't stay hanging even if a custom test framework misbehaves
-        // (can be an issue on Windows).
-        runtime.shutdown_background();
+            // Ensure that the runtime doesn't stay hanging even if a custom test framework misbehaves
+            // (can be an issue on Windows).
+            runtime.shutdown_background();
+            // Dropping clears the list progress bar.
+            drop(list_progress);
+
+            result?
+        };
 
         // Phase 2: apply test-level filters and build suites.
         //


### PR DESCRIPTION
In some cases, particularly around slow antivirus/XProtect, listing tests can be painfully slow without obvious feedback as to why. Provide a progress bar as feedback after 2 seconds.