### PR TITLE
update quick-junit to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3326,9 +3326,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-junit"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8216516c957e00535b3c91770524c219dd7df90dec439a182547f750dfe41591"
+checksum = "3eba1124f9c87c1b2f9e9665f0519ca75b09f9a5504e42e72d23cad8da63b52f"
 dependencies = [
  "chrono",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ pin-project-lite = "0.2.17"
 pretty_assertions = "1.4.1"
 proptest = "1.11.0"
 pulldown-cmark = { version = "0.13.4", default-features = false }
-quick-junit = "0.6.1"
+quick-junit = "0.7.0"
 rand = "0.10.2"
 recursion = "0.5.4"
 regex = "1.12.4"


### PR DESCRIPTION
Has better support for skipped test counts.