### PR TITLE
[nextest-metadata] add MismatchReason::is_substantive_skip

### DIFF
--- a/nextest-metadata/src/test_list.rs
+++ b/nextest-metadata/src/test_list.rs
@@ -1000,6 +1000,21 @@ impl MismatchReason {
         Self::RerunAlreadyPassed,
         Self::DefaultFilter,
     ];
+
+    /// Returns true if the skip reflects a real filtering decision, rather than
+    /// a run-mode artifact such as a non-benchmark test excluded from a
+    /// benchmark run.
+    pub fn is_substantive_skip(self) -> bool {
+        match self {
+            MismatchReason::NotBenchmark => false,
+            MismatchReason::Ignored
+            | MismatchReason::String
+            | MismatchReason::Expression
+            | MismatchReason::Partition
+            | MismatchReason::RerunAlreadyPassed
+            | MismatchReason::DefaultFilter => true,
+        }
+    }
 }
 
 impl fmt::Display for MismatchReason {
@@ -1167,5 +1182,18 @@ mod tests {
 
         // If you add a variant, update ALL_VARIANTS and this count.
         assert_eq!(MismatchReason::ALL_VARIANTS.len(), 7);
+    }
+
+    #[test]
+    fn is_substantive_skip_only_excludes_not_benchmark() {
+        assert!(!MismatchReason::NotBenchmark.is_substantive_skip());
+        for &reason in MismatchReason::ALL_VARIANTS {
+            if reason != MismatchReason::NotBenchmark {
+                assert!(
+                    reason.is_substantive_skip(),
+                    "{reason:?} is a substantive skip"
+                );
+            }
+        }
     }
 }

--- a/nextest-runner/src/list/test_list.rs
+++ b/nextest-runner/src/list/test_list.rs
@@ -578,25 +578,17 @@ impl<'g> TestList<'g> {
             let skipped_tests = self
                 .iter_tests()
                 .filter(|instance| match instance.test_info.filter_match {
-                    FilterMatch::Mismatch {
-                        reason: MismatchReason::RerunAlreadyPassed,
-                    } => {
-                        skipped_tests_rerun += 1;
+                    FilterMatch::Mismatch { reason } => {
+                        if !reason.is_substantive_skip() {
+                            skipped_tests_non_benchmark += 1;
+                        }
+                        match reason {
+                            MismatchReason::RerunAlreadyPassed => skipped_tests_rerun += 1,
+                            MismatchReason::DefaultFilter => skipped_tests_default_filter += 1,
+                            _ => {}
+                        }
                         true
                     }
-                    FilterMatch::Mismatch {
-                        reason: MismatchReason::NotBenchmark,
-                    } => {
-                        skipped_tests_non_benchmark += 1;
-                        true
-                    }
-                    FilterMatch::Mismatch {
-                        reason: MismatchReason::DefaultFilter,
-                    } => {
-                        skipped_tests_default_filter += 1;
-                        true
-                    }
-                    FilterMatch::Mismatch { .. } => true,
                     FilterMatch::Matches => false,
                 })
                 .count();

--- a/nextest-runner/src/runner/dispatcher.rs
+++ b/nextest-runner/src/runner/dispatcher.rs
@@ -33,7 +33,6 @@ use chrono::Local;
 use debug_ignore::DebugIgnore;
 use futures::future::{Fuse, FusedFuture};
 use iddqd::{IdOrdItem, IdOrdMap, id_upcast};
-use nextest_metadata::MismatchReason;
 use quick_junit::ReportUuid;
 use std::{collections::BTreeSet, env, mem, pin::Pin, time::Duration};
 use tokio::{
@@ -843,10 +842,7 @@ where
                 test_instance,
                 reason,
             }) => {
-                // If the mismatch reason is that this test isn't a benchmark,
-                // we don't display it in the skip counts (but still keep track
-                // of it internally).
-                if !matches!(reason, MismatchReason::NotBenchmark) {
+                if reason.is_substantive_skip() {
                     self.run_stats.skipped += 1;
                 }
                 self.callback_none_response(TestEventKind::TestSkipped {


### PR DESCRIPTION
Going to use this in #3472.

This is pure refactoring with no functional changes.