### PR TITLE
[nextest-runner] support cargo config `include` key

### DIFF
--- a/fixtures/fixture-project/.cargo/config
+++ b/fixtures/fixture-project/.cargo/config
@@ -1,3 +1,7 @@
+# Pull in an additional config file to exercise nextest's support for Cargo's
+# `include` key. The included file defines an [env] variable that tests assert on.
+include = ["included-config.toml"]
+
 [target.x86_64-pc-windows-gnu]
 runner = "wine"
 
@@ -12,6 +16,9 @@ CONFIG_WORKSPACE_DIR = { value = "", relative = true }
 
 CMD_ENV_VAR = { value = "test-value-set-by-main-config" }
 CMD_ENV_VAR_CARGO = { value = "test-value-set-by-main-config", force = true }
+
+# Defined in both the main config and the included config; the main config wins.
+__NEXTEST_TESTING_INCLUDED_CONFIG_OVERRIDDEN_BY_MAIN = "test-PASSED-value-set-by-main-config"
 
 __NEXTEST_ENV_VAR_FOR_TESTING_NOT_IN_PARENT_ENV = "test-PASSED-value-set-by-main-config"
 __NEXTEST_ENV_VAR_FOR_TESTING_IN_PARENT_ENV_NO_OVERRIDE = "test-FAILED-value-set-by-main-config"

--- a/fixtures/fixture-project/.cargo/included-config.toml
+++ b/fixtures/fixture-project/.cargo/included-config.toml
@@ -1,0 +1,9 @@
+# This file is pulled in via the `include` key in .cargo/config. It exists to
+# test that nextest honors Cargo's config `include` directive.
+[env]
+# A variable defined only in this included file.
+__NEXTEST_TESTING_INCLUDED_CONFIG = "test-PASSED-value-set-by-included-config"
+
+# A variable also defined in the main config; the main (including) config takes
+# precedence over this included file, so the test expects the main config's value.
+__NEXTEST_TESTING_INCLUDED_CONFIG_OVERRIDDEN_BY_MAIN = "test-FAILED-value-set-by-included-config"

--- a/fixtures/fixture-project/tests/basic.rs
+++ b/fixtures/fixture-project/tests/basic.rs
@@ -325,6 +325,19 @@ fn test_cargo_env_vars() {
             std::env::var("__NEXTEST_TESTING_EXTRA_CONFIG_OVERRIDE_FORCE_FALSE").as_deref(),
             Ok("test-PASSED-value-set-by-environment"),
         );
+
+        // A variable defined only in a file pulled in via the `include` key in
+        // .cargo/config should be picked up.
+        assert_eq!(
+            std::env::var("__NEXTEST_TESTING_INCLUDED_CONFIG").as_deref(),
+            Ok("test-PASSED-value-set-by-included-config"),
+        );
+        // A variable defined in both the main config and the included config:
+        // the including (main) config takes precedence over the included file.
+        assert_eq!(
+            std::env::var("__NEXTEST_TESTING_INCLUDED_CONFIG_OVERRIDDEN_BY_MAIN").as_deref(),
+            Ok("test-PASSED-value-set-by-main-config"),
+        );
     }
 
     // Since this test doesn't have a build script, assert that OUT_DIR isn't present at either

--- a/nextest-runner/src/cargo_config/discovery.rs
+++ b/nextest-runner/src/cargo_config/discovery.rs
@@ -3,8 +3,15 @@
 
 use crate::errors::{CargoConfigError, CargoConfigParseError, InvalidCargoCliConfigReason};
 use camino::{Utf8Path, Utf8PathBuf};
-use serde::Deserialize;
-use std::collections::BTreeMap;
+use itertools::Itertools;
+use serde::{
+    Deserialize,
+    de::{self, MapAccess, Visitor, value::MapAccessDeserializer},
+};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt, io,
+};
 use toml_edit::Item;
 use tracing::debug;
 
@@ -167,20 +174,20 @@ fn parse_cli_configs(
     cli_configs: impl Iterator<Item = impl AsRef<str>>,
 ) -> Result<Vec<(CargoConfigSource, CargoConfig)>, CargoConfigError> {
     cli_configs
-        .into_iter()
         .map(|config_str| {
             // Each cargo config is expected to be a valid TOML file.
             let config_str = config_str.as_ref();
 
             let as_path = cwd.join(config_str);
             if as_path.exists() {
-                // Read this config as a file.
+                // Read this config as a file, expanding any files it includes.
                 load_file(as_path)
             } else {
                 let config = parse_cli_config(config_str)?;
-                Ok((CargoConfigSource::CliOption, config))
+                Ok(vec![(CargoConfigSource::CliOption, config)])
             }
         })
+        .flatten_ok()
         .collect()
 }
 
@@ -354,21 +361,52 @@ fn discover_impl(
         }
     }
 
-    let configs = config_paths
+    config_paths
         .into_iter()
         .map(load_file)
-        .collect::<Result<Vec<_>, CargoConfigError>>()?;
-
-    Ok(configs)
+        .flatten_ok()
+        .collect()
 }
 
+/// Loads a config file and, recursively, any files it includes via the `include` key.
+///
+/// The returned configs are in precedence order, highest first, matching the order expected by
+/// [`CargoConfigs::discovered_configs`]: a config file's own values take precedence over the files
+/// it includes, and among included files, those listed later take precedence over those listed
+/// earlier. Includes are resolved depth-first, so a file's entire include subtree outranks the next
+/// sibling include.
+///
+/// Errors if any file is reached more than once while resolving this file's includes, matching
+/// Cargo. For example, if `a` includes `b` and `c`, and `b` also includes `c`, then `c` is reached
+/// twice and is rejected. Each call tracks reached files independently, so the same file included
+/// from two separate top-level config files (e.g. at different hierarchy levels) is fine.
 fn load_file(
     path: impl Into<Utf8PathBuf>,
-) -> Result<(CargoConfigSource, CargoConfig), CargoConfigError> {
+) -> Result<Vec<(CargoConfigSource, CargoConfig)>, CargoConfigError> {
     let path = path.into();
     let path = path
         .canonicalize_utf8()
         .map_err(|error| CargoConfigError::FailedPathCanonicalization { path, error })?;
+
+    // `seen` is traversal bookkeeping shared across the whole include tree, so it is threaded
+    // through by mutable reference. The loaded configs, in contrast, are returned by each call and
+    // concatenated by the caller.
+    let mut seen = BTreeSet::new();
+    load_file_impl(path, &mut seen)
+}
+
+/// Loads a single already-canonicalized config file and its includes, returning them in precedence
+/// order (highest first).
+///
+/// `seen` tracks the paths reached so far across the entire include tree, so that a file reached
+/// more than once (via a cycle or multiple include paths) is rejected.
+fn load_file_impl(
+    path: Utf8PathBuf,
+    seen: &mut BTreeSet<Utf8PathBuf>,
+) -> Result<Vec<(CargoConfigSource, CargoConfig)>, CargoConfigError> {
+    if !seen.insert(path.clone()) {
+        return Err(CargoConfigError::IncludeReachedTwice { path });
+    }
 
     let config_contents =
         std::fs::read_to_string(&path).map_err(|error| CargoConfigError::ConfigReadError {
@@ -381,7 +419,56 @@ fn load_file(
             error,
         }))
     })?;
-    Ok((CargoConfigSource::File(path), config))
+
+    // The directory containing this config file. Include paths are resolved relative to it.
+    let config_dir = path
+        .parent()
+        .expect("a canonicalized config file path has a parent directory")
+        .to_owned();
+    let includes = config.include.clone();
+
+    // This config's own values take precedence over anything it includes, so it comes first.
+    let mut configs = vec![(CargoConfigSource::File(path.clone()), config)];
+
+    // Then each include in reverse listed order: a later include takes precedence over an earlier
+    // one, and higher precedence comes first, so the last include (and its subtree) is appended
+    // before earlier ones. Each include's own subtree is resolved fully before the next sibling.
+    for include in includes.into_iter().rev() {
+        if !include.path.ends_with(".toml") {
+            return Err(CargoConfigError::IncludePathNotToml {
+                path: include.path,
+                included_from: path.clone(),
+            });
+        }
+
+        let include_path = config_dir.join(&include.path);
+        let canonicalized = match include_path.canonicalize_utf8() {
+            Ok(canonicalized) => canonicalized,
+            Err(error) if include.optional && error.kind() == io::ErrorKind::NotFound => {
+                // Optional includes silently skip missing files, matching Cargo.
+                continue;
+            }
+            Err(error) => {
+                return Err(CargoConfigError::FailedPathCanonicalization {
+                    path: include_path,
+                    error,
+                });
+            }
+        };
+
+        // Wrap any failure with the include that led to it, building up a chain of `include` keys
+        // that mirrors Cargo's nested diagnostics.
+        let included = load_file_impl(canonicalized, seen).map_err(|error| {
+            CargoConfigError::FailedToLoadInclude {
+                path: include.path,
+                included_from: path.clone(),
+                error: Box::new(error),
+            }
+        })?;
+        configs.extend(included);
+    }
+
+    Ok(configs)
 }
 
 #[derive(Clone, Deserialize, Debug)]
@@ -420,6 +507,10 @@ impl CargoConfigEnv {
 
 #[derive(Deserialize, Debug)]
 pub(crate) struct CargoConfig {
+    /// Additional config files to load, per Cargo's `include` key. See
+    /// <https://doc.rust-lang.org/cargo/reference/config.html#config-in-external-files>.
+    #[serde(default)]
+    pub(crate) include: Vec<CargoConfigInclude>,
     #[serde(default)]
     pub(crate) build: CargoConfigBuild,
     pub(crate) target: Option<BTreeMap<String, CargoConfigRunner>>,
@@ -427,6 +518,73 @@ pub(crate) struct CargoConfig {
     pub(crate) env: BTreeMap<String, CargoConfigEnv>,
     #[serde(default)]
     pub(crate) term: CargoConfigTerm,
+}
+
+/// A single entry in a Cargo config `include` list.
+///
+/// Each entry is either a bare path string or a table with `path` and optional `optional` keys. See
+/// <https://doc.rust-lang.org/cargo/reference/config.html#including-extra-configuration-files>.
+#[derive(Clone, Debug)]
+pub(crate) struct CargoConfigInclude {
+    /// The path to the config file to include, relative to the directory containing the config file
+    /// that specifies it.
+    pub(crate) path: String,
+
+    /// If `true`, a missing include file is silently skipped rather than being treated as an error.
+    pub(crate) optional: bool,
+}
+
+impl<'de> Deserialize<'de> for CargoConfigInclude {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Cargo accepts either a bare string or a `{ path, optional }` table for each include entry.
+        // A custom visitor is used rather than `#[serde(untagged)]` to produce clearer error
+        // messages.
+        struct IncludeVisitor;
+
+        impl<'de> Visitor<'de> for IncludeVisitor {
+            type Value = CargoConfigInclude;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str(
+                    "a config include path (a string, or a table with a `path` key \
+                     and an optional `optional` key)",
+                )
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(CargoConfigInclude {
+                    path: value.to_owned(),
+                    optional: false,
+                })
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                // The table form of an include entry.
+                #[derive(Deserialize)]
+                struct IncludeTable {
+                    path: String,
+                    #[serde(default)]
+                    optional: bool,
+                }
+                let table = IncludeTable::deserialize(MapAccessDeserializer::new(map))?;
+                Ok(CargoConfigInclude {
+                    path: table.path,
+                    optional: table.optional,
+                })
+            }
+        }
+
+        deserializer.deserialize_any(IncludeVisitor)
+    }
 }
 
 #[derive(Deserialize, Default, Debug)]
@@ -464,6 +622,7 @@ pub(crate) struct CargoConfigTermProgress {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{cargo_config::test_helpers::write_config, errors::DisplayErrorChain};
     use test_case::test_case;
 
     #[test]
@@ -531,5 +690,243 @@ mod tests {
             expected_reason, actual_reason,
             "expected reason for failure doesn't match actual reason"
         );
+    }
+
+    #[test]
+    fn test_include_deserialize() {
+        // Bare string form.
+        let config: CargoConfig = toml::from_str(r#"include = ["a.toml", "b.toml"]"#).unwrap();
+        assert_eq!(config.include.len(), 2);
+        assert_eq!(config.include[0].path, "a.toml");
+        assert!(!config.include[0].optional);
+        assert_eq!(config.include[1].path, "b.toml");
+
+        // Table form, with and without `optional`.
+        let config: CargoConfig = toml::from_str(
+            r#"include = [{ path = "a.toml" }, { path = "b.toml", optional = true }]"#,
+        )
+        .unwrap();
+        assert_eq!(config.include[0].path, "a.toml");
+        assert!(!config.include[0].optional);
+        assert_eq!(config.include[1].path, "b.toml");
+        assert!(config.include[1].optional);
+
+        // Mixed string and table forms.
+        let config: CargoConfig =
+            toml::from_str(r#"include = ["a.toml", { path = "b.toml", optional = true }]"#)
+                .unwrap();
+        assert_eq!(config.include[0].path, "a.toml");
+        assert!(config.include[1].optional);
+
+        // Missing `path` in a table is an error.
+        toml::from_str::<CargoConfig>(r#"include = [{ optional = true }]"#)
+            .expect_err("table include without `path` should fail");
+
+        // Unknown keys in a table is ignored.
+        let config: CargoConfig =
+            toml::from_str(r#"include = [{ path = "a.toml", nope = true }]"#).unwrap();
+        assert_eq!(config.include[0].path, "a.toml");
+    }
+
+    /// Peels [`CargoConfigError::FailedToLoadInclude`] wrappers off an error, returning the
+    /// innermost cause. Errors from inside an include are wrapped in one such layer per include hop.
+    fn innermost_cause(error: &CargoConfigError) -> &CargoConfigError {
+        let mut error = error;
+        while let CargoConfigError::FailedToLoadInclude { error: inner, .. } = error {
+            error = inner;
+        }
+        error
+    }
+
+    /// Loads the config at `<dir>/.cargo/config.toml` and returns the config sources in precedence
+    /// order (highest first), relative to `dir` for readability.
+    fn load_include_sources(dir: &Utf8Path) -> Vec<Utf8PathBuf> {
+        let configs = load_file(dir.join(".cargo/config.toml")).expect("configs load successfully");
+        configs
+            .into_iter()
+            .map(|(source, _)| match source {
+                CargoConfigSource::File(path) => path
+                    .strip_prefix(dir)
+                    .expect("path is under the temp dir")
+                    .to_owned(),
+                CargoConfigSource::CliOption => panic!("no CLI options in this test"),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_include_precedence_and_recursion() {
+        let temp = camino_tempfile::tempdir().unwrap();
+        let dir = Utf8PathBuf::try_from(temp.path().canonicalize().unwrap()).unwrap();
+
+        // config.toml includes a.toml then b.toml; a.toml recursively includes nested.toml. The
+        // resulting precedence order (highest first) should be:
+        //   config.toml, b.toml, a.toml, nested.toml.
+        // That is: a file's own values beat its includes, and later includes beat earlier ones.
+        write_config(
+            &dir,
+            ".cargo/config.toml",
+            r#"include = ["a.toml", "b.toml"]"#,
+        );
+        write_config(&dir, ".cargo/a.toml", r#"include = ["nested.toml"]"#);
+        write_config(&dir, ".cargo/b.toml", "");
+        write_config(&dir, ".cargo/nested.toml", "");
+
+        assert_eq!(
+            load_include_sources(&dir),
+            vec![
+                Utf8PathBuf::from(".cargo/config.toml"),
+                Utf8PathBuf::from(".cargo/b.toml"),
+                Utf8PathBuf::from(".cargo/a.toml"),
+                Utf8PathBuf::from(".cargo/nested.toml"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_include_relative_to_config_file() {
+        let temp = camino_tempfile::tempdir().unwrap();
+        let dir = Utf8PathBuf::try_from(temp.path().canonicalize().unwrap()).unwrap();
+
+        // Include paths are resolved relative to the directory of the config file that specifies
+        // them, not the workspace root.
+        write_config(
+            &dir,
+            ".cargo/config.toml",
+            r#"include = ["../shared/extra.toml"]"#,
+        );
+        write_config(&dir, "shared/extra.toml", "");
+
+        assert_eq!(
+            load_include_sources(&dir),
+            vec![
+                Utf8PathBuf::from(".cargo/config.toml"),
+                Utf8PathBuf::from("shared/extra.toml"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_include_optional_missing() {
+        let temp = camino_tempfile::tempdir().unwrap();
+        let dir = Utf8PathBuf::try_from(temp.path().canonicalize().unwrap()).unwrap();
+
+        // An optional include that is missing is silently skipped; a required one that is missing is
+        // an error.
+        write_config(
+            &dir,
+            ".cargo/config.toml",
+            r#"include = [{ path = "missing.toml", optional = true }]"#,
+        );
+        assert_eq!(
+            load_include_sources(&dir),
+            vec![Utf8PathBuf::from(".cargo/config.toml")]
+        );
+
+        write_config(&dir, ".cargo/config.toml", r#"include = ["missing.toml"]"#);
+        let err = load_file(dir.join(".cargo/config.toml"))
+            .expect_err("required missing include should fail");
+        assert!(
+            matches!(err, CargoConfigError::FailedPathCanonicalization { .. }),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_include_non_toml_rejected() {
+        let temp = camino_tempfile::tempdir().unwrap();
+        let dir = Utf8PathBuf::try_from(temp.path().canonicalize().unwrap()).unwrap();
+
+        write_config(&dir, ".cargo/config.toml", r#"include = ["extra.conf"]"#);
+        write_config(&dir, ".cargo/extra.conf", "");
+
+        let err =
+            load_file(dir.join(".cargo/config.toml")).expect_err("non-.toml include should fail");
+        assert!(
+            matches!(err, CargoConfigError::IncludePathNotToml { .. }),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_include_cycle_detected() {
+        let temp = camino_tempfile::tempdir().unwrap();
+        let dir = Utf8PathBuf::try_from(temp.path().canonicalize().unwrap()).unwrap();
+
+        write_config(&dir, ".cargo/config.toml", r#"include = ["a.toml"]"#);
+        write_config(&dir, ".cargo/a.toml", r#"include = ["b.toml"]"#);
+        write_config(&dir, ".cargo/b.toml", r#"include = ["a.toml"]"#);
+
+        let err = load_file(dir.join(".cargo/config.toml")).expect_err("include cycle should fail");
+        assert!(
+            matches!(
+                innermost_cause(&err),
+                CargoConfigError::IncludeReachedTwice { .. }
+            ),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_include_reached_twice_rejected() {
+        let temp = camino_tempfile::tempdir().unwrap();
+        let dir = Utf8PathBuf::try_from(temp.path().canonicalize().unwrap()).unwrap();
+
+        // config.toml includes a.toml and b.toml, and a.toml also includes b.toml. b.toml is reached
+        // twice, so it is rejected even though there is no cycle. This matches Cargo.
+        write_config(
+            &dir,
+            ".cargo/config.toml",
+            r#"include = ["a.toml", "b.toml"]"#,
+        );
+        write_config(&dir, ".cargo/a.toml", r#"include = ["b.toml"]"#);
+        write_config(&dir, ".cargo/b.toml", "");
+
+        let err = load_file(dir.join(".cargo/config.toml"))
+            .expect_err("a file reached twice should fail");
+        assert!(
+            matches!(
+                innermost_cause(&err),
+                CargoConfigError::IncludeReachedTwice { .. }
+            ),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_include_error_chain() {
+        let temp = camino_tempfile::tempdir().unwrap();
+        let dir = Utf8PathBuf::try_from(temp.path().canonicalize().unwrap()).unwrap();
+
+        // config.toml -> a.toml -> b.toml -> missing.toml. The failure at the leaf should surface as
+        // a chain naming each include hop, mirroring Cargo's nested diagnostics.
+        write_config(&dir, ".cargo/config.toml", r#"include = ["a.toml"]"#);
+        write_config(&dir, ".cargo/a.toml", r#"include = ["b.toml"]"#);
+        write_config(&dir, ".cargo/b.toml", r#"include = ["missing.toml"]"#);
+
+        let err = load_file(dir.join(".cargo/config.toml"))
+            .expect_err("missing leaf include should fail");
+
+        // The top-level error names the first hop, and the innermost cause is the missing file.
+        assert!(
+            matches!(&err, CargoConfigError::FailedToLoadInclude { path, .. } if path == "a.toml"),
+            "unexpected top-level error: {err:?}"
+        );
+        assert!(
+            matches!(
+                innermost_cause(&err),
+                CargoConfigError::FailedPathCanonicalization { .. }
+            ),
+            "unexpected innermost cause: {err:?}"
+        );
+
+        // The rendered chain should mention every include hop.
+        let rendered = format!("{}", DisplayErrorChain::new(&err));
+        for hop in ["a.toml", "b.toml", "missing.toml"] {
+            assert!(
+                rendered.contains(hop),
+                "error chain should mention `{hop}`, got:\n{rendered}"
+            );
+        }
     }
 }

--- a/nextest-runner/src/cargo_config/env.rs
+++ b/nextest-runner/src/cargo_config/env.rs
@@ -291,7 +291,7 @@ mod imp {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cargo_config::test_helpers::setup_temp_dir;
+    use crate::cargo_config::test_helpers::{setup_temp_dir, write_config};
     use std::ffi::OsStr;
 
     #[test]
@@ -328,6 +328,110 @@ mod tests {
             .get(OsStr::new("SOME_VAR"))
             .expect("SOME_VAR is specified in test config");
         assert_eq!(var.value, "cli-config");
+    }
+
+    #[test]
+    fn test_env_var_from_include() {
+        // An `[env]` value defined in an included config file should be picked up, and the including
+        // file's own values should take precedence over it.
+        let temp = camino_tempfile::tempdir().unwrap();
+        let dir = Utf8PathBuf::try_from(temp.path().canonicalize().unwrap()).unwrap();
+
+        write_config(
+            &dir,
+            ".cargo/config.toml",
+            r#"
+            include = ["included.toml"]
+
+            [env]
+            OWN_VAR = "from-config"
+            SHARED_VAR = "from-config"
+            "#,
+        );
+        write_config(
+            &dir,
+            ".cargo/included.toml",
+            r#"
+            [env]
+            INCLUDED_VAR = "from-include"
+            SHARED_VAR = "from-include"
+            "#,
+        );
+
+        let configs =
+            CargoConfigs::new_with_isolation(&[] as &[&str], &dir, &dir, Vec::new()).unwrap();
+        let env = EnvironmentMap::new(&configs);
+
+        assert_eq!(
+            env.map
+                .get(OsStr::new("INCLUDED_VAR"))
+                .expect("INCLUDED_VAR is set from the included config")
+                .value,
+            "from-include",
+        );
+        assert_eq!(
+            env.map
+                .get(OsStr::new("OWN_VAR"))
+                .expect("OWN_VAR is set from the main config")
+                .value,
+            "from-config",
+        );
+        // The including file's own value wins over the included file's value.
+        assert_eq!(
+            env.map
+                .get(OsStr::new("SHARED_VAR"))
+                .expect("SHARED_VAR is set")
+                .value,
+            "from-config",
+        );
+    }
+
+    #[test]
+    fn test_env_var_include_precedence() {
+        // With two includes defining the same variable, the later include wins; and the top-level
+        // config still wins over both includes.
+        let temp = camino_tempfile::tempdir().unwrap();
+        let dir = Utf8PathBuf::try_from(temp.path().canonicalize().unwrap()).unwrap();
+
+        write_config(
+            &dir,
+            ".cargo/config.toml",
+            r#"
+            include = ["first.toml", "second.toml"]
+
+            [env]
+            TOP_VAR = "from-config"
+            "#,
+        );
+        write_config(
+            &dir,
+            ".cargo/first.toml",
+            r#"
+            [env]
+            TOP_VAR = "from-first"
+            INCLUDE_VAR = "from-first"
+            "#,
+        );
+        write_config(
+            &dir,
+            ".cargo/second.toml",
+            r#"
+            [env]
+            TOP_VAR = "from-second"
+            INCLUDE_VAR = "from-second"
+            "#,
+        );
+
+        let configs =
+            CargoConfigs::new_with_isolation(&[] as &[&str], &dir, &dir, Vec::new()).unwrap();
+        let env = EnvironmentMap::new(&configs);
+
+        let value = |name| env.map.get(OsStr::new(name)).map(|var| var.value.as_str());
+
+        // The top-level config wins over both includes.
+        assert_eq!(value("TOP_VAR"), Some("from-config"));
+        // Between the two includes, the one listed later wins.
+        assert_eq!(value("INCLUDE_VAR"), Some("from-second"));
     }
 
     #[test]

--- a/nextest-runner/src/cargo_config/test_helpers.rs
+++ b/nextest-runner/src/cargo_config/test_helpers.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use super::TargetTriple;
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 use camino_tempfile::Utf8TempDir;
 use color_eyre::eyre::{Context, Result};
 use target_spec::{Platform, TargetFeatures};
@@ -64,6 +64,13 @@ pub(super) fn setup_temp_dir() -> Result<Utf8TempDir> {
     .wrap_err("error writing foo/extra-custom-config.toml")?;
 
     Ok(dir)
+}
+
+/// Writes `contents` to `<dir>/<rel_path>`, creating parent directories as needed.
+pub(super) fn write_config(dir: &Utf8Path, rel_path: &str, contents: &str) {
+    let path = dir.join(rel_path);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, contents).unwrap();
 }
 
 impl TargetTriple {

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -1749,6 +1749,41 @@ pub enum CargoConfigError {
     /// Failed to deserialize config file
     #[error(transparent)]
     ConfigParseError(#[from] Box<CargoConfigParseError>),
+
+    /// Failed to load a config file pulled in via another config file's `include` key.
+    ///
+    /// This wraps the underlying error so that the chain of `include` keys leading to the failure
+    /// is preserved, matching Cargo's nested diagnostics.
+    #[error("failed to load config include `{path}` from `{included_from}`")]
+    FailedToLoadInclude {
+        /// The include path, as written in the config file.
+        path: String,
+
+        /// The config file that specified the include.
+        included_from: Utf8PathBuf,
+
+        /// The underlying error.
+        #[source]
+        error: Box<CargoConfigError>,
+    },
+
+    /// A config file's `include` key referred to a path not ending in `.toml`.
+    #[error("config `include` path `{path}` in `{included_from}` does not end with `.toml`")]
+    IncludePathNotToml {
+        /// The offending include path, as written in the config file.
+        path: String,
+
+        /// The config file that specified the include.
+        included_from: Utf8PathBuf,
+    },
+
+    /// A config file was reached more than once while following config `include` keys. This
+    /// includes cycles as well as a file reached via multiple include paths.
+    #[error("config file `{path}` is included more than once")]
+    IncludeReachedTwice {
+        /// The path that was reached more than once.
+        path: Utf8PathBuf,
+    },
 }
 
 /// Failed to deserialize config file


### PR DESCRIPTION
Nextest reimplements Cargo's config discovery but it didn't handle the top-level `include` key stabilized in 1.94. Deserialization just ignored the `include` in a discovered `.cargo/config.toml`.

This change now loads each config file's includes recursively, matching Cargo's semantics:

- `include` is a list of bare path strings or `{ path, optional }` tables. Paths are relative to the directory of the config file that specifies them and must end with `.toml`.
- A file's own values take precedence over the files it includes, and later includes take precedence over earlier ones.
- Includes are resolved recursively, with per-root-file cycle detection.
- `optional = true` silently skips a missing include, matching Cargo.

I also added unit tests and extended the fixture project's `.cargo/config` to pull in an included file and assert on its variables in the existing cargo env integration test.

Resolves #3511 