### PR TITLE
[nextest-runner] always keep dylibs in archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,7 +452,7 @@ jobs:
       # Only --lib is built here because fixture-project's other test targets
       # contain deliberately-failing tests.
       #
-      # These three steps clear RUSTFLAGS because this workflow sets
+      # The steps that build fixture-project clear RUSTFLAGS because this workflow sets
       # `-D warnings`, and fixture-project's lib deliberately calls a deprecated
       # function to produce a compiler warning for the --cargo-message-format
       # tests. The integration test harness clears RUSTFLAGS for the same reason
@@ -497,18 +497,31 @@ jobs:
           ./scripts/nextest-without-rustup.sh run \
             --manifest-path fixtures/fixture-project/Cargo.toml \
             --package fixture-project --lib
+      # fixture-project is included here so that the archive has to carry the
+      # dylib-test dylib. Here, dylib-test is not among the selected packages,
+      # so it doesn't enter the set of packages that apply_archive_filters
+      # considers relevant -- but fixture-project's lib test still needs its
+      # dylib at exec time.
+      #
+      # --lib is required here because fixture-project's other test targets
+      # contain deliberately failing tests, and we want this step to succeed.
+      #
+      # RUSTFLAGS is cleared for the deprecation warning in fixture-project's
+      # lib, as in the steps above.
       - name: Archive fixture tests with build-dir
         env:
           CARGO_NEXTEST: target/debug/cargo-nextest
           RUSTUP_AVAILABLE: 1
+          RUSTFLAGS: ""
           CARGO_BUILD_BUILD_DIR: ${{ github.workspace }}/build-output
         run: |
           ./scripts/nextest-without-rustup.sh archive \
             -Z build-dir-new-layout \
             --manifest-path fixtures/fixture-project/Cargo.toml \
             --archive-file target/build-dir-archive.tar.zst \
+            --lib \
             --package cdylib-link --package cdylib-example \
-            --package with-build-script
+            --package with-build-script --package fixture-project
       # Run from the archive without build-dir env to verify archive
       # portability. (build_directory is normalized to target_directory in the
       # archive). Wipe both the target and build directories first to ensure

--- a/integration-tests/tests/integration/main.rs
+++ b/integration-tests/tests/integration/main.rs
@@ -1509,6 +1509,35 @@ fn test_archive_with_build_filter() {
             );
         },
     );
+
+    // This filter excludes dylib-test's test binary, but fixture-project's lib
+    // test still needs dylib-test's dylib at exec time.
+    let expected_dylib = "dylib_test";
+    let dylib_test_case = "tests::call_dylib_add_two";
+    check_archive_contents(
+        &env_info,
+        "package(fixture-project)",
+        "archive_filter_package_dylib",
+        |env_info, archive_file, paths| {
+            assert!(
+                paths.iter().any(|path| {
+                    // Dylibs are uplifted to the final artifact directory, so
+                    // they sit alongside deps rather than inside it.
+                    path.parent().and_then(Utf8Path::file_name) == Some("debug")
+                        && path_contains_test_fixture_file(path, expected_dylib)
+                }),
+                "{:?} was missing from the test archive",
+                expected_dylib
+            );
+            let output = list_from_archive(env_info, &archive_file);
+            assert!(
+                output.stdout_as_str().contains(dylib_test_case),
+                "{:?} was missing from the test list\n{}",
+                dylib_test_case,
+                output
+            );
+        },
+    );
 }
 
 /// Checks if the file name at `path` contains `expected_file_name`
@@ -1691,19 +1720,43 @@ fn run_archive(env_info: &TestEnvInfo, archive_file: &Utf8Path) -> (TempProject,
     )
 }
 
+/// Lists tests out of an archive.
+///
+/// This requires that all binaries be executable (e.g., that dylib dependencies
+/// are satisfied).
+fn list_from_archive(env_info: &TestEnvInfo, archive_file: &Utf8Path) -> CargoNextestOutput {
+    let (_p2, _extracted_target, output) =
+        nextest_from_archive(env_info, archive_file, "list", NextestExitCode::OK);
+    output
+}
+
 fn run_archive_with_args(
     env_info: &TestEnvInfo,
     archive_file: &Utf8Path,
     run_property: RunProperties,
     expected_exit_code: i32,
 ) -> (TempProject, Utf8PathBuf) {
+    let (p2, extracted_target, output) =
+        nextest_from_archive(env_info, archive_file, "run", expected_exit_code);
+    check_run_output_with_junit(&output.stderr, &p2.junit_path("default"), run_property);
+
+    // project is included in return value to keep tempdirs alive
+    (p2, extracted_target)
+}
+
+fn nextest_from_archive(
+    env_info: &TestEnvInfo,
+    archive_file: &Utf8Path,
+    subcommand: &str,
+    expected_exit_code: i32,
+) -> (TempProject, Utf8PathBuf, CargoNextestOutput) {
     let p2 = TempProject::new(env_info).unwrap();
     let extract_to = p2.workspace_root().join("extract_to");
     std::fs::create_dir_all(&extract_to).unwrap();
 
     let output = CargoNextestCli::for_test(env_info)
         .args([
-            "run",
+            subcommand,
             "--archive-file",
             archive_file.as_str(),
             "--workspace-remap",
@@ -1718,10 +1771,8 @@ fn run_archive_with_args(
         Some(expected_exit_code),
         "correct exit code for command\n{output}"
     );
-    check_run_output_with_junit(&output.stderr, &p2.junit_path("default"), run_property);
 
-    // project is included in return value to keep tempdirs alive
-    (p2, extract_to.join("target"))
+    (p2, extract_to.join("target"), output)
 }
 
 #[test]

--- a/integration-tests/tests/integration/snapshots/integration__archive_filter_none.snap
+++ b/integration-tests/tests/integration/snapshots/integration__archive_filter_none.snap
@@ -2,7 +2,7 @@
 source: integration-tests/tests/integration/main.rs
 expression: output.stderr_as_str()
 ---
-   Archiving 0 binaries (16 test binaries and 4 non-test binaries filtered out), 2 linked paths, and 1 standard library to <archive-file>
+   Archiving 1 binary (including 1 non-test binary; 16 test binaries and 3 non-test binaries filtered out), 2 linked paths, and 1 standard library to <archive-file>
      Warning linked path `<target-dir>/debug/build/<cdylib-link-hash>/does-not-exist` not found, requested by: cdylib-link v0.1.0
              (this is a bug in this crate that should be fixed)
     Archived <file-count> files to <archive-file> in <duration>

--- a/integration-tests/tests/integration/snapshots/integration__archive_filter_package_dylib.snap
+++ b/integration-tests/tests/integration/snapshots/integration__archive_filter_package_dylib.snap
@@ -2,7 +2,7 @@
 source: integration-tests/tests/integration/main.rs
 expression: output.stderr_as_str()
 ---
-   Archiving 2 binaries (including 1 non-test binary; 15 test binaries and 3 non-test binaries filtered out), 2 linked paths, and 1 standard library to <archive-file>
+   Archiving 14 binaries (including 4 non-test binaries; 6 test binaries filtered out), 2 linked paths, and 1 standard library to <archive-file>
      Warning linked path `<target-dir>/debug/build/<cdylib-link-hash>/does-not-exist` not found, requested by: cdylib-link v0.1.0
              (this is a bug in this crate that should be fixed)
     Archived <file-count> files to <archive-file> in <duration>

--- a/nextest-runner/src/list/non_test_binaries.rs
+++ b/nextest-runner/src/list/non_test_binaries.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use guppy::PackageId;
-use nextest_metadata::RustNonTestBinarySummary;
-use std::collections::{BTreeMap, BTreeSet};
+use nextest_metadata::{RustNonTestBinaryKind, RustNonTestBinarySummary};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 /// A collection of non-test binaries that are part of a build.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -58,18 +58,36 @@ impl RustNonTestBinaries {
         self.by_package_id.get(package_id).into_iter().flatten()
     }
 
-    pub(crate) fn partition_by_package_id(
+    /// Partitions the non-test binaries in this collection for use with an archive.
+    ///
+    /// This drops package-scoped binaries owned by packages with no archived test binary.
+    pub(crate) fn partition_for_archive(
         &self,
-        mut retain: impl FnMut(&PackageId) -> bool,
+        relevant_package_ids: &HashSet<&str>,
+    ) -> PartitionedNonTestBinaries {
+        self.partition(|package_id, binary| {
+            relevant_package_ids.contains(package_id.repr()) || !is_package_scoped(&binary.kind)
+        })
+    }
+
+    fn partition(
+        &self,
+        mut retain: impl FnMut(&PackageId, &RustNonTestBinarySummary) -> bool,
     ) -> PartitionedNonTestBinaries {
         let mut by_package_id = BTreeMap::new();
         let mut filtered_out_binary_count = 0;
 
         for (package_id, files) in &self.by_package_id {
-            if retain(package_id) {
-                by_package_id.insert(package_id.clone(), files.clone());
-            } else {
-                filtered_out_binary_count += binary_count(files);
+            let retained: BTreeSet<_> = files
+                .iter()
+                .filter(|file| retain(package_id, file))
+                .cloned()
+                .collect();
+
+            filtered_out_binary_count += binary_count(files) - binary_count(&retained);
+            // If nothing was retained, don't bother adding it to the result.
+            if !retained.is_empty() {
+                by_package_id.insert(package_id.clone(), retained);
             }
         }
 
@@ -93,10 +111,17 @@ fn binary_count(files: &BTreeSet<RustNonTestBinarySummary>) -> usize {
         .len()
 }
 
+/// Returns true if this non-test binary is package-scoped.
+///
+/// This returns true for bin-exes (via `CARGO_BIN_EXE_<name>`) and false for
+/// other kinds.
+fn is_package_scoped(kind: &RustNonTestBinaryKind) -> bool {
+    *kind == RustNonTestBinaryKind::BIN_EXE
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nextest_metadata::RustNonTestBinaryKind;
 
     #[test]
     fn binary_count_is_platform_stable() {
@@ -155,7 +180,7 @@ mod tests {
     }
 
     #[test]
-    fn partition_by_package_id_counts_binaries() {
+    fn partition_counts_binaries() {
         let non_test_binaries = RustNonTestBinaries::from_summary(BTreeMap::from([
             (
                 "with-tests".to_owned(),
@@ -186,9 +211,8 @@ mod tests {
             ),
         ]));
 
-        let partitioned = non_test_binaries.partition_by_package_id(|package_id| {
-            matches!(package_id.repr(), "with-tests" | "mixed")
-        });
+        let partitioned = non_test_binaries
+            .partition(|package_id, _| matches!(package_id.repr(), "with-tests" | "mixed"));
 
         assert_eq!(
             partitioned.retained.to_summary(),
@@ -219,6 +243,91 @@ mod tests {
         );
     }
 
+    #[test]
+    fn partition_for_archive_only_scopes_bin_exes() {
+        let non_test_binaries = RustNonTestBinaries::from_summary(BTreeMap::from([
+            (
+                "with-tests".to_owned(),
+                BTreeSet::from([bin_exe("helper", "debug/helper")]),
+            ),
+            (
+                "three-bins".to_owned(),
+                BTreeSet::from([
+                    bin_exe("one", "debug/one"),
+                    bin_exe("two", "debug/two"),
+                    bin_exe("three", "debug/three"),
+                ]),
+            ),
+            (
+                "mixed".to_owned(),
+                BTreeSet::from([
+                    bin_exe("mixed-bin", "debug/mixed-bin"),
+                    dylib("mixed_dylib", "debug/libmixed_dylib.so"),
+                ]),
+            ),
+            (
+                "mixed-no-tests".to_owned(),
+                BTreeSet::from([
+                    bin_exe("untested-bin", "debug/untested-bin"),
+                    dylib("untested_dylib", "debug/libuntested_dylib.so"),
+                ]),
+            ),
+            (
+                "dylib-only".to_owned(),
+                BTreeSet::from([dylib("only_dylib", "debug/libonly_dylib.so")]),
+            ),
+            (
+                "unknown-only".to_owned(),
+                BTreeSet::from([future_kind(
+                    "from_a_newer_nextest",
+                    "debug/from_a_newer_nextest",
+                )]),
+            ),
+        ]));
+
+        let relevant_package_ids = HashSet::from(["with-tests", "mixed"]);
+        let partitioned = non_test_binaries.partition_for_archive(&relevant_package_ids);
+
+        assert_eq!(
+            partitioned.retained.to_summary(),
+            BTreeMap::from([
+                (
+                    "with-tests".to_owned(),
+                    BTreeSet::from([bin_exe("helper", "debug/helper")]),
+                ),
+                (
+                    "mixed".to_owned(),
+                    BTreeSet::from([
+                        bin_exe("mixed-bin", "debug/mixed-bin"),
+                        dylib("mixed_dylib", "debug/libmixed_dylib.so"),
+                    ]),
+                ),
+                (
+                    "mixed-no-tests".to_owned(),
+                    BTreeSet::from([dylib("untested_dylib", "debug/libuntested_dylib.so")]),
+                ),
+                (
+                    "dylib-only".to_owned(),
+                    BTreeSet::from([dylib("only_dylib", "debug/libonly_dylib.so")]),
+                ),
+                (
+                    "unknown-only".to_owned(),
+                    BTreeSet::from([future_kind(
+                        "from_a_newer_nextest",
+                        "debug/from_a_newer_nextest",
+                    )]),
+                ),
+            ]),
+            "only bin-exes are package-scoped: dylibs and unrecognized kinds are always retained, \
+             and packages left with no binaries are dropped"
+        );
+        assert_eq!(
+            partitioned.filtered_out_binary_count, 4,
+            "3 bin-exes are dropped from three-bins and 1 from mixed-no-tests; counting map \
+             entries that vanished, as the old code did, would report 1"
+        );
+    }
+
     fn bin_exe(name: &str, path: &str) -> RustNonTestBinarySummary {
         RustNonTestBinarySummary {
             name: name.to_owned(),
@@ -231,6 +340,14 @@ mod tests {
         RustNonTestBinarySummary {
             name: name.to_owned(),
             kind: RustNonTestBinaryKind::DYLIB,
+            path: path.into(),
+        }
+    }
+
+    fn future_kind(name: &str, path: &str) -> RustNonTestBinarySummary {
+        RustNonTestBinarySummary {
+            name: name.to_owned(),
+            kind: RustNonTestBinaryKind::new("some-future-kind"),
             path: path.into(),
         }
     }

--- a/nextest-runner/src/reuse_build/archiver.rs
+++ b/nextest-runner/src/reuse_build/archiver.rs
@@ -82,7 +82,7 @@ pub fn apply_archive_filters(
     let partitioned_non_test_binaries = binary_list
         .rust_build_meta
         .non_test_binaries
-        .partition_by_package_id(|package_id| relevant_package_ids.contains(package_id.repr()));
+        .partition_for_archive(&relevant_package_ids);
 
     // Also filter out build script out directories and env vars.
     let mut filtered_build_script_out_dirs =


### PR DESCRIPTION
Dylibs are in the global search path, so different logic applies to them than it does to regular executables.