### PR TITLE
[nextest-runner] move run ID unique prefix into RecordSession

### DIFF
--- a/cargo-nextest/src/dispatch/core/run.rs
+++ b/cargo-nextest/src/dispatch/core/run.rs
@@ -1136,7 +1136,7 @@ impl App {
 
         // Set up recording if the experimental feature is enabled (via env var or user config)
         // AND recording is enabled in the config.
-        let (recording_session, run_id_unique_prefix) = if resolved_user_config
+        let recording_session = if resolved_user_config
             .is_experimental_enabled(UserConfigExperimental::Record)
             && resolved_user_config.record.enabled
         {
@@ -1172,20 +1172,20 @@ impl App {
                         opts,
                     );
                     structured_reporter.set_record(record);
-                    (Some(setup.session), Some(setup.run_id_unique_prefix))
+                    Some(setup.session)
                 }
                 Err(err) => match err.disabled_error() {
                     Some(reason) => {
                         // Recording is disabled due to a format version mismatch.
                         // Log a warning and continue without recording.
                         warn!("recording disabled: {reason}");
-                        (None, None)
+                        None
                     }
                     None => return Err(ExpectedError::RecordSessionSetupError { err }),
                 },
             }
         } else {
-            (None, None)
+            None
         };
 
         let show_term_progress = ShowTerminalProgress::from_cargo_configs(
@@ -1201,8 +1201,8 @@ impl App {
         );
 
         // Set the run ID unique prefix for highlighting if a recording session is active.
-        if let Some(prefix) = run_id_unique_prefix {
-            reporter.set_run_id_unique_prefix(prefix);
+        if let Some(session) = &recording_session {
+            reporter.set_run_id_unique_prefix(session.run_id_unique_prefix().clone());
         }
 
         configure_handle_inheritance(no_capture)?;
@@ -1408,7 +1408,7 @@ impl App {
 
         // Set up recording if the experimental feature is enabled AND recording is enabled in
         // the config.
-        let (recording_session, run_id_unique_prefix) = if resolved_user_config
+        let recording_session = if resolved_user_config
             .is_experimental_enabled(UserConfigExperimental::Record)
             && resolved_user_config.record.enabled
         {
@@ -1435,20 +1435,20 @@ impl App {
                         opts,
                     );
                     structured_reporter.set_record(record);
-                    (Some(setup.session), Some(setup.run_id_unique_prefix))
+                    Some(setup.session)
                 }
                 Err(err) => match err.disabled_error() {
                     Some(reason) => {
                         // Recording is disabled due to a format version mismatch.
                         // Log a warning and continue without recording.
                         warn!("recording disabled: {reason}");
-                        (None, None)
+                        None
                     }
                     None => return Err(ExpectedError::RecordSessionSetupError { err }),
                 },
             }
         } else {
-            (None, None)
+            None
         };
 
         let show_term_progress = ShowTerminalProgress::from_cargo_configs(
@@ -1464,8 +1464,8 @@ impl App {
         );
 
         // Set the run ID unique prefix for highlighting if a recording session is active.
-        if let Some(prefix) = run_id_unique_prefix {
-            reporter.set_run_id_unique_prefix(prefix);
+        if let Some(session) = &recording_session {
+            reporter.set_run_id_unique_prefix(session.run_id_unique_prefix().clone());
         }
 
         // TODO: no_capture is always true for benchmarks for now.

--- a/nextest-runner/src/record/session.rs
+++ b/nextest-runner/src/record/session.rs
@@ -63,11 +63,6 @@ pub struct RecordSessionSetup {
     pub session: RecordSession,
     /// The recorder to pass to the structured reporter.
     pub recorder: RunRecorder,
-    /// The shortest unique prefix for the run ID.
-    ///
-    /// This can be used for display purposes to highlight the unique prefix
-    /// portion of the run ID.
-    pub run_id_unique_prefix: ShortestRunIdPrefix,
 }
 
 /// Manages the full lifecycle of a recording session.
@@ -77,6 +72,7 @@ pub struct RecordSessionSetup {
 pub struct RecordSession {
     state_dir: Utf8PathBuf,
     run_id: ReportUuid,
+    run_id_unique_prefix: ShortestRunIdPrefix,
 }
 
 impl RecordSession {
@@ -121,18 +117,20 @@ impl RecordSession {
         let session = RecordSession {
             state_dir,
             run_id: config.run_id,
+            run_id_unique_prefix,
         };
 
-        Ok(RecordSessionSetup {
-            session,
-            recorder,
-            run_id_unique_prefix,
-        })
+        Ok(RecordSessionSetup { session, recorder })
     }
 
     /// Returns the run ID for this session.
     pub fn run_id(&self) -> ReportUuid {
         self.run_id
+    }
+
+    /// Returns the shortest unique prefix for this session's run ID.
+    pub fn run_id_unique_prefix(&self) -> &ShortestRunIdPrefix {
+        &self.run_id_unique_prefix
     }
 
     /// Returns the state directory for this session.


### PR DESCRIPTION
Previously, RecordSessionSetup carried the shortest unique run ID prefix as a separate field, and the run and bench paths threaded it around as one half of an `(Option<RecordSession>, Option<ShortestRunIdPrefix>)` tuple whose halves were always both Some or both None.

With this commit, the prefix now lives on RecordSession.