### PR TITLE
[cargo-nextest] make all recording setup failures non-fatal

### DIFF
--- a/cargo-nextest/src/dispatch/core/run.rs
+++ b/cargo-nextest/src/dispatch/core/run.rs
@@ -26,6 +26,7 @@ use nextest_runner::{
         core::ConfigExperimental,
         elements::{MaxFail, RetryPolicy, TestThreads},
     },
+    errors::DisplayErrorChain,
     helpers::{ShowTerminalProgress, ThemeCharacters, force_or_new_run_id, plural},
     input::InputHandlerKind,
     list::{BinaryList, ListProgressOptions, TestExecuteContext, TestList},
@@ -837,6 +838,30 @@ pub(super) fn filter_env_vars_for_recording(
     .collect()
 }
 
+/// Performs setup for a recording session.
+///
+/// Errors during setup are treated as non-fatal and are logged.
+fn setup_recording_session(
+    config: RecordSessionConfig<'_>,
+    cargo_metadata_json: Arc<String>,
+    test_list: &TestList<'_>,
+    structured_reporter: &mut structured::StructuredReporter<'_>,
+) -> Option<RecordSession> {
+    match RecordSession::setup(config) {
+        Ok(setup) => {
+            let record = structured::RecordReporter::new(setup.recorder);
+            let opts = RecordOpts::new(test_list.mode());
+            record.write_meta(cargo_metadata_json, test_list.to_summary(), opts);
+            structured_reporter.set_record(record);
+            Some(setup.session)
+        }
+        Err(error) => {
+            warn!("recording disabled: {}", DisplayErrorChain::new(&error));
+            None
+        }
+    }
+}
+
 /// Application for running tests (run/list/bench).
 pub(crate) struct App {
     pub(crate) base: BaseApp,
@@ -1162,28 +1187,12 @@ impl App {
                 max_output_size: resolved_user_config.record.max_output_size,
                 rerun_info,
             };
-            match RecordSession::setup(config) {
-                Ok(setup) => {
-                    let record = structured::RecordReporter::new(setup.recorder);
-                    let opts = RecordOpts::new(test_list.mode());
-                    record.write_meta(
-                        self.base.cargo_metadata_json.clone(),
-                        test_list.to_summary(),
-                        opts,
-                    );
-                    structured_reporter.set_record(record);
-                    Some(setup.session)
-                }
-                Err(err) => match err.disabled_error() {
-                    Some(reason) => {
-                        // Recording is disabled due to a format version mismatch.
-                        // Log a warning and continue without recording.
-                        warn!("recording disabled: {reason}");
-                        None
-                    }
-                    None => return Err(ExpectedError::RecordSessionSetupError { err }),
-                },
-            }
+            setup_recording_session(
+                config,
+                self.base.cargo_metadata_json.clone(),
+                &test_list,
+                &mut structured_reporter,
+            )
         } else {
             None
         };
@@ -1425,28 +1434,12 @@ impl App {
                 // TODO: support reruns? value seems dubious.
                 rerun_info: None,
             };
-            match RecordSession::setup(config) {
-                Ok(setup) => {
-                    let record = structured::RecordReporter::new(setup.recorder);
-                    let opts = RecordOpts::new(test_list.mode());
-                    record.write_meta(
-                        self.base.cargo_metadata_json.clone(),
-                        test_list.to_summary(),
-                        opts,
-                    );
-                    structured_reporter.set_record(record);
-                    Some(setup.session)
-                }
-                Err(err) => match err.disabled_error() {
-                    Some(reason) => {
-                        // Recording is disabled due to a format version mismatch.
-                        // Log a warning and continue without recording.
-                        warn!("recording disabled: {reason}");
-                        None
-                    }
-                    None => return Err(ExpectedError::RecordSessionSetupError { err }),
-                },
-            }
+            setup_recording_session(
+                config,
+                self.base.cargo_metadata_json.clone(),
+                &test_list,
+                &mut structured_reporter,
+            )
         } else {
             None
         };

--- a/cargo-nextest/src/errors.rs
+++ b/cargo-nextest/src/errors.rs
@@ -10,8 +10,8 @@ use nextest_runner::{
     config::core::{ConfigExperimental, ToolName},
     errors::{
         ChromeTraceError, PortableRecordingError, PortableRecordingReadError, RecordReadError,
-        RecordSetupError, RunIdResolutionError, RunStoreError, StateDirError,
-        TestListFromSummaryError, UserConfigError, *,
+        RunIdResolutionError, RunStoreError, StateDirError, TestListFromSummaryError,
+        UserConfigError, *,
     },
     helpers::{format_interceptor_too_many_tests, plural},
     indenter::DisplayIndented,
@@ -373,11 +373,6 @@ pub enum ExpectedError {
         #[source]
         err: RunStoreError,
     },
-    #[error("error setting up recording session")]
-    RecordSessionSetupError {
-        #[source]
-        err: RecordSetupError,
-    },
     #[error("filterset parse error")]
     FiltersetParseError {
         all_errors: Vec<FiltersetParseErrors>,
@@ -667,7 +662,6 @@ impl ExpectedError {
             }
             Self::RecordStateDirNotFound { .. }
             | Self::RecordSetupError { .. }
-            | Self::RecordSessionSetupError { .. }
             | Self::RunIdResolutionError { .. }
             | Self::RecordReadError { .. }
             | Self::StoreVersionIncompatible { .. }
@@ -1261,10 +1255,6 @@ impl ExpectedError {
             }
             Self::RecordSetupError { err } => {
                 error!("error setting up recording");
-                Some(err as &dyn Error)
-            }
-            Self::RecordSessionSetupError { err } => {
-                error!("error setting up recording session");
                 Some(err as &dyn Error)
             }
             Self::FiltersetParseError { all_errors } => {

--- a/integration-tests/tests/integration/record_replay.rs
+++ b/integration-tests/tests/integration/record_replay.rs
@@ -2269,6 +2269,117 @@ fn test_replayability_store_version_too_new() {
     }
 }
 
+// A corrupted runs.json.zst must disable recording with a warning.
+#[test]
+fn test_record_setup_corrupt_index_is_nonfatal() {
+    let env_info = set_env_vars_for_test();
+    let p = TempProject::new(&env_info).unwrap();
+    let cache_dir = create_cache_dir(&p);
+    let (_user_config_dir, user_config_path) = create_record_user_config();
+
+    const RUN_ID: &str = "97000001-0000-0000-0000-000000000001";
+
+    let recording = cli_with_recording(&env_info, &p, &cache_dir, &user_config_path, Some(RUN_ID))
+        .args([
+            "run",
+            "--workspace",
+            "--all-targets",
+            "-E",
+            "test(=test_success)",
+        ])
+        .output();
+    assert!(
+        recording.exit_status.success(),
+        "initial recorded run should succeed: {recording}"
+    );
+    check_run_output_for_test_names(&recording.stderr, &["test_success"], RunProperties::empty());
+
+    let runs_dir = find_runs_dir(&cache_dir).expect("runs dir should exist after recording");
+    let count_run_dirs = |runs_dir: &Utf8Path| {
+        fs::read_dir(runs_dir)
+            .expect("runs dir should be readable")
+            .filter(|entry| {
+                entry
+                    .as_ref()
+                    .expect("read runs dir entry")
+                    .file_type()
+                    .expect("read runs dir entry file type")
+                    .is_dir()
+            })
+            .count()
+    };
+    assert_eq!(
+        count_run_dirs(&runs_dir),
+        1,
+        "one run dir should exist after the initial recording"
+    );
+
+    fs::write(runs_dir.join("runs.json.zst"), b"not a zstd stream")
+        .expect("corrupt data written to runs.json.zst");
+
+    let output = cli_with_recording(&env_info, &p, &cache_dir, &user_config_path, None)
+        .args([
+            "run",
+            "--workspace",
+            "--all-targets",
+            "-E",
+            "test(=test_success)",
+        ])
+        .output();
+    assert!(
+        output.exit_status.success(),
+        "run with a corrupt index should still succeed: {output}"
+    );
+    let stderr = output.stderr_as_str();
+    assert!(
+        stderr.contains("recording disabled"),
+        "run with a corrupt index should warn that recording is disabled: {output}"
+    );
+    assert!(
+        stderr.contains("run list"),
+        "warning should mention the run list failure: {output}"
+    );
+    check_run_output_for_test_names(&output.stderr, &["test_success"], RunProperties::empty());
+    assert_eq!(
+        count_run_dirs(&runs_dir),
+        1,
+        "no new run dir should be created while recording is disabled"
+    );
+}
+
+// An unwritable state dir must disable recording with a warning.
+#[test]
+fn test_record_setup_unwritable_state_dir_is_nonfatal() {
+    let env_info = set_env_vars_for_test();
+    let p = TempProject::new(&env_info).unwrap();
+    let (_user_config_dir, user_config_path) = create_record_user_config();
+
+    let state_dir = p.temp_root().join("unwritable-state");
+
+    // Put a regular file where the state dir is -- this causes an error on all
+    // platforms.
+    fs::write(&state_dir, b"blocking file").expect("created blocking file at state dir path");
+
+    let output = cli_with_recording(&env_info, &p, &state_dir, &user_config_path, None)
+        .args([
+            "run",
+            "--workspace",
+            "--all-targets",
+            "-E",
+            "test(=test_success)",
+        ])
+        .output();
+    assert!(
+        output.exit_status.success(),
+        "run with an unwritable state dir should still succeed: {output}"
+    );
+    assert!(
+        output.stderr_as_str().contains("recording disabled"),
+        "run with an unwritable state dir should warn that recording is disabled: {output}"
+    );
+    check_run_output_for_test_names(&output.stderr, &["test_success"], RunProperties::empty());
+}
+
 // --- Rerun tests ---
 
 /// Reads rerun-info.json from a recorded run's store.zip.

--- a/nextest-runner/src/errors.rs
+++ b/nextest-runner/src/errors.rs
@@ -2318,23 +2318,6 @@ pub enum RecordSetupError {
     RecorderCreate(#[source] RunStoreError),
 }
 
-impl RecordSetupError {
-    /// If this error indicates that recording should be disabled (but the test
-    /// run should continue), returns the underlying error.
-    ///
-    /// This is the case when the runs.json.zst file has a newer format version than
-    /// this nextest supports. Recording is disabled to avoid data loss, but the
-    /// test run can proceed normally.
-    pub fn disabled_error(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            RecordSetupError::RecorderCreate(err @ RunStoreError::FormatVersionTooNew { .. }) => {
-                Some(err)
-            }
-            _ => None,
-        }
-    }
-}
-
 /// An error that occurred while pruning recorded runs.
 #[derive(Debug, Error)]
 pub enum RecordPruneError {


### PR DESCRIPTION
Previously we would mark a subset of recording setup failures as non-fatal. Change this so that all recording setup failures are non-fatal.

There are arguments both ways for this, but to me the most compelling one is that recording _finalization_ is a warning and _initialization_ should be consistent with that.

Fixes #3542.