### PR TITLE
[cargo-nextest] only show "continue rerunning" hint when a rerun is available

### DIFF
--- a/cargo-nextest/src/dispatch/core/run.rs
+++ b/cargo-nextest/src/dispatch/core/run.rs
@@ -1656,7 +1656,10 @@ fn final_result(
             info!("no outstanding tests remain");
             Ok(())
         }
-        Some(count) => Err(ExpectedError::RerunTestsOutstanding { count }),
+        Some(count) => Err(ExpectedError::RerunTestsOutstanding {
+            count,
+            rerun_available,
+        }),
         None => Ok(()),
     }
 }
@@ -1751,7 +1754,10 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Err(ExpectedError::RerunTestsOutstanding { count: 5 })
+                Err(ExpectedError::RerunTestsOutstanding {
+                    count: 5,
+                    rerun_available: false,
+                })
             ),
             "--no-tests=auto (rerun with outstanding) should return RerunTestsOutstanding"
         );
@@ -1790,7 +1796,10 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Err(ExpectedError::RerunTestsOutstanding { count: 3 })
+                Err(ExpectedError::RerunTestsOutstanding {
+                    count: 3,
+                    rerun_available: false,
+                })
             ),
             "default (rerun with outstanding) should return RerunTestsOutstanding"
         );
@@ -1817,9 +1826,29 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Err(ExpectedError::RerunTestsOutstanding { count: 2 })
+                Err(ExpectedError::RerunTestsOutstanding {
+                    count: 2,
+                    rerun_available: false,
+                })
             ),
-            "all tests passed (rerun with outstanding) should return RerunTestsOutstanding"
+            "all tests passed (rerun with outstanding) should return RerunTestsOutstanding \
+             with rerun_available: false"
+        );
+
+        // Rerun with outstanding, and this run was recorded. We can show the
+        // continue rerunning hint in this case.
+        let stats = make_run_stats(5, 5, 5);
+        let result = final_result(NextestRunMode::Test, stats, None, Some(2), true);
+        assert!(
+            matches!(
+                result,
+                Err(ExpectedError::RerunTestsOutstanding {
+                    count: 2,
+                    rerun_available: true
+                })
+            ),
+            "all tests passed (recorded rerun with outstanding) should return \
+             RerunTestsOutstanding with rerun_available: true"
         );
 
         // Failures return TestRunFailed (no rerun available).

--- a/cargo-nextest/src/errors.rs
+++ b/cargo-nextest/src/errors.rs
@@ -271,6 +271,8 @@ pub enum ExpectedError {
     RerunTestsOutstanding {
         /// The number of tests that were not seen during this rerun.
         count: usize,
+        /// Whether this run was recorded, so `-R latest` can continue the chain.
+        rerun_available: bool,
     },
     #[error("no tests to run")]
     NoTestsRun {
@@ -1101,7 +1103,10 @@ impl ExpectedError {
                 }
                 None
             }
-            Self::RerunTestsOutstanding { count } => {
+            Self::RerunTestsOutstanding {
+                count,
+                rerun_available,
+            } => {
                 warn!(
                     "{} outstanding {} still {}",
                     count.style(styles.bold),
@@ -1112,11 +1117,13 @@ impl ExpectedError {
                 // Advice to run `cargo nextest run -R latest` might not always
                 // be complete due to the expanded build scope or disappearing
                 // tests. We just hint that the user can continue doing reruns.
-                info!(
-                    target: "cargo_nextest::no_heading",
-                    "(hint: {} to continue rerunning)",
-                    "cargo nextest run -R latest".style(styles.bold),
-                );
+                if *rerun_available {
+                    info!(
+                        target: "cargo_nextest::no_heading",
+                        "(hint: {} to continue rerunning)",
+                        "cargo nextest run -R latest".style(styles.bold),
+                    );
+                }
                 None
             }
             Self::NoTestsRun { mode, is_default } => {

--- a/integration-tests/tests/integration/record_replay.rs
+++ b/integration-tests/tests/integration/record_replay.rs
@@ -2858,6 +2858,7 @@ fn test_rerun_tests_outstanding() {
 
     const INITIAL_RUN_ID: &str = "96000001-0000-0000-0000-000000000001";
     const RERUN_ID: &str = "96000002-0000-0000-0000-000000000002";
+    const DENIED_RERUN_ID: &str = "96000003-0000-0000-0000-000000000003";
 
     let initial_output = cli_with_recording(
         &env_info,
@@ -2903,6 +2904,63 @@ fn test_rerun_tests_outstanding() {
         "rerun_tests_outstanding",
         redact_dynamic_fields(&rerun_output.stderr_as_str(), temp_root)
     );
+
+    // A rerun that causes runs.json.zst writes (and thus recording) to be
+    // disabled. We must not record this run or show the continue-rerunning
+    // hint.
+    let runs_dir = find_runs_dir(&cache_dir).expect("runs dir should exist after recording");
+    deny_runs_json_writes(&runs_dir);
+
+    let denied_rerun_output = cli_with_recording(
+        &env_info,
+        &p,
+        &cache_dir,
+        &user_config_path,
+        Some(DENIED_RERUN_ID),
+    )
+    .args([
+        "run",
+        "--cargo-message-format=json",
+        "--rerun",
+        INITIAL_RUN_ID,
+        "-E",
+        "test(=test_success)",
+    ])
+    .unchecked(true)
+    .output();
+    assert_eq!(
+        denied_rerun_output.exit_status.code(),
+        Some(NextestExitCode::RERUN_TESTS_OUTSTANDING),
+        "rerun with outstanding tests not seen should return RERUN_TESTS_OUTSTANDING: \
+         {denied_rerun_output}"
+    );
+    assert!(
+        !runs_dir.join(DENIED_RERUN_ID).exists(),
+        "the rerun should not have been recorded: {denied_rerun_output}"
+    );
+    insta::assert_snapshot!(
+        "rerun_tests_outstanding_recording_disabled",
+        redact_dynamic_fields(&denied_rerun_output.stderr_as_str(), temp_root)
+    );
+}
+
+// A little hack that alters runs.json.zst so that reads succeed but writes are
+// denied.
+fn deny_runs_json_writes(runs_dir: &Utf8Path) {
+    let runs_json_path = runs_dir.join("runs.json.zst");
+    let compressed = fs::read(&runs_json_path).expect("read runs.json.zst");
+    let decompressed =
+        zstd::stream::decode_all(compressed.as_slice()).expect("decompressed runs.json.zst");
+    let mut list: serde_json::Value =
+        serde_json::from_slice(&decompressed).expect("parsed runs.json.zst as JSON");
+    let format_version = list
+        .get_mut("format-version")
+        .expect("runs.json.zst has a format-version field");
+    *format_version = serde_json::Value::from(9999);
+    let updated = serde_json::to_vec(&list).expect("serialized runs.json.zst");
+    let recompressed =
+        zstd::stream::encode_all(updated.as_slice(), 3).expect("compressed runs.json.zst");
+    fs::write(&runs_json_path, recompressed).expect("wrote runs.json.zst");
 }
 
 /// Rerun from a portable recording.

--- a/integration-tests/tests/integration/snapshots/integration__record_replay__rerun_tests_outstanding_recording_disabled.snap
+++ b/integration-tests/tests/integration/snapshots/integration__record_replay__rerun_tests_outstanding_recording_disabled.snap
@@ -1,0 +1,20 @@
+---
+source: integration-tests/tests/integration/record_replay.rs
+expression: "redact_dynamic_fields(&denied_rerun_output.stderr_as_str(), temp_root)"
+---
+info: experimental features enabled: setup-scripts, wrapper-scripts, benchmarks
+info: rerun: inheriting build scope from original run: (default scope)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]
+warning: recording disabled: failed to create run recorder
+  caused by:
+  - cannot write to record store: runs.json.zst format version 9999 is newer than supported version 2
+────────────
+ Nextest run ID 96000003-0000-0000-0000-000000000003 with nextest profile: default
+    Starting 1 test across 7 binaries (31 tests skipped)
+        PASS [ duration] (1/1) fixture-project::basic test_success
+────────────
+     Summary [ duration] 1 test run: 1 passed, 31 skipped
+        Note 2 outstanding tests not seen during this rerun:
+             fixture-project::basic test_failure_assert
+             fixture-project::basic test_failure_error
+warning: 2 outstanding tests still remain


### PR DESCRIPTION
Identified during review.